### PR TITLE
Replace java logging with Log4j

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
@@ -566,7 +566,8 @@ public class SecurityAnalyticsPlugin extends Plugin
 
                     @Override
                     public void onFailure(Exception e) {
-                        log.warn("Failed to initialize LogType config index and builtin log types", e);
+                        log.warn(
+                                "Failed to initialize LogType config index and builtin log types", e.getMessage());
                     }
                 });
     }

--- a/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
@@ -566,7 +566,7 @@ public class SecurityAnalyticsPlugin extends Plugin
 
                     @Override
                     public void onFailure(Exception e) {
-                        log.warn("Failed to initialize LogType config index and builtin log types");
+                        log.warn("Failed to initialize LogType config index and builtin log types", e);
                     }
                 });
     }

--- a/src/main/java/org/opensearch/securityanalytics/rules/objects/WCSFieldValidator.java
+++ b/src/main/java/org/opensearch/securityanalytics/rules/objects/WCSFieldValidator.java
@@ -95,7 +95,7 @@ public class WCSFieldValidator {
 
         wcsFields.set(Collections.unmodifiableSet(fields));
 
-        log.info("WCS field validator initialized with {} fields", fields.size());
+        log.debug("WCS field validator initialized with {} fields", fields.size());
     }
 
     /**

--- a/src/main/java/org/opensearch/securityanalytics/rules/objects/WCSFieldValidator.java
+++ b/src/main/java/org/opensearch/securityanalytics/rules/objects/WCSFieldValidator.java
@@ -16,6 +16,8 @@
  */
 package org.opensearch.securityanalytics.rules.objects;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.securityanalytics.rules.exceptions.SigmaError;
@@ -26,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
@@ -42,7 +43,7 @@ import java.util.stream.Collectors;
  */
 public class WCSFieldValidator {
 
-    private static final Logger log = Logger.getLogger(WCSFieldValidator.class.getName());
+    private static final Logger log = LogManager.getLogger(WCSFieldValidator.class);
 
     /** WCS fields resolved from the index mapping. */
     private static final AtomicReference<Set<String>> wcsFields =
@@ -56,13 +57,13 @@ public class WCSFieldValidator {
      */
     public static void initFromIndexMetadata(IndexMetadata indexMetadata) {
         if (indexMetadata == null) {
-            log.warning("Cannot initialize WCS fields: null index metadata");
+            log.warn("Cannot initialize WCS fields: null index metadata");
             return;
         }
 
         MappingMetadata mapping = indexMetadata.mapping();
         if (mapping == null) {
-            log.warning("Cannot initialize WCS fields: no mapping in index metadata");
+            log.warn("Cannot initialize WCS fields: no mapping in index metadata");
             return;
         }
 
@@ -94,7 +95,7 @@ public class WCSFieldValidator {
 
         wcsFields.set(Collections.unmodifiableSet(fields));
 
-        log.info("WCS field validator initialized with " + fields.size() + " fields");
+        log.info("WCS field validator initialized with {} fields", fields.size());
     }
 
     /**


### PR DESCRIPTION
### Description
Fix misleading WARN-level log messages at cluster startup:

- **WCSFieldValidator**: Replace `java.util.logging` (JUL) with Log4j2. JUL output goes to stderr, which OpenSearch captures as `[WARN][stderr]`, causing even INFO-level messages to appear as warnings. Now uses the same Log4j2 framework as the rest of the codebase.
- **SecurityAnalyticsPlugin**: Include the exception in the LogType config index initialization failure log. Previously the WARN message omitted the cause, making it impossible to diagnose why initialization failed.

### Issues Resolved
Closes #109 
