### PR TITLE
Fix logtype when document name field is missing

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/correlation/JoinEngine.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/JoinEngine.java
@@ -24,6 +24,7 @@ import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.search.MultiSearchRequest;
 import org.opensearch.action.search.MultiSearchResponse;
 import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.cluster.routing.Preference;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
@@ -282,6 +283,7 @@ public class JoinEngine {
 
         SearchRequest searchRequest = new SearchRequest();
         searchRequest.indices(CorrelationRule.CORRELATION_RULE_INDEX);
+        searchRequest.indicesOptions(IndicesOptions.lenientExpandOpen());
         searchRequest.source(searchSourceBuilder);
         searchRequest.preference(Preference.PRIMARY_FIRST.type());
         searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(30L));

--- a/src/main/java/org/opensearch/securityanalytics/correlation/JoinEngine.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/JoinEngine.java
@@ -161,7 +161,15 @@ public class JoinEngine {
                             SearchHit[] logTypes = response.getHits().getHits();
                             List<String> logTypeNames = new ArrayList<>();
                             for (SearchHit logType : logTypes) {
-                                String logTypeName = logType.getSourceAsMap().get("name").toString();
+                                Object nameObj = logType.getSourceAsMap().get("name");
+                                if (nameObj == null) {
+                                    log.warn(
+                                            "[CORRELATIONS] Skipping log type doc [{}]: missing field [name]. Available keys: {}",
+                                            logType.getId(),
+                                            logType.getSourceAsMap().keySet());
+                                    continue;
+                                }
+                                String logTypeName = nameObj.toString();
                                 logTypeNames.add(logTypeName);
 
                                 RangeQueryBuilder rangeQueryBuilder =
@@ -312,7 +320,7 @@ public class JoinEngine {
                                 log.error(
                                         "[CORRELATIONS] Exception encountered while searching correlation rule index for finding id {}",
                                         finding.getId(),
-                                        e.getMessage());
+                                        e);
                                 this.getValidDocuments(
                                         detectorType, indices, List.of(), List.of(), autoCorrelations);
                             } catch (Exception ex) {

--- a/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
@@ -57,10 +57,44 @@ public class VectorEmbeddingsEngine {
         this.correlateFindingAction = correlateFindingAction;
     }
 
+    /**
+     * Extracts a required field from a source map, throwing a clear error instead of an NPE
+     * if the field is missing.
+     *
+     * @throws OpenSearchStatusException if the field is not present in the map.
+     */
+    private static String requireField(Map<String, Object> source, String field) {
+        Object value = source.get(field);
+        if (value == null) {
+            throw new OpenSearchStatusException(
+                    String.format(Locale.ROOT, "Missing required field [%s] in document. Available keys: %s", field, source.keySet()),
+                    RestStatus.INTERNAL_SERVER_ERROR);
+        }
+        return value.toString();
+    }
+
+    /**
+     * Safely resolves the correlation_id for a given detector type from the log types map.
+     *
+     * @return the correlation ID string, or {@code null} if any intermediate value is missing.
+     */
+    private static String getCorrelationId(Map<String, CustomLogType> logTypes, String detectorType) {
+        CustomLogType customLogType = logTypes.get(detectorType);
+        if (customLogType == null || customLogType.getTags() == null) {
+            return null;
+        }
+        Object corrId = customLogType.getTags().get("correlation_id");
+        return corrId != null ? corrId.toString() : null;
+    }
+
     public void insertCorrelatedFindings(String detectorType, Finding finding, String logType, List<String> correlatedFindings, float timestampFeature, List<String> correlationRules, Map<String, CustomLogType> logTypes) {
         SearchRequest searchRequest = getSearchMetadataIndexRequest(detectorType, finding, logTypes);
-        Map<String, Object> tags = logTypes.get(detectorType).getTags();
-        String correlationId = tags.get("correlation_id").toString();
+        String correlationId = getCorrelationId(logTypes, detectorType);
+        if (correlationId == null) {
+            log.warn("Missing correlation_id for detector type [{}] and finding [{}]", detectorType, finding.getId());
+            onFailure(new OpenSearchStatusException("Missing correlation_id for detector type: " + detectorType, RestStatus.INTERNAL_SERVER_ERROR));
+            return;
+        }
 
         long findingTimestamp = finding.getTimestamp().toEpochMilli();
         client.search(searchRequest, ActionListener.wrap(response -> {
@@ -74,7 +108,7 @@ public class VectorEmbeddingsEngine {
             }
 
             Map<String, Object> hitSource = response.getHits().getHits()[0].getSourceAsMap();
-            long counter = Long.parseLong(hitSource.get("counter").toString());
+            long counter = Long.parseLong(requireField(hitSource, "counter"));
 
             MultiSearchRequest mSearchRequest = new MultiSearchRequest();
 
@@ -119,8 +153,8 @@ public class VectorEmbeddingsEngine {
                     for (int idx = 0; idx < totalHits; ++idx) {
                         SearchHit hit = item.getResponse().getHits().getHits()[idx];
                         Map<String, Object> sourceAsMap = hit.getSourceAsMap();
-                        long neighborCounter = Long.parseLong(sourceAsMap.get("counter").toString());
-                        String correlatedFinding = sourceAsMap.get("finding1").toString();
+                        long neighborCounter = Long.parseLong(requireField(sourceAsMap, "counter"));
+                        String correlatedFinding = requireField(sourceAsMap, "finding1");
 
                         try {
                             float[] corrVector = new float[3];
@@ -197,15 +231,21 @@ public class VectorEmbeddingsEngine {
     }
 
     public void insertOrphanFindings(String detectorType, Finding finding, float timestampFeature, Map<String, CustomLogType> logTypes) {
-        if (logTypes.get(detectorType) == null ) {
+        if (logTypes.get(detectorType) == null) {
             log.debug("Missing detector type {} in the log types index for finding id {}. Keys in the index: {}",
                     detectorType, finding.getId(), Arrays.toString(logTypes.keySet().toArray()));
             onFailure(new OpenSearchStatusException("insertOrphanFindings null log types for detector type: " + detectorType, RestStatus.INTERNAL_SERVER_ERROR));
+            return;
+        }
+
+        String correlationId = getCorrelationId(logTypes, detectorType);
+        if (correlationId == null) {
+            log.warn("Missing correlation_id for detector type [{}] and finding [{}]", detectorType, finding.getId());
+            onFailure(new OpenSearchStatusException("Missing correlation_id for detector type: " + detectorType, RestStatus.INTERNAL_SERVER_ERROR));
+            return;
         }
 
         SearchRequest searchRequest = getSearchMetadataIndexRequest(detectorType, finding, logTypes);
-        Map<String, Object> tags = logTypes.get(detectorType).getTags();
-        String correlationId = tags.get("correlation_id").toString();
         long findingTimestamp = finding.getTimestamp().toEpochMilli();
 
         client.search(searchRequest, ActionListener.wrap(response -> {
@@ -216,8 +256,8 @@ public class VectorEmbeddingsEngine {
             try {
                 Map<String, Object> hitSource = response.getHits().getHits()[0].getSourceAsMap();
                 String id = response.getHits().getHits()[0].getId();
-                long counter = Long.parseLong(hitSource.get("counter").toString());
-                long timestamp = Long.parseLong(hitSource.get("timestamp").toString());
+                long counter = Long.parseLong(requireField(hitSource, "counter"));
+                long timestamp = Long.parseLong(requireField(hitSource, "timestamp"));
                 if (counter == 0L) {
                     XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
                     builder.field("root", true);
@@ -294,7 +334,7 @@ public class VectorEmbeddingsEngine {
                                     contentBuilder.field("counter", 50L);
                                     contentBuilder.field("finding1", finding.getId());
                                     contentBuilder.field("finding2", "");
-                                    contentBuilder.field("logType", Integer.valueOf(logTypes.get(detectorType).getTags().get("correlation_id").toString()).toString());
+                                    contentBuilder.field("logType", correlationId);
                                     contentBuilder.field("timestamp", findingTimestamp);
                                     contentBuilder.field("corr_vector", corrVector);
                                     contentBuilder.field("recordType", "finding");
@@ -346,7 +386,7 @@ public class VectorEmbeddingsEngine {
 
                             if (hit != null) {
                                 Map<String, Object> sourceAsMap = searchResponse.getHits().getHits()[0].getSourceAsMap();
-                                existCounter = Long.parseLong(sourceAsMap.get("counter").toString());
+                                existCounter = Long.parseLong(requireField(sourceAsMap, "counter"));
                             }
 
                             if (totalHits == 0L || existCounter != ((long) (2.0f * ((float) counter) - 50.0f) / 2.0f)) {
@@ -363,7 +403,7 @@ public class VectorEmbeddingsEngine {
                                     builder.field("counter", counter);
                                     builder.field("finding1", finding.getId());
                                     builder.field("finding2", "");
-                                    builder.field("logType", Integer.valueOf(logTypes.get(detectorType).getTags().get("correlation_id").toString()).toString());
+                                    builder.field("logType", correlationId);
                                     builder.field("timestamp", findingTimestamp);
                                     builder.field("corr_vector", corrVector);
                                     builder.field("recordType", "finding");
@@ -407,7 +447,7 @@ public class VectorEmbeddingsEngine {
                                                 xContentBuilder.field("counter", counter + 50L);
                                                 xContentBuilder.field("finding1", finding.getId());
                                                 xContentBuilder.field("finding2", "");
-                                                xContentBuilder.field("logType", Integer.valueOf(logTypes.get(detectorType).getTags().get("correlation_id").toString()).toString());
+                                                xContentBuilder.field("logType", correlationId);
                                                 xContentBuilder.field("timestamp", findingTimestamp);
                                                 xContentBuilder.field("corr_vector", corrVector);
                                                 xContentBuilder.field("recordType", "finding");
@@ -456,7 +496,6 @@ public class VectorEmbeddingsEngine {
             throw new OpenSearchStatusException("LogTypes Index is missing the detector type", RestStatus.INTERNAL_SERVER_ERROR);
         }
 
-        Map<String, Object> tags = logTypes.get(detectorType).getTags();
         MatchQueryBuilder queryBuilder = QueryBuilders.matchQuery(
                 "root", true
         );

--- a/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/VectorEmbeddingsEngine.java
@@ -91,8 +91,8 @@ public class VectorEmbeddingsEngine {
         SearchRequest searchRequest = getSearchMetadataIndexRequest(detectorType, finding, logTypes);
         String correlationId = getCorrelationId(logTypes, detectorType);
         if (correlationId == null) {
-            log.warn("Missing correlation_id for detector type [{}] and finding [{}]", detectorType, finding.getId());
-            onFailure(new OpenSearchStatusException("Missing correlation_id for detector type: " + detectorType, RestStatus.INTERNAL_SERVER_ERROR));
+            log.debug("Skipping correlation for detector type [{}] and finding [{}]: no correlation_id assigned", detectorType, finding.getId());
+            correlateFindingAction.onOperation();
             return;
         }
 
@@ -240,8 +240,8 @@ public class VectorEmbeddingsEngine {
 
         String correlationId = getCorrelationId(logTypes, detectorType);
         if (correlationId == null) {
-            log.warn("Missing correlation_id for detector type [{}] and finding [{}]", detectorType, finding.getId());
-            onFailure(new OpenSearchStatusException("Missing correlation_id for detector type: " + detectorType, RestStatus.INTERNAL_SERVER_ERROR));
+            log.debug("Skipping correlation for detector type [{}] and finding [{}]: no correlation_id assigned", detectorType, finding.getId());
+            correlateFindingAction.onOperation();
             return;
         }
 

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
@@ -118,6 +118,46 @@ public class TransportCorrelateFindingAction
 
     private final WazuhEnrichedFindingService enrichedFindingService;
 
+    static Map<String, CustomLogType> buildLogTypesFromHits(
+            SearchHit[] hits, String monitorId, String findingId) {
+        Map<String, CustomLogType> logTypes = new HashMap<>();
+        for (SearchHit hit : hits) {
+            addLogTypeIfValid(logTypes, hit.getSourceAsMap(), hit.getId(), monitorId, findingId);
+        }
+        return logTypes;
+    }
+
+    static void addLogTypeIfValid(
+            Map<String, CustomLogType> logTypes,
+            Map<String, Object> sourceMap,
+            String hitId,
+            String monitorId,
+            String findingId) {
+        Object nameObj = sourceMap.get("name");
+        if (nameObj == null) {
+            log.warn(
+                    "Skipping malformed log type doc [{}] for monitor [{}] finding [{}]: missing field [name]. Available keys: {}",
+                    hitId,
+                    monitorId,
+                    findingId,
+                    sourceMap.keySet());
+            return;
+        }
+
+        String name = nameObj.toString();
+        try {
+            logTypes.put(name, new CustomLogType(sourceMap));
+        } catch (Exception e) {
+            log.warn(
+                    "Skipping malformed log type doc [{}] with name [{}] for monitor [{}] finding [{}]",
+                    hitId,
+                    name,
+                    monitorId,
+                    findingId,
+                    e);
+        }
+    }
+
     @Inject
     public TransportCorrelateFindingAction(
             TransportService transportService,
@@ -357,8 +397,7 @@ public class TransportCorrelateFindingAction
                                             enrichedFindingService.enrich(finding);
                                             joinEngine.onSearchDetectorResponse(detector, finding);
                                         } catch (Exception e) {
-                                            log.error(
-                                                    "Exception for request {}", searchRequest.toString(), e.getMessage());
+                                            log.error("Exception for request {}", searchRequest, e);
                                             onFailures(e);
                                         }
                                     } else {
@@ -637,13 +676,8 @@ public class TransportCorrelateFindingAction
                                                                                         }
 
                                                                                         SearchHit[] hits = searchResponse.getHits().getHits();
-                                                                                        Map<String, CustomLogType> logTypes = new HashMap<>();
-                                                                                        for (SearchHit hit : hits) {
-                                                                                            Map<String, Object> sourceMap = hit.getSourceAsMap();
-                                                                                            logTypes.put(
-                                                                                                    sourceMap.get("name").toString(),
-                                                                                                    new CustomLogType(sourceMap));
-                                                                                        }
+                                                                                        Map<String, CustomLogType> logTypes =
+                                                                                                buildLogTypes(hits);
 
                                                                                         if (correlatedFindings != null) {
                                                                                             if (correlatedFindings.isEmpty()) {
@@ -724,6 +758,10 @@ public class TransportCorrelateFindingAction
             return searchRequest;
         }
 
+        private Map<String, CustomLogType> buildLogTypes(SearchHit[] hits) {
+            return buildLogTypesFromHits(hits, request.getMonitorId(), request.getFinding().getId());
+        }
+
         private IndexRequest getCorrelationMetadataIndexRequest(String id, long newScoreTimestamp)
                 throws IOException {
             XContentBuilder scoreBuilder = XContentFactory.jsonBuilder().startObject();
@@ -756,11 +794,7 @@ public class TransportCorrelateFindingAction
                                 }
 
                                 SearchHit[] hits = response.getHits().getHits();
-                                Map<String, CustomLogType> logTypes = new HashMap<>();
-                                for (SearchHit hit : hits) {
-                                    Map<String, Object> sourceMap = hit.getSourceAsMap();
-                                    logTypes.put(sourceMap.get("name").toString(), new CustomLogType(sourceMap));
-                                }
+                                Map<String, CustomLogType> logTypes = buildLogTypes(hits);
 
                                 if (correlatedFindings != null) {
                                     if (correlatedFindings.isEmpty()) {
@@ -811,11 +845,10 @@ public class TransportCorrelateFindingAction
 
         public void onFailures(Exception t) {
             log.error(
-                    "Exception occurred while processing correlations for monitor id "
-                            + request.getMonitorId()
-                            + " and finding id "
-                            + request.getFinding().getId(),
-                    t.getMessage());
+                    "Exception occurred while processing correlations for monitor id {} and finding id {}",
+                    request.getMonitorId(),
+                    request.getFinding().getId(),
+                    t);
             if (counter.compareAndSet(false, true)) {
                 finishHim(t);
             }

--- a/src/main/java/org/opensearch/securityanalytics/util/SecurityAnalyticsException.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/SecurityAnalyticsException.java
@@ -1,16 +1,28 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.opensearch.securityanalytics.util;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchException;
-import org.opensearch.core.common.Strings;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.common.Strings;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.securityanalytics.rules.exceptions.CompositeSigmaErrors;
 
 import java.io.IOException;
@@ -48,7 +60,7 @@ public class SecurityAnalyticsException extends OpenSearchException {
                 RestStatus status = RestStatus.BAD_REQUEST;
 
                 XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
-                for (Exception e: ((CompositeSigmaErrors) ex).getErrors()) {
+                for (Exception e : ((CompositeSigmaErrors) ex).getErrors()) {
                     builder.field(e.getClass().getSimpleName(), e.getMessage());
                     log.error("[USER ERROR] Security Analytics error: {}", e.getMessage());
                 }
@@ -60,7 +72,7 @@ public class SecurityAnalyticsException extends OpenSearchException {
                 return SecurityAnalyticsException.wrap(e);
             }
         } else {
-            log.error("Security Analytics error: {}", ex.getMessage());
+            log.error("Security Analytics error [{}]: {}", ex.getClass().getName(), ex.getMessage(), ex);
 
             String friendlyMsg = "Unknown error";
             RestStatus status = RestStatus.INTERNAL_SERVER_ERROR;
@@ -94,14 +106,18 @@ public class SecurityAnalyticsException extends OpenSearchException {
             RestStatus status = RestStatus.BAD_REQUEST;
 
             XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
-            for (Exception e: ex) {
+            for (Exception e : ex) {
                 builder.field(e.getClass().getSimpleName(), e.getMessage());
                 log.warn("[USER ERROR] Security Analytics error: {}", e.getMessage());
             }
             builder.endObject();
             String friendlyMsg = builder.toString();
 
-            return new SecurityAnalyticsException(friendlyMsg, status, new Exception(String.format(Locale.getDefault(), "%s: %s", ex.getClass().getName(), friendlyMsg)));
+            return new SecurityAnalyticsException(
+                    friendlyMsg,
+                    status,
+                    new Exception(
+                            String.format(Locale.getDefault(), "%s: %s", ex.getClass().getName(), friendlyMsg)));
         } catch (IOException e) {
             return SecurityAnalyticsException.wrap(e);
         }

--- a/src/test/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingActionTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingActionTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opensearch.securityanalytics.transport;
+
+import org.opensearch.securityanalytics.model.CustomLogType;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TransportCorrelateFindingActionTests extends OpenSearchTestCase {
+
+    public void testAddLogTypeIfValid_withValidSource_addsLogType() {
+        Map<String, CustomLogType> logTypes = new HashMap<>();
+
+        TransportCorrelateFindingAction.addLogTypeIfValid(
+                logTypes, validSource("windows", "Windows logs"), "hit-1", "monitor-1", "finding-1");
+
+        assertEquals(1, logTypes.size());
+        assertTrue(logTypes.containsKey("windows"));
+        assertEquals("Windows logs", logTypes.get("windows").getDescription());
+    }
+
+    public void testAddLogTypeIfValid_missingName_skipsSource() {
+        Map<String, CustomLogType> logTypes = new HashMap<>();
+        Map<String, Object> source = new HashMap<>();
+        source.put("description", "Linux logs");
+        source.put("space", "default");
+        source.put("tags", Map.of("source", "linux"));
+
+        TransportCorrelateFindingAction.addLogTypeIfValid(
+                logTypes, source, "hit-missing-name", "monitor-1", "finding-1");
+
+        assertTrue(logTypes.isEmpty());
+    }
+
+    public void testAddLogTypeIfValid_mixedSources_keepsOnlyValidEntries() {
+        Map<String, CustomLogType> logTypes = new HashMap<>();
+
+        Map<String, Object> missingNameSource = new HashMap<>();
+        missingNameSource.put("description", "Missing name");
+        missingNameSource.put("space", "default");
+        missingNameSource.put("tags", Map.of("source", "broken"));
+
+        Map<String, Object> missingDescriptionSource = new HashMap<>();
+        missingDescriptionSource.put("name", "broken");
+        missingDescriptionSource.put("space", "default");
+        missingDescriptionSource.put("tags", Map.of("source", "broken"));
+
+        TransportCorrelateFindingAction.addLogTypeIfValid(
+                logTypes, validSource("apache", "Apache logs"), "hit-valid", "monitor-1", "finding-1");
+        TransportCorrelateFindingAction.addLogTypeIfValid(
+                logTypes, missingNameSource, "hit-missing-name", "monitor-1", "finding-1");
+        TransportCorrelateFindingAction.addLogTypeIfValid(
+                logTypes, missingDescriptionSource, "hit-missing-description", "monitor-1", "finding-1");
+
+        assertEquals(1, logTypes.size());
+        assertTrue(logTypes.containsKey("apache"));
+    }
+
+    private static Map<String, Object> validSource(String name, String description) {
+        Map<String, Object> source = new HashMap<>();
+        source.put("name", name);
+        source.put("description", description);
+        source.put("space", "default");
+        source.put("category", "web");
+        source.put("tags", Map.of("source", "wazuh"));
+        return source;
+    }
+}


### PR DESCRIPTION
## Description
Fix logtype when document name field is missing

### Validations
1. Wazuh 5.0 environment with this fix applied
2. Cleanup the env and restart
    ```json
    DELETE /.cti-*
    DELETE /.opensearch-sap-*
    DELETE /.engine-filters
    DELETE /.wazuh-content-manager-jobs
    ```
3. Wait for the environment to sync
4. Check the error logs are not present anymore
    ```
    root@vagrant:/home/vagrant# grep "JoinEngine" /var/log/wazuh-indexer/wazuh-cluster.log 
    root@vagrant:/home/vagrant# grep "TransportCorrelateFindingAction" /var/log/wazuh-indexer/wazuh-cluster.log 
    root@vagrant:/home/vagrant# grep "SecurityAnalyticsException" /var/log/wazuh-indexer/wazuh-cluster.log 
    root@vagrant:/home/vagrant#
    ```

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
