### PR TITLE
Disable OpenSearch pre-packaged rules index

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -1286,15 +1286,15 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                             initRuleIndexAndImportRules(request, new ActionListener<>() {
                                 @Override
                                 public void onResponse(List<IndexMonitorResponse> monitorResponses) {
-                                    log.debug("monitors indexed");
-                                    request.getDetector().setMonitorIds(getMonitorIds(monitorResponses));
-                                    request.getDetector().setRuleIdMonitorIdMap(mapMonitorIds(monitorResponses));
-                                    try {
-                                        indexDetector();
-                                    } catch (Exception e) {
-                                        logger.debug("create detector failed", e);
-                                        onFailures(e);
-                                    }
+                                    // log.debug("monitors indexed");
+                                    // request.getDetector().setMonitorIds(getMonitorIds(monitorResponses));
+                                    // request.getDetector().setRuleIdMonitorIdMap(mapMonitorIds(monitorResponses));
+                                    // try {
+                                    //     indexDetector();
+                                    // } catch (Exception e) {
+                                    //     logger.debug("create detector failed", e);
+                                    //     onFailures(e);
+                                    // }
                                 }
 
                                 @Override
@@ -1440,24 +1440,24 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                     public void onResponse(CreateIndexResponse response) {
                         log.debug("prepackaged rule index created");
                         ruleIndices.onCreateMappingsResponse(response, true);
-                        ruleIndices.importRules(RefreshPolicy.IMMEDIATE, indexTimeout,
-                            new ActionListener<>() {
-                                @Override
-                                public void onResponse(BulkResponse response) {
-                                    log.debug("rules imported");
-                                    if (!response.hasFailures()) {
-                                        importRules(request, listener);
-                                    } else {
-                                        onFailures(new OpenSearchStatusException(response.buildFailureMessage(), RestStatus.INTERNAL_SERVER_ERROR));
-                                    }
-                                }
+                        // ruleIndices.importRules(RefreshPolicy.IMMEDIATE, indexTimeout,
+                        //     new ActionListener<>() {
+                        //         @Override
+                        //         public void onResponse(BulkResponse response) {
+                        //             log.debug("rules imported");
+                        //             if (!response.hasFailures()) {
+                        //                 // importRules(request, listener);
+                        //             } else {
+                        //                 onFailures(new OpenSearchStatusException(response.buildFailureMessage(), RestStatus.INTERNAL_SERVER_ERROR));
+                        //             }
+                        //         }
 
-                                @Override
-                                public void onFailure(Exception e) {
-                                    log.debug("failed to import rules", e);
-                                    onFailures(e);
-                                }
-                            });
+                        //         @Override
+                        //         public void onFailure(Exception e) {
+                        //             log.debug("failed to import rules", e);
+                        //             onFailures(e);
+                        //         }
+                        //     });
                     }
 
                     @Override
@@ -1468,33 +1468,33 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                 new ActionListener<>() {
                     @Override
                     public void onResponse(AcknowledgedResponse response) {
-                        ruleIndices.onUpdateMappingsResponse(response, true);
-                        ruleIndices.deleteRules(new ActionListener<>() {
-                            @Override
-                            public void onResponse(BulkByScrollResponse response) {
-                                ruleIndices.importRules(WriteRequest.RefreshPolicy.IMMEDIATE, indexTimeout,
-                                    new ActionListener<>() {
-                                        @Override
-                                        public void onResponse(BulkResponse response) {
-                                            if (!response.hasFailures()) {
-                                                importRules(request, listener);
-                                            } else {
-                                                onFailures(new OpenSearchStatusException(response.buildFailureMessage(), RestStatus.INTERNAL_SERVER_ERROR));
-                                            }
-                                        }
-
-                                        @Override
-                                        public void onFailure(Exception e) {
-                                            onFailures(e);
-                                        }
-                                    });
-                            }
-
-                            @Override
-                            public void onFailure(Exception e) {
-                                onFailures(e);
-                            }
-                        });
+                        // ruleIndices.onUpdateMappingsResponse(response, true);
+                        // ruleIndices.deleteRules(new ActionListener<>() {
+                        //     @Override
+                        //     public void onResponse(BulkByScrollResponse response) {
+                        //         ruleIndices.importRules(WriteRequest.RefreshPolicy.IMMEDIATE, indexTimeout,
+                        //             new ActionListener<>() {
+                        //                 @Override
+                        //                 public void onResponse(BulkResponse response) {
+                        //                     if (!response.hasFailures()) {
+                        //                         importRules(request, listener);
+                        //                     } else {
+                        //                         onFailures(new OpenSearchStatusException(response.buildFailureMessage(), RestStatus.INTERNAL_SERVER_ERROR));
+                        //                     }
+                        //                 }
+                        //
+                        //                 @Override
+                        //                 public void onFailure(Exception e) {
+                        //                     onFailures(e);
+                        //                 }
+                        //             });
+                        //     }
+                        //
+                        //     @Override
+                        //     public void onFailure(Exception e) {
+                        //         onFailures(e);
+                        //     }
+                        // });
                     }
 
                     @Override
@@ -1509,27 +1509,27 @@ public class TransportIndexDetectorAction extends HandledTransportAction<IndexDe
                             onFailures(new OpenSearchStatusException("Search request timed out", RestStatus.REQUEST_TIMEOUT));
                         }
 
-                        long count = response.getHits().getTotalHits().value();
-                        if (count == 0) {
-                            ruleIndices.importRules(WriteRequest.RefreshPolicy.IMMEDIATE, indexTimeout,
-                                new ActionListener<>() {
-                                    @Override
-                                    public void onResponse(BulkResponse response) {
-                                        if (!response.hasFailures()) {
-                                            importRules(request, listener);
-                                        } else {
-                                            onFailures(new OpenSearchStatusException(response.buildFailureMessage(), RestStatus.INTERNAL_SERVER_ERROR));
-                                        }
-                                    }
+                        // long count = response.getHits().getTotalHits().value();
+                        // if (count == 0) {
+                        //     ruleIndices.importRules(WriteRequest.RefreshPolicy.IMMEDIATE, indexTimeout,
+                        //         new ActionListener<>() {
+                        //             @Override
+                        //             public void onResponse(BulkResponse response) {
+                        //                 if (!response.hasFailures()) {
+                        //                     importRules(request, listener);
+                        //                 } else {
+                        //                     onFailures(new OpenSearchStatusException(response.buildFailureMessage(), RestStatus.INTERNAL_SERVER_ERROR));
+                        //                 }
+                        //             }
 
-                                    @Override
-                                    public void onFailure(Exception e) {
-                                        onFailures(e);
-                                    }
-                                });
-                        } else {
-                            importRules(request, listener);
-                        }
+                        //             @Override
+                        //             public void onFailure(Exception e) {
+                        //                 onFailures(e);
+                        //             }
+                        //         });
+                        // } else {
+                        //     importRules(request, listener);
+                        // }
                     }
 
                     @Override

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportSearchRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportSearchRuleAction.java
@@ -95,22 +95,22 @@ public class TransportSearchRuleAction extends HandledTransportAction<SearchRule
                             @Override
                             public void onResponse(CreateIndexResponse response) {
                                 ruleIndices.onCreateMappingsResponse(response, true);
-                                ruleIndices.importRules(WriteRequest.RefreshPolicy.IMMEDIATE, indexTimeout,
-                                        new ActionListener<>() {
-                                            @Override
-                                            public void onResponse(BulkResponse response) {
-                                                if (!response.hasFailures()) {
-                                                    search(request.getSearchRequest());
-                                                } else {
-                                                    onFailures(new OpenSearchStatusException(response.buildFailureMessage(), RestStatus.INTERNAL_SERVER_ERROR));
-                                                }
-                                            }
-
-                                            @Override
-                                            public void onFailure(Exception e) {
-                                                onFailures(e);
-                                            }
-                                        });
+                                // ruleIndices.importRules(WriteRequest.RefreshPolicy.IMMEDIATE, indexTimeout,
+                                //         new ActionListener<>() {
+                                //             @Override
+                                //             public void onResponse(BulkResponse response) {
+                                //                 if (!response.hasFailures()) {
+                                //                     search(request.getSearchRequest());
+                                //                 } else {
+                                //                     onFailures(new OpenSearchStatusException(response.buildFailureMessage(), RestStatus.INTERNAL_SERVER_ERROR));
+                                //                 }
+                                //             }
+                                //
+                                //             @Override
+                                //             public void onFailure(Exception e) {
+                                //                 onFailures(e);
+                                //             }
+                                //         });
                             }
 
                             @Override
@@ -121,33 +121,33 @@ public class TransportSearchRuleAction extends HandledTransportAction<SearchRule
                         new ActionListener<>() {
                             @Override
                             public void onResponse(AcknowledgedResponse response) {
-                                ruleIndices.onUpdateMappingsResponse(response, true);
-                                ruleIndices.deleteRules(new ActionListener<>() {
-                                    @Override
-                                    public void onResponse(BulkByScrollResponse response) {
-                                        ruleIndices.importRules(WriteRequest.RefreshPolicy.IMMEDIATE, indexTimeout,
-                                                new ActionListener<>() {
-                                                    @Override
-                                                    public void onResponse(BulkResponse response) {
-                                                        if (!response.hasFailures()) {
-                                                            search(request.getSearchRequest());
-                                                        } else {
-                                                            onFailures(new OpenSearchStatusException(response.buildFailureMessage(), RestStatus.INTERNAL_SERVER_ERROR));
-                                                        }
-                                                    }
-
-                                                    @Override
-                                                    public void onFailure(Exception e) {
-                                                        onFailures(e);
-                                                    }
-                                                });
-                                    }
-
-                                    @Override
-                                    public void onFailure(Exception e) {
-                                        onFailures(e);
-                                    }
-                                });
+                                // ruleIndices.onUpdateMappingsResponse(response, true);
+                                // ruleIndices.deleteRules(new ActionListener<>() {
+                                //     @Override
+                                //     public void onResponse(BulkByScrollResponse response) {
+                                //         ruleIndices.importRules(WriteRequest.RefreshPolicy.IMMEDIATE, indexTimeout,
+                                //                 new ActionListener<>() {
+                                //                     @Override
+                                //                     public void onResponse(BulkResponse response) {
+                                //                         if (!response.hasFailures()) {
+                                //                             search(request.getSearchRequest());
+                                //                         } else {
+                                //                             onFailures(new OpenSearchStatusException(response.buildFailureMessage(), RestStatus.INTERNAL_SERVER_ERROR));
+                                //                         }
+                                //                     }
+                                //
+                                //                     @Override
+                                //                     public void onFailure(Exception e) {
+                                //                         onFailures(e);
+                                //                     }
+                                //                 });
+                                //     }
+                                //
+                                //     @Override
+                                //     public void onFailure(Exception e) {
+                                //         onFailures(e);
+                                //     }
+                                // });
                             }
 
                             @Override

--- a/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
@@ -152,7 +152,7 @@ public class RuleIndices {
         if (response.isAcknowledged()) {
             log.info(String.format(Locale.getDefault(), "Created %s with mappings.", isPrepackaged? Rule.PRE_PACKAGED_RULES_INDEX: Rule.CUSTOM_RULES_INDEX));
             if (isPrepackaged) {
-                IndexUtils.prePackagedRuleIndexUpdated();
+                // IndexUtils.prePackagedRuleIndexUpdated();
             } else {
                 IndexUtils.customRuleIndexUpdated();
             }
@@ -166,7 +166,7 @@ public class RuleIndices {
         if (response.isAcknowledged()) {
             log.info(String.format(Locale.getDefault(), "Updated  %s with mappings.", isPrepackaged? Rule.PRE_PACKAGED_RULES_INDEX: Rule.CUSTOM_RULES_INDEX));
             if (isPrepackaged) {
-                IndexUtils.prePackagedRuleIndexUpdated();
+                // IndexUtils.prePackagedRuleIndexUpdated();
             } else {
                 IndexUtils.customRuleIndexUpdated();
             }
@@ -181,12 +181,12 @@ public class RuleIndices {
             if (!ruleIndexExists(true)) {
                 initRuleIndex(createListener, true);
             } else if (!IndexUtils.prePackagedRuleIndexUpdated) {
-                IndexUtils.updateIndexMapping(
-                        Rule.PRE_PACKAGED_RULES_INDEX,
-                        RuleIndices.ruleMappings(), clusterService.state(), client.admin().indices(),
-                        updateListener,
-                        false
-                );
+                // IndexUtils.updateIndexMapping(
+                //         Rule.PRE_PACKAGED_RULES_INDEX,
+                //         RuleIndices.ruleMappings(), clusterService.state(), client.admin().indices(),
+                //         updateListener,
+                //         false
+                // );
             } else {
                 countRules(searchListener);
             }


### PR DESCRIPTION
### Description
Removes the creation of the pre-packaged rules index.

The code responsible for the pre-packaged index creation/update wont be deleted, currently it will remain commented-out

### Related Issues
Closes https://github.com/wazuh/internal-devel-requests/issues/3587
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
