### PR TITLE
Check GitHub actions and Gradle dependencies with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - directory: /src
+    open-pull-requests-limit: 1
+    package-ecosystem: gradle
+    schedule:
+      interval: weekly
+      day: "friday"
+  - directory: /
+    package-ecosystem: github-actions
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "dependabot:"


### PR DESCRIPTION
### Description
This PR updates dependabot to run weekly on github actions workflows, and alert when newer versions are available.
### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1191
