### PR TITLE
Add new log category `unclassified`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add new actions to security-analytics-commons [(#22)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/22)
 - Implement GH Action for Local Maven publication [(#29)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/29)
 - Add new action to create custom rules [(#31)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/31)
+- Add Unclassified log category for integrations and custom log types [(#42)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/42)
 
 ### Dependencies
 -

--- a/commons/src/main/java/com/wazuh/securityanalytics/model/Integration.java
+++ b/commons/src/main/java/com/wazuh/securityanalytics/model/Integration.java
@@ -43,7 +43,8 @@ public class Integration implements Writeable, ToXContentObject {
         "Network Activity",
         "Security",
         "System Activity",
-        "Other"
+        "Other",
+        "Unclassified"
     );
 
     private static final String NAME_FIELD = "name";

--- a/src/main/java/org/opensearch/securityanalytics/model/CustomLogType.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/CustomLogType.java
@@ -35,7 +35,8 @@ public class CustomLogType implements Writeable, ToXContentObject {
             "Network Activity",
             "Security",
             "System Activity",
-            "Other"
+            "Other",
+            "Unclassified"
     );
 
     public static final String CUSTOM_LOG_TYPE_ID_FIELD = "custom_logtype_id";


### PR DESCRIPTION
### Description
A new log category must be created  to establish a new data stream `wazuh-events-v5-unclassified` to preserve events that remain uncategorized.

### Related Issues
Closes https://github.com/wazuh/wazuh-indexer-plugins/issues/832


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
