### PR TITLE
Fix race condition on findings correlation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix link-checker workflow [(#50)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/50)
 - Fix CodeQL autobuild failure using manual compilation [(#71)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/71)
 - Fix detector creation to query custom rules by `document.id`[(#97)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/97)
+- Fix race condition on findings correlation [(#106)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/106)
 
 ### Security
 -

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
@@ -19,7 +19,9 @@ package org.opensearch.securityanalytics.transport;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.join.ScoreMode;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRunnable;
@@ -228,7 +230,14 @@ public class TransportCorrelateFindingAction
                                                                                             RestStatus.INTERNAL_SERVER_ERROR));
                                                                         }
                                                                     },
-                                                                    correlateFindingAction::onFailures));
+                                                                    e -> {
+                                                                        if (ExceptionsHelper.unwrapCause(e)
+                                                                                instanceof ResourceAlreadyExistsException) {
+                                                                            correlateFindingAction.start();
+                                                                        } else {
+                                                                            correlateFindingAction.onFailures(e);
+                                                                        }
+                                                                    }));
                                                 } catch (Exception ex) {
                                                     correlateFindingAction.onFailures(ex);
                                                 }
@@ -247,7 +256,14 @@ public class TransportCorrelateFindingAction
                                                                                             RestStatus.INTERNAL_SERVER_ERROR));
                                                                         }
                                                                     },
-                                                                    correlateFindingAction::onFailures));
+                                                                    e -> {
+                                                                        if (ExceptionsHelper.unwrapCause(e)
+                                                                                instanceof ResourceAlreadyExistsException) {
+                                                                            IndexUtils.correlationAlertIndexUpdated();
+                                                                        } else {
+                                                                            correlateFindingAction.onFailures(e);
+                                                                        }
+                                                                    }));
                                                 } catch (Exception ex) {
                                                     correlateFindingAction.onFailures(ex);
                                                 }
@@ -259,7 +275,13 @@ public class TransportCorrelateFindingAction
                                                             RestStatus.INTERNAL_SERVER_ERROR));
                                         }
                                     },
-                                    correlateFindingAction::onFailures));
+                                    e -> {
+                                        if (ExceptionsHelper.unwrapCause(e) instanceof ResourceAlreadyExistsException) {
+                                            correlateFindingAction.start();
+                                        } else {
+                                            correlateFindingAction.onFailures(e);
+                                        }
+                                    }));
                 } catch (Exception ex) {
                     correlateFindingAction.onFailures(ex);
                 }


### PR DESCRIPTION
### Description
This PR fixes the race condition detailed on the comment https://github.com/wazuh/wazuh-indexer-security-analytics/issues/82#issuecomment-4214357210


### Validation

1. On a working Wazuh 5.0.0 environment with Wazuh Indexer with the fixed SAP package
2. Wait for the Wazuh Agent to report its events
3. Check the internal and public SAP findings count are the same
    ```JSON
    GET .ds-wazuh-findings-v5-security-000001/_count
    {
      "count": 244,
      "_shards": {
        "total": 3,
        "successful": 3,
        "skipped": 0,
        "failed": 0
      }
    }
     
    GET .opensearch-sap-wazuh-sca-findings/_count
    {
      "count": 244,
      "_shards": {
        "total": 1,
        "successful": 1,
        "skipped": 0,
        "failed": 0
      }
    }
    ```

### Related Issues
Closes #82 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
