### PR TITLE
Limit number of rules per detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Allow creating custom and standard integrations [(#32)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/32)
 - Change SAP logic to use findings indices [(#76)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/76)
 - Optimize findings enrichment [(#93)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/93)
+- Limit number of rules per detector [(#111)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/111)
 
 ### Deprecated
 -

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -143,6 +143,7 @@ public class TransportIndexDetectorAction
         implements SecureTransportAction {
 
     public static final String PLUGIN_OWNER_FIELD = "security_analytics";
+    private static final int MAX_RULES_PER_DETECTOR = 100;
     private static final Logger log = LogManager.getLogger(TransportIndexDetectorAction.class);
     public static final String TIMESTAMP_FIELD_ALIAS = "timestamp";
     public static final String CHAINED_FINDINGS_MONITOR_STRING = "chained_findings_monitor";
@@ -250,7 +251,33 @@ public class TransportIndexDetectorAction
             return;
         }
 
+        String ruleCountError = validateRuleCount(request.getDetector());
+        if (ruleCountError != null) {
+            listener.onFailure(
+                    SecurityAnalyticsException.wrap(
+                            new OpenSearchStatusException(ruleCountError, RestStatus.BAD_REQUEST)));
+            return;
+        }
+
         checkIndicesAndExecute(task, request, listener, user);
+    }
+
+    /**
+     * Returns an error message if any detector input exceeds the maximum allowed rule count, or
+     * {@code null} if all inputs are within the limit.
+     */
+    static String validateRuleCount(Detector detector) {
+        for (DetectorInput input : detector.getInputs()) {
+            int ruleCount = Math.max(input.getCustomRules().size(), input.getPrePackagedRules().size());
+            if (ruleCount > MAX_RULES_PER_DETECTOR) {
+                return String.format(
+                        Locale.getDefault(),
+                        "Detector cannot have more than %d rules, but found %d",
+                        MAX_RULES_PER_DETECTOR,
+                        ruleCount);
+            }
+        }
+        return null;
     }
 
     private void checkIndicesAndExecute(

--- a/src/test/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorActionTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorActionTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opensearch.securityanalytics.transport;
+
+import org.opensearch.securityanalytics.model.Detector;
+import org.opensearch.securityanalytics.model.DetectorInput;
+import org.opensearch.securityanalytics.model.DetectorRule;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.opensearch.securityanalytics.TestHelpers.randomDetectorWithInputs;
+
+public class TransportIndexDetectorActionTests extends OpenSearchTestCase {
+
+    public void testValidateRuleCount_withinLimit_returnsNull() {
+        List<DetectorRule> rules = List.of(new DetectorRule("rule-1"), new DetectorRule("rule-2"));
+        DetectorInput input =
+                new DetectorInput("test", List.of("index-1"), Collections.emptyList(), rules);
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        assertNull(TransportIndexDetectorAction.validateRuleCount(detector));
+    }
+
+    public void testValidateRuleCount_atLimit_returnsNull() {
+        List<DetectorRule> rules =
+                IntStream.rangeClosed(1, 100)
+                        .mapToObj(i -> new DetectorRule("rule-" + i))
+                        .collect(Collectors.toList());
+        DetectorInput input =
+                new DetectorInput("test", List.of("index-1"), Collections.emptyList(), rules);
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        assertNull(TransportIndexDetectorAction.validateRuleCount(detector));
+    }
+
+    public void testValidateRuleCount_exceedsLimit_returnsError() {
+        List<DetectorRule> rules =
+                IntStream.rangeClosed(1, 101)
+                        .mapToObj(i -> new DetectorRule("rule-" + i))
+                        .collect(Collectors.toList());
+        DetectorInput input =
+                new DetectorInput("test", List.of("index-1"), Collections.emptyList(), rules);
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        String error = TransportIndexDetectorAction.validateRuleCount(detector);
+        assertNotNull(error);
+        assertTrue(error.contains("more than 100 rules"));
+        assertTrue(error.contains("101"));
+    }
+
+    public void testValidateRuleCount_customRulesExceedsLimit_returnsError() {
+        List<DetectorRule> customRules =
+                IntStream.rangeClosed(1, 101)
+                        .mapToObj(i -> new DetectorRule("custom-rule-" + i))
+                        .collect(Collectors.toList());
+        DetectorInput input =
+                new DetectorInput("test", List.of("index-1"), customRules, Collections.emptyList());
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        String error = TransportIndexDetectorAction.validateRuleCount(detector);
+        assertNotNull(error);
+        assertTrue(error.contains("more than 100 rules"));
+    }
+
+    public void testValidateRuleCount_emptyRules_returnsNull() {
+        DetectorInput input =
+                new DetectorInput(
+                        "test", List.of("index-1"), Collections.emptyList(), Collections.emptyList());
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        assertNull(TransportIndexDetectorAction.validateRuleCount(detector));
+    }
+}


### PR DESCRIPTION
### Description
This PR makes changes to the SAP's Index Detector transport so it verifies that the number of rules associated with a detector never exceeds 100. This is done at the transport layer so as to catch inter-plugin as well as rest layer calls.

### Resolves
Resolves https://github.com/wazuh/wazuh-indexer-security-analytics/issues/111
