### PR TITLE
Prevent modification of standard threat detectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Allow creating custom and standard integrations [(#32)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/32)
 - Change SAP logic to use findings indices [(#76)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/76)
 - Optimize findings enrichment [(#93)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/93)
+- Disable standard threat detectors modification [(#121)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/121)
 
 ### Deprecated
 -

--- a/src/main/java/org/opensearch/securityanalytics/action/IndexDetectorRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/IndexDetectorRequest.java
@@ -1,6 +1,18 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.opensearch.securityanalytics.action;
 
@@ -37,10 +49,11 @@ public class IndexDetectorRequest extends ActionRequest {
     }
 
     public IndexDetectorRequest(StreamInput sin) throws IOException {
-        this(sin.readString(),
-             WriteRequest.RefreshPolicy.readFrom(sin),
-             sin.readEnum(RestRequest.Method.class),
-             Detector.readFrom(sin));
+        this(
+                sin.readString(),
+                WriteRequest.RefreshPolicy.readFrom(sin),
+                sin.readEnum(RestRequest.Method.class),
+                Detector.readFrom(sin));
     }
 
     @Override
@@ -70,5 +83,9 @@ public class IndexDetectorRequest extends ActionRequest {
 
     public WriteRequest.RefreshPolicy getRefreshPolicy() {
         return refreshPolicy;
+    }
+
+    public void setDetector(Detector detector) {
+        this.detector = detector;
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/model/Detector.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/Detector.java
@@ -1,22 +1,23 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.opensearch.securityanalytics.model;
 
-import java.io.IOException;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 import org.opensearch.commons.alerting.model.CronSchedule;
 import org.opensearch.commons.alerting.model.Schedule;
 import org.opensearch.commons.authuser.User;
@@ -30,6 +31,16 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.core.xcontent.XContentParserUtils;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 
 public class Detector implements Writeable, ToXContentObject {
 
@@ -55,6 +66,10 @@ public class Detector implements Writeable, ToXContentObject {
     public static final String ALERTING_WORKFLOW_ID = "workflow_ids";
 
     public static final String BUCKET_MONITOR_ID_RULE_ID = "bucket_monitor_id_rule_id";
+
+    public static final String SOURCE_FIELD = "source";
+    public static final String DEFAULT_SOURCE = "Custom";
+    public static final String SIGMA_SOURCE = "Sigma";
     private static final String RULE_TOPIC_INDEX = "rule_topic_index";
 
     private static final String ALERTS_INDEX = "alert_index";
@@ -68,70 +83,71 @@ public class Detector implements Writeable, ToXContentObject {
     // Used as a key in rule-monitor map for the purpose of easy detection of the doc level monitor
     public static final String DOC_LEVEL_MONITOR = "-1";
 
-    public static final NamedXContentRegistry.Entry XCONTENT_REGISTRY = new NamedXContentRegistry.Entry(
-        Detector.class,
-        new ParseField(DETECTOR_TYPE),
-        xcp -> parse(xcp, null, null)
-    );
+    public static final NamedXContentRegistry.Entry XCONTENT_REGISTRY =
+            new NamedXContentRegistry.Entry(
+                    Detector.class, new ParseField(DETECTOR_TYPE), xcp -> parse(xcp, null, null));
 
     @Override
     public String toString() {
         return "Detector{"
-            + "id='"
-            + id
-            + '\''
-            + ", version="
-            + version
-            + ", name='"
-            + name
-            + '\''
-            + ", threatIntelEnabled="
-            + threatIntelEnabled
-            + ", enabled="
-            + enabled
-            + ", schedule="
-            + schedule
-            + ", lastUpdateTime="
-            + lastUpdateTime
-            + ", enabledTime="
-            + enabledTime
-            + ", logType='"
-            + logType
-            + '\''
-            + ", user="
-            + user
-            + ", inputs="
-            + inputs
-            + ", triggers="
-            + triggers
-            + ", monitorIds="
-            + monitorIds
-            + ", ruleIdMonitorIdMap="
-            + ruleIdMonitorIdMap
-            + ", workflowIds="
-            + workflowIds
-            + ", ruleIndex='"
-            + ruleIndex
-            + '\''
-            + ", alertsIndex='"
-            + alertsIndex
-            + '\''
-            + ", alertsHistoryIndex='"
-            + alertsHistoryIndex
-            + '\''
-            + ", alertsHistoryIndexPattern='"
-            + alertsHistoryIndexPattern
-            + '\''
-            + ", findingsIndex='"
-            + findingsIndex
-            + '\''
-            + ", findingsIndexPattern='"
-            + findingsIndexPattern
-            + '\''
-            + ", type='"
-            + type
-            + '\''
-            + '}';
+                + "id='"
+                + id
+                + '\''
+                + ", version="
+                + version
+                + ", name='"
+                + name
+                + '\''
+                + ", threatIntelEnabled="
+                + threatIntelEnabled
+                + ", enabled="
+                + enabled
+                + ", schedule="
+                + schedule
+                + ", lastUpdateTime="
+                + lastUpdateTime
+                + ", enabledTime="
+                + enabledTime
+                + ", logType='"
+                + logType
+                + '\''
+                + ", user="
+                + user
+                + ", inputs="
+                + inputs
+                + ", triggers="
+                + triggers
+                + ", monitorIds="
+                + monitorIds
+                + ", ruleIdMonitorIdMap="
+                + ruleIdMonitorIdMap
+                + ", workflowIds="
+                + workflowIds
+                + ", ruleIndex='"
+                + ruleIndex
+                + '\''
+                + ", alertsIndex='"
+                + alertsIndex
+                + '\''
+                + ", alertsHistoryIndex='"
+                + alertsHistoryIndex
+                + '\''
+                + ", alertsHistoryIndexPattern='"
+                + alertsHistoryIndexPattern
+                + '\''
+                + ", findingsIndex='"
+                + findingsIndex
+                + '\''
+                + ", findingsIndexPattern='"
+                + findingsIndexPattern
+                + '\''
+                + ", type='"
+                + type
+                + '\''
+                + ", source='"
+                + source
+                + '\''
+                + '}';
     }
 
     private String id;
@@ -176,31 +192,33 @@ public class Detector implements Writeable, ToXContentObject {
 
     private String findingsIndexPattern;
 
+    private String source;
+
     private final String type;
 
     public Detector(
-        String id,
-        Long version,
-        String name,
-        Boolean enabled,
-        Schedule schedule,
-        Instant lastUpdateTime,
-        Instant enabledTime,
-        String logType,
-        User user,
-        List<DetectorInput> inputs,
-        List<DetectorTrigger> triggers,
-        List<String> monitorIds,
-        String ruleIndex,
-        String alertsIndex,
-        String alertsHistoryIndex,
-        String alertsHistoryIndexPattern,
-        String findingsIndex,
-        String findingsIndexPattern,
-        Map<String, String> rulePerMonitor,
-        List<String> workflowIds,
-        Boolean threatIntelEnabled
-    ) {
+            String id,
+            Long version,
+            String name,
+            Boolean enabled,
+            Schedule schedule,
+            Instant lastUpdateTime,
+            Instant enabledTime,
+            String logType,
+            User user,
+            List<DetectorInput> inputs,
+            List<DetectorTrigger> triggers,
+            List<String> monitorIds,
+            String ruleIndex,
+            String alertsIndex,
+            String alertsHistoryIndex,
+            String alertsHistoryIndexPattern,
+            String findingsIndex,
+            String findingsIndexPattern,
+            Map<String, String> rulePerMonitor,
+            List<String> workflowIds,
+            Boolean threatIntelEnabled,
+            String source) {
         this.type = DETECTOR_TYPE;
 
         this.id = id != null ? id : NO_ID;
@@ -224,6 +242,7 @@ public class Detector implements Writeable, ToXContentObject {
         this.logType = logType;
         this.workflowIds = workflowIds != null ? workflowIds : null;
         this.threatIntelEnabled = threatIntelEnabled != null && threatIntelEnabled;
+        this.source = source != null ? source : DEFAULT_SOURCE;
 
         if (enabled) {
             Objects.requireNonNull(enabledTime);
@@ -232,28 +251,28 @@ public class Detector implements Writeable, ToXContentObject {
 
     public Detector(StreamInput sin) throws IOException {
         this(
-            sin.readString(),
-            sin.readLong(),
-            sin.readString(),
-            sin.readBoolean(),
-            Schedule.readFrom(sin),
-            sin.readInstant(),
-            sin.readOptionalInstant(),
-            sin.readString(),
-            sin.readBoolean() ? new User(sin) : null,
-            sin.readList(DetectorInput::readFrom),
-            sin.readList(DetectorTrigger::readFrom),
-            sin.readStringList(),
-            sin.readOptionalString(),
-            sin.readOptionalString(),
-            sin.readOptionalString(),
-            sin.readOptionalString(),
-            sin.readOptionalString(),
-            sin.readOptionalString(),
-            sin.readMap(StreamInput::readString, StreamInput::readString),
-            sin.readStringList(),
-            sin.readBoolean()
-        );
+                sin.readString(),
+                sin.readLong(),
+                sin.readString(),
+                sin.readBoolean(),
+                Schedule.readFrom(sin),
+                sin.readInstant(),
+                sin.readOptionalInstant(),
+                sin.readString(),
+                sin.readBoolean() ? new User(sin) : null,
+                sin.readList(DetectorInput::readFrom),
+                sin.readList(DetectorTrigger::readFrom),
+                sin.readStringList(),
+                sin.readOptionalString(),
+                sin.readOptionalString(),
+                sin.readOptionalString(),
+                sin.readOptionalString(),
+                sin.readOptionalString(),
+                sin.readOptionalString(),
+                sin.readMap(StreamInput::readString, StreamInput::readString),
+                sin.readStringList(),
+                sin.readBoolean(),
+                sin.readOptionalString());
     }
 
     @Override
@@ -296,9 +315,11 @@ public class Detector implements Writeable, ToXContentObject {
             out.writeStringCollection(workflowIds);
         }
         out.writeBoolean(threatIntelEnabled);
+        out.writeOptionalString(source);
     }
 
-    public XContentBuilder toXContentWithUser(XContentBuilder builder, Params params) throws IOException {
+    public XContentBuilder toXContentWithUser(XContentBuilder builder, Params params)
+            throws IOException {
         return createXContentBuilder(builder, params, false);
     }
 
@@ -307,7 +328,8 @@ public class Detector implements Writeable, ToXContentObject {
         return createXContentBuilder(builder, params, true);
     }
 
-    private XContentBuilder createXContentBuilder(XContentBuilder builder, ToXContent.Params params, Boolean secure) throws IOException {
+    private XContentBuilder createXContentBuilder(
+            XContentBuilder builder, ToXContent.Params params, Boolean secure) throws IOException {
         builder.startObject();
         if (params.paramAsBoolean("with_type", false)) {
             builder.startObject(type);
@@ -329,10 +351,9 @@ public class Detector implements Writeable, ToXContentObject {
             builder.nullField(ENABLED_TIME_FIELD);
         } else {
             builder.timeField(
-                ENABLED_TIME_FIELD,
-                String.format(Locale.getDefault(), "%s_in_millis", ENABLED_TIME_FIELD),
-                enabledTime.toEpochMilli()
-            );
+                    ENABLED_TIME_FIELD,
+                    String.format(Locale.getDefault(), "%s_in_millis", ENABLED_TIME_FIELD),
+                    enabledTime.toEpochMilli());
         }
 
         builder.field(SCHEDULE_FIELD, schedule);
@@ -349,10 +370,9 @@ public class Detector implements Writeable, ToXContentObject {
             builder.nullField(LAST_UPDATE_TIME_FIELD);
         } else {
             builder.timeField(
-                LAST_UPDATE_TIME_FIELD,
-                String.format(Locale.getDefault(), "%s_in_millis", LAST_UPDATE_TIME_FIELD),
-                lastUpdateTime.toEpochMilli()
-            );
+                    LAST_UPDATE_TIME_FIELD,
+                    String.format(Locale.getDefault(), "%s_in_millis", LAST_UPDATE_TIME_FIELD),
+                    lastUpdateTime.toEpochMilli());
         }
 
         builder.field(ALERTING_MONITOR_ID, monitorIds);
@@ -370,6 +390,7 @@ public class Detector implements Writeable, ToXContentObject {
         builder.field(ALERTS_HISTORY_INDEX_PATTERN, alertsHistoryIndexPattern);
         builder.field(FINDINGS_INDEX, findingsIndex);
         builder.field(FINDINGS_INDEX_PATTERN, findingsIndexPattern);
+        builder.field(SOURCE_FIELD, source);
 
         if (params.paramAsBoolean("with_type", false)) {
             builder.endObject();
@@ -378,9 +399,11 @@ public class Detector implements Writeable, ToXContentObject {
     }
 
     public static Detector docParse(XContentParser xcp, String id, Long version) throws IOException {
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp);
+        XContentParserUtils.ensureExpectedToken(
+                XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp);
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, xcp.nextToken(), xcp);
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp);
+        XContentParserUtils.ensureExpectedToken(
+                XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp);
         Detector detector = xcp.namedObject(Detector.class, xcp.currentName(), null);
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.END_OBJECT, xcp.nextToken(), xcp);
 
@@ -418,8 +441,10 @@ public class Detector implements Writeable, ToXContentObject {
         String findingsIndex = null;
         String findingsIndexPattern = null;
         Boolean enableThreatIntel = false;
+        String source = DEFAULT_SOURCE;
 
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp);
+        XContentParserUtils.ensureExpectedToken(
+                XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp);
         while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
             String fieldName = xcp.currentName();
             xcp.nextToken();
@@ -448,14 +473,16 @@ public class Detector implements Writeable, ToXContentObject {
                     schedule = Schedule.parse(xcp);
                     break;
                 case INPUTS_FIELD:
-                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp);
+                    XContentParserUtils.ensureExpectedToken(
+                            XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp);
                     while (xcp.nextToken() != XContentParser.Token.END_ARRAY) {
                         DetectorInput input = DetectorInput.parse(xcp);
                         inputs.add(input);
                     }
                     break;
                 case TRIGGERS_FIELD:
-                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp);
+                    XContentParserUtils.ensureExpectedToken(
+                            XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp);
                     while (xcp.nextToken() != XContentParser.Token.END_ARRAY) {
                         DetectorTrigger trigger = DetectorTrigger.parse(xcp);
                         triggers.add(trigger);
@@ -482,14 +509,16 @@ public class Detector implements Writeable, ToXContentObject {
                     }
                     break;
                 case ALERTING_MONITOR_ID:
-                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp);
+                    XContentParserUtils.ensureExpectedToken(
+                            XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp);
                     while (xcp.nextToken() != XContentParser.Token.END_ARRAY) {
                         String monitorId = xcp.text();
                         monitorIds.add(monitorId);
                     }
                     break;
                 case ALERTING_WORKFLOW_ID:
-                    XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp);
+                    XContentParserUtils.ensureExpectedToken(
+                            XContentParser.Token.START_ARRAY, xcp.currentToken(), xcp);
                     while (xcp.nextToken() != XContentParser.Token.END_ARRAY) {
                         String workflowId = xcp.textOrNull();
                         if (workflowId != null) {
@@ -518,6 +547,9 @@ public class Detector implements Writeable, ToXContentObject {
                 case FINDINGS_INDEX_PATTERN:
                     findingsIndexPattern = xcp.text();
                     break;
+                case SOURCE_FIELD:
+                    source = xcp.text();
+                    break;
                 default:
                     xcp.skipChildren();
             }
@@ -534,28 +566,28 @@ public class Detector implements Writeable, ToXContentObject {
         }
 
         return new Detector(
-            id,
-            version,
-            Objects.requireNonNull(name, "Detector name is null"),
-            enabled,
-            Objects.requireNonNull(schedule, "Detector schedule is null"),
-            lastUpdateTime != null ? lastUpdateTime : Instant.now(),
-            enabledTime,
-            logType,
-            user,
-            inputs,
-            triggers,
-            monitorIds,
-            ruleIndex,
-            alertsIndex,
-            alertsHistoryIndex,
-            alertsHistoryIndexPattern,
-            findingsIndex,
-            findingsIndexPattern,
-            rulePerMonitor,
-            workflowIds,
-            enableThreatIntel
-        );
+                id,
+                version,
+                Objects.requireNonNull(name, "Detector name is null"),
+                enabled,
+                Objects.requireNonNull(schedule, "Detector schedule is null"),
+                lastUpdateTime != null ? lastUpdateTime : Instant.now(),
+                enabledTime,
+                logType,
+                user,
+                inputs,
+                triggers,
+                monitorIds,
+                ruleIndex,
+                alertsIndex,
+                alertsHistoryIndex,
+                alertsHistoryIndexPattern,
+                findingsIndex,
+                findingsIndexPattern,
+                rulePerMonitor,
+                workflowIds,
+                enableThreatIntel,
+                source);
     }
 
     public static Detector readFrom(StreamInput sin) throws IOException {
@@ -726,44 +758,61 @@ public class Detector implements Writeable, ToXContentObject {
         return logType;
     }
 
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    /**
+     * Returns whether this detector belongs to the standard (Sigma) space and is therefore protected
+     * from user modifications.
+     */
+    public boolean isStandardDetector() {
+        return SIGMA_SOURCE.equalsIgnoreCase(source);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Detector detector = (Detector) o;
         return Objects.equals(id, detector.id)
-            && Objects.equals(version, detector.version)
-            && Objects.equals(name, detector.name)
-            && Objects.equals(enabled, detector.enabled)
-            && Objects.equals(schedule, detector.schedule)
-            && Objects.equals(lastUpdateTime, detector.lastUpdateTime)
-            && Objects.equals(enabledTime, detector.enabledTime)
-            && Objects.equals(logType, detector.logType)
-            && ((user == null && detector.user == null) || Objects.equals(user, detector.user))
-            && Objects.equals(inputs, detector.inputs)
-            && Objects.equals(triggers, detector.triggers)
-            && Objects.equals(type, detector.type)
-            && Objects.equals(monitorIds, detector.monitorIds)
-            && Objects.equals(ruleIndex, detector.ruleIndex);
+                && Objects.equals(version, detector.version)
+                && Objects.equals(name, detector.name)
+                && Objects.equals(enabled, detector.enabled)
+                && Objects.equals(schedule, detector.schedule)
+                && Objects.equals(lastUpdateTime, detector.lastUpdateTime)
+                && Objects.equals(enabledTime, detector.enabledTime)
+                && Objects.equals(logType, detector.logType)
+                && ((user == null && detector.user == null) || Objects.equals(user, detector.user))
+                && Objects.equals(inputs, detector.inputs)
+                && Objects.equals(triggers, detector.triggers)
+                && Objects.equals(type, detector.type)
+                && Objects.equals(monitorIds, detector.monitorIds)
+                && Objects.equals(ruleIndex, detector.ruleIndex)
+                && Objects.equals(source, detector.source);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(
-            id,
-            version,
-            name,
-            enabled,
-            schedule,
-            lastUpdateTime,
-            enabledTime,
-            logType,
-            user,
-            inputs,
-            triggers,
-            type,
-            monitorIds,
-            ruleIndex
-        );
+                id,
+                version,
+                name,
+                enabled,
+                schedule,
+                lastUpdateTime,
+                enabledTime,
+                logType,
+                user,
+                inputs,
+                triggers,
+                type,
+                monitorIds,
+                ruleIndex,
+                source);
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/model/DetectorRule.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/DetectorRule.java
@@ -1,6 +1,18 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.opensearch.securityanalytics.model;
 
@@ -13,11 +25,9 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.core.xcontent.XContentParserUtils;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.UUID;
+import java.util.Objects;
 
 public class DetectorRule implements Writeable, ToXContentObject {
 
@@ -39,9 +49,7 @@ public class DetectorRule implements Writeable, ToXContentObject {
     }
 
     public Map<String, Object> asTemplateArg() {
-        return Map.of(
-                RULE_ID_FIELD, id
-        );
+        return Map.of(RULE_ID_FIELD, id);
     }
 
     @Override
@@ -51,16 +59,15 @@ public class DetectorRule implements Writeable, ToXContentObject {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject()
-                .field(RULE_ID_FIELD, id)
-                .endObject();
+        builder.startObject().field(RULE_ID_FIELD, id).endObject();
         return builder;
     }
 
     public static DetectorRule parse(XContentParser xcp) throws IOException {
         String id = null;
 
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp);
+        XContentParserUtils.ensureExpectedToken(
+                XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp);
         while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
             String fieldName = xcp.currentName();
             xcp.nextToken();
@@ -80,5 +87,18 @@ public class DetectorRule implements Writeable, ToXContentObject {
 
     public String getId() {
         return id;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        DetectorRule that = (DetectorRule) object;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteDetectorAction.java
@@ -1,18 +1,23 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.opensearch.securityanalytics.transport;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Locale;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRunnable;
 import org.opensearch.action.StepListener;
@@ -59,16 +64,31 @@ import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
 import org.opensearch.transport.client.node.NodeClient;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
 import static org.opensearch.securityanalytics.model.Detector.NO_VERSION;
 
-public class TransportDeleteDetectorAction extends HandledTransportAction<DeleteDetectorRequest, DeleteDetectorResponse> {
+public class TransportDeleteDetectorAction
+        extends HandledTransportAction<DeleteDetectorRequest, DeleteDetectorResponse> {
 
     private static final Logger log = LogManager.getLogger(TransportDeleteDetectorAction.class);
-    private static final List<ThrowableCheckingPredicates> ACCEPTABLE_ENTITY_MISSING_THROWABLE_MATCHERS = List.of(
-        ThrowableCheckingPredicates.MONITOR_NOT_FOUND,
-        ThrowableCheckingPredicates.WORKFLOW_NOT_FOUND,
-        ThrowableCheckingPredicates.ALERTING_CONFIG_INDEX_NOT_FOUND
-    );
+
+    /**
+     * Thread context header used by internal Wazuh plugin callers (e.g. Content Manager) to bypass
+     * standard-detector deletion restrictions.
+     */
+    public static final String WAZUH_INTERNAL_CALLER_HEADER = "_wazuh_internal_caller";
+
+    private static final List<ThrowableCheckingPredicates>
+            ACCEPTABLE_ENTITY_MISSING_THROWABLE_MATCHERS =
+                    List.of(
+                            ThrowableCheckingPredicates.MONITOR_NOT_FOUND,
+                            ThrowableCheckingPredicates.WORKFLOW_NOT_FOUND,
+                            ThrowableCheckingPredicates.ALERTING_CONFIG_INDEX_NOT_FOUND);
 
     private final Client client;
 
@@ -95,17 +115,16 @@ public class TransportDeleteDetectorAction extends HandledTransportAction<Delete
 
     @Inject
     public TransportDeleteDetectorAction(
-        TransportService transportService,
-        IndexTemplateManager indexTemplateManager,
-        Client client,
-        ActionFilters actionFilters,
-        NamedXContentRegistry xContentRegistry,
-        RuleTopicIndices ruleTopicIndices,
-        DetectorIndices detectorIndices,
-        ClusterService clusterService,
-        Settings settings,
-        ExceptionChecker exceptionChecker
-    ) {
+            TransportService transportService,
+            IndexTemplateManager indexTemplateManager,
+            Client client,
+            ActionFilters actionFilters,
+            NamedXContentRegistry xContentRegistry,
+            RuleTopicIndices ruleTopicIndices,
+            DetectorIndices detectorIndices,
+            ClusterService clusterService,
+            Settings settings,
+            ExceptionChecker exceptionChecker) {
         super(DeleteDetectorAction.NAME, transportService, actionFilters, DeleteDetectorRequest::new);
         this.client = client;
         this.ruleTopicIndices = ruleTopicIndices;
@@ -119,28 +138,39 @@ public class TransportDeleteDetectorAction extends HandledTransportAction<Delete
         this.settings = settings;
 
         this.enabledWorkflowUsage = SecurityAnalyticsSettings.ENABLE_WORKFLOW_USAGE.get(this.settings);
-        this.clusterService.getClusterSettings()
-            .addSettingsUpdateConsumer(SecurityAnalyticsSettings.ENABLE_WORKFLOW_USAGE, this::setEnabledWorkflowUsage);
+        this.clusterService
+                .getClusterSettings()
+                .addSettingsUpdateConsumer(
+                        SecurityAnalyticsSettings.ENABLE_WORKFLOW_USAGE, this::setEnabledWorkflowUsage);
         this.exceptionChecker = exceptionChecker;
     }
 
     @Override
-    protected void doExecute(Task task, DeleteDetectorRequest request, ActionListener<DeleteDetectorResponse> listener) {
-        AsyncDeleteDetectorAction asyncAction = new AsyncDeleteDetectorAction(task, request, listener, detectorIndices);
+    protected void doExecute(
+            Task task, DeleteDetectorRequest request, ActionListener<DeleteDetectorResponse> listener) {
+        // Capture before thread context is stashed in start()
+        boolean isInternalCaller =
+                "content-manager"
+                        .equals(this.threadPool.getThreadContext().getHeader(WAZUH_INTERNAL_CALLER_HEADER));
+        AsyncDeleteDetectorAction asyncAction =
+                new AsyncDeleteDetectorAction(task, request, listener, detectorIndices, isInternalCaller);
         asyncAction.start();
     }
 
     private void deleteAlertingMonitor(
-        String monitorId,
-        WriteRequest.RefreshPolicy refreshPolicy,
-        ActionListener<DeleteMonitorResponse> listener
-    ) {
+            String monitorId,
+            WriteRequest.RefreshPolicy refreshPolicy,
+            ActionListener<DeleteMonitorResponse> listener) {
         DeleteMonitorRequest request = new DeleteMonitorRequest(monitorId, refreshPolicy);
         AlertingPluginInterface.INSTANCE.deleteMonitor((NodeClient) client, request, listener);
     }
 
-    private void deleteDetector(String detectorId, WriteRequest.RefreshPolicy refreshPolicy, ActionListener<DeleteResponse> listener) {
-        DeleteRequest request = new DeleteRequest(Detector.DETECTORS_INDEX, detectorId).setRefreshPolicy(refreshPolicy);
+    private void deleteDetector(
+            String detectorId,
+            WriteRequest.RefreshPolicy refreshPolicy,
+            ActionListener<DeleteResponse> listener) {
+        DeleteRequest request =
+                new DeleteRequest(Detector.DETECTORS_INDEX, detectorId).setRefreshPolicy(refreshPolicy);
         client.delete(request, listener);
     }
 
@@ -152,157 +182,175 @@ public class TransportDeleteDetectorAction extends HandledTransportAction<Delete
         private final AtomicBoolean counter = new AtomicBoolean();
         private final DetectorIndices detectorIndices;
         private final Task task;
+        private final boolean isInternalCaller;
 
         AsyncDeleteDetectorAction(
-            Task task,
-            DeleteDetectorRequest request,
-            ActionListener<DeleteDetectorResponse> listener,
-            DetectorIndices detectorIndices
-        ) {
+                Task task,
+                DeleteDetectorRequest request,
+                ActionListener<DeleteDetectorResponse> listener,
+                DetectorIndices detectorIndices,
+                boolean isInternalCaller) {
             this.task = task;
             this.request = request;
             this.listener = listener;
             this.response = new AtomicReference<>();
             this.detectorIndices = detectorIndices;
+            this.isInternalCaller = isInternalCaller;
         }
 
         void start() {
             if (!detectorIndices.detectorIndexExists()) {
                 onFailures(
-                    new OpenSearchStatusException(
-                        String.format(Locale.getDefault(), "Detector with %s is not found", request.getDetectorId()),
-                        RestStatus.NOT_FOUND
-                    )
-                );
+                        new OpenSearchStatusException(
+                                String.format(
+                                        Locale.getDefault(), "Detector with %s is not found", request.getDetectorId()),
+                                RestStatus.NOT_FOUND));
                 return;
-
             }
             TransportDeleteDetectorAction.this.threadPool.getThreadContext().stashContext();
             String detectorId = request.getDetectorId();
             GetRequest getRequest = new GetRequest(Detector.DETECTORS_INDEX, detectorId);
-            client.get(getRequest, new ActionListener<>() {
-                @Override
-                public void onResponse(GetResponse response) {
-                    if (!response.isExists()) {
-                        onFailures(
-                            new OpenSearchStatusException(
-                                String.format(Locale.getDefault(), "Detector with %s is not found", detectorId),
-                                RestStatus.NOT_FOUND
-                            )
-                        );
-                        return;
-                    }
+            client.get(
+                    getRequest,
+                    new ActionListener<>() {
+                        @Override
+                        public void onResponse(GetResponse response) {
+                            if (!response.isExists()) {
+                                onFailures(
+                                        new OpenSearchStatusException(
+                                                String.format(
+                                                        Locale.getDefault(), "Detector with %s is not found", detectorId),
+                                                RestStatus.NOT_FOUND));
+                                return;
+                            }
 
-                    try {
-                        XContentParser xcp = XContentHelper.createParser(
-                            xContentRegistry,
-                            LoggingDeprecationHandler.INSTANCE,
-                            response.getSourceAsBytesRef(),
-                            XContentType.JSON
-                        );
-                        Detector detector = Detector.docParse(xcp, response.getId(), response.getVersion());
-                        onGetResponse(detector);
-                    } catch (Exception e) {
-                        onFailures(e);
-                    }
-                }
+                            try {
+                                XContentParser xcp =
+                                        XContentHelper.createParser(
+                                                xContentRegistry,
+                                                LoggingDeprecationHandler.INSTANCE,
+                                                response.getSourceAsBytesRef(),
+                                                XContentType.JSON);
+                                Detector detector = Detector.docParse(xcp, response.getId(), response.getVersion());
+                                onGetResponse(detector);
+                            } catch (Exception e) {
+                                onFailures(e);
+                            }
+                        }
 
-                @Override
-                public void onFailure(Exception t) {
-                    onFailures(
-                        new OpenSearchStatusException(
-                            String.format(Locale.getDefault(), "Detector with %s is not found", detectorId),
-                            RestStatus.NOT_FOUND
-                        )
-                    );
-                }
-            });
+                        @Override
+                        public void onFailure(Exception t) {
+                            onFailures(
+                                    new OpenSearchStatusException(
+                                            String.format(
+                                                    Locale.getDefault(), "Detector with %s is not found", detectorId),
+                                            RestStatus.NOT_FOUND));
+                        }
+                    });
         }
 
         private void onGetResponse(Detector detector) {
+            if (detector.isStandardDetector() && !isInternalCaller) {
+                onFailures(
+                        new OpenSearchStatusException(
+                                "Standard detectors cannot be deleted by users.", RestStatus.BAD_REQUEST));
+                return;
+            }
+
             StepListener<AcknowledgedResponse> onDeleteWorkflowStep = new StepListener<>();
             // 1. Delete the workflow if the workflow is supported
             deleteWorkflow(detector, onDeleteWorkflowStep);
-            onDeleteWorkflowStep.whenComplete(acknowledgedResponse -> {
-                List<String> monitorIds = detector.getMonitorIds();
-                if (monitorIds == null || monitorIds.isEmpty()) {
-                    deleteDetectorFromConfig(detector.getId(), request.getRefreshPolicy());
-                } else {
-                    ActionListener<DeleteMonitorResponse> deletesListener = new GroupedActionListener<>(new ActionListener<>() {
-                        @Override
-                        public void onResponse(Collection<DeleteMonitorResponse> responses) {
-                            SetOnce<RestStatus> errorStatusSupplier = new SetOnce<>();
-                            if (responses.stream().filter(response -> {
-                                if (response.getStatus() != RestStatus.OK) {
-                                    log.error(
-                                        "Detector not being deleted because monitor [{}] could not be deleted. Status [{}]",
-                                        response.getId(),
-                                        response.getStatus()
-                                    );
-                                    errorStatusSupplier.trySet(response.getStatus());
-                                    return true;
-                                }
-                                return false;
-                            }).count() > 0) {
-                                onFailures(
-                                    new OpenSearchStatusException(
-                                        "Monitor associated with detected could not be deleted",
-                                        errorStatusSupplier.get()
-                                    )
-                                );
-                            }
+            onDeleteWorkflowStep.whenComplete(
+                    acknowledgedResponse -> {
+                        List<String> monitorIds = detector.getMonitorIds();
+                        if (monitorIds == null || monitorIds.isEmpty()) {
                             deleteDetectorFromConfig(detector.getId(), request.getRefreshPolicy());
-                        }
+                        } else {
+                            ActionListener<DeleteMonitorResponse> deletesListener =
+                                    new GroupedActionListener<>(
+                                            new ActionListener<>() {
+                                                @Override
+                                                public void onResponse(Collection<DeleteMonitorResponse> responses) {
+                                                    SetOnce<RestStatus> errorStatusSupplier = new SetOnce<>();
+                                                    if (responses.stream()
+                                                                    .filter(
+                                                                            response -> {
+                                                                                if (response.getStatus() != RestStatus.OK) {
+                                                                                    log.error(
+                                                                                            "Detector not being deleted because monitor [{}] could not be deleted. Status [{}]",
+                                                                                            response.getId(),
+                                                                                            response.getStatus());
+                                                                                    errorStatusSupplier.trySet(response.getStatus());
+                                                                                    return true;
+                                                                                }
+                                                                                return false;
+                                                                            })
+                                                                    .count()
+                                                            > 0) {
+                                                        onFailures(
+                                                                new OpenSearchStatusException(
+                                                                        "Monitor associated with detected could not be deleted",
+                                                                        errorStatusSupplier.get()));
+                                                    }
+                                                    deleteDetectorFromConfig(detector.getId(), request.getRefreshPolicy());
+                                                }
 
-                        @Override
-                        public void onFailure(Exception e) {
-                            if (exceptionChecker.doesGroupedActionListenerExceptionMatch(e, ACCEPTABLE_ENTITY_MISSING_THROWABLE_MATCHERS)) {
-                                logAcceptableEntityMissingException(e, detector.getId());
-                                deleteDetectorFromConfig(detector.getId(), request.getRefreshPolicy());
-                            } else {
-                                log.error(String.format(Locale.ROOT, "Failed to delete detector %s", detector.getId()), e.getMessage());
-                                if (counter.compareAndSet(false, true)) {
-                                    finishHim(null, e);
-                                }
+                                                @Override
+                                                public void onFailure(Exception e) {
+                                                    if (exceptionChecker.doesGroupedActionListenerExceptionMatch(
+                                                            e, ACCEPTABLE_ENTITY_MISSING_THROWABLE_MATCHERS)) {
+                                                        logAcceptableEntityMissingException(e, detector.getId());
+                                                        deleteDetectorFromConfig(detector.getId(), request.getRefreshPolicy());
+                                                    } else {
+                                                        log.error(
+                                                                String.format(
+                                                                        Locale.ROOT, "Failed to delete detector %s", detector.getId()),
+                                                                e.getMessage());
+                                                        if (counter.compareAndSet(false, true)) {
+                                                            finishHim(null, e);
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            monitorIds.size());
+                            for (String monitorId : monitorIds) {
+                                deleteAlertingMonitor(monitorId, request.getRefreshPolicy(), deletesListener);
                             }
                         }
-                    }, monitorIds.size());
-                    for (String monitorId : monitorIds) {
-                        deleteAlertingMonitor(monitorId, request.getRefreshPolicy(), deletesListener);
-                    }
-                }
-            }, e -> {
-                if (counter.compareAndSet(false, true)) {
-                    finishHim(null, e);
-                }
-            });
+                    },
+                    e -> {
+                        if (counter.compareAndSet(false, true)) {
+                            finishHim(null, e);
+                        }
+                    });
         }
 
-        private void deleteWorkflow(Detector detector, ActionListener<AcknowledgedResponse> actionListener) {
+        private void deleteWorkflow(
+                Detector detector, ActionListener<AcknowledgedResponse> actionListener) {
             if (detector.isWorkflowSupported() && enabledWorkflowUsage) {
                 var workflowId = detector.getWorkflowIds().get(0);
-                log.debug(String.format("Deleting the workflow %s before deleting the detector", workflowId));
+                log.debug(
+                        String.format("Deleting the workflow %s before deleting the detector", workflowId));
                 StepListener<DeleteWorkflowResponse> onDeleteWorkflowStep = new StepListener<>();
                 workflowService.deleteWorkflow(workflowId, onDeleteWorkflowStep);
                 onDeleteWorkflowStep.whenComplete(
-                    deleteWorkflowResponse -> actionListener.onResponse(new AcknowledgedResponse(true)),
-                    deleteWorkflowResponse -> handleDeleteWorkflowFailure(detector.getId(), deleteWorkflowResponse, actionListener)
-                );
+                        deleteWorkflowResponse -> actionListener.onResponse(new AcknowledgedResponse(true)),
+                        deleteWorkflowResponse ->
+                                handleDeleteWorkflowFailure(
+                                        detector.getId(), deleteWorkflowResponse, actionListener));
             } else {
-                // If detector doesn't have the workflows it means that older version of the plugin is used and just skip the step
+                // If detector doesn't have the workflows it means that older version of the plugin is used
+                // and just skip the step
                 actionListener.onResponse(new AcknowledgedResponse(true));
             }
         }
 
         private void handleDeleteWorkflowFailure(
-            final String detectorId,
-            final Exception deleteWorkflowException,
-            final ActionListener<AcknowledgedResponse> actionListener
-        ) {
+                final String detectorId,
+                final Exception deleteWorkflowException,
+                final ActionListener<AcknowledgedResponse> actionListener) {
             if (exceptionChecker.doesGroupedActionListenerExceptionMatch(
-                deleteWorkflowException,
-                ACCEPTABLE_ENTITY_MISSING_THROWABLE_MATCHERS
-            )) {
+                    deleteWorkflowException, ACCEPTABLE_ENTITY_MISSING_THROWABLE_MATCHERS)) {
                 logAcceptableEntityMissingException(deleteWorkflowException, detectorId);
                 actionListener.onResponse(new AcknowledgedResponse(true));
             } else {
@@ -310,31 +358,35 @@ public class TransportDeleteDetectorAction extends HandledTransportAction<Delete
             }
         }
 
-        private void deleteDetectorFromConfig(String detectorId, WriteRequest.RefreshPolicy refreshPolicy) {
-            deleteDetector(detectorId, refreshPolicy, new ActionListener<>() {
-                @Override
-                public void onResponse(DeleteResponse response) {
-
-                    indexTemplateManager.deleteAllUnusedTemplates(new ActionListener<Void>() {
+        private void deleteDetectorFromConfig(
+                String detectorId, WriteRequest.RefreshPolicy refreshPolicy) {
+            deleteDetector(
+                    detectorId,
+                    refreshPolicy,
+                    new ActionListener<>() {
                         @Override
-                        public void onResponse(Void unused) {
-                            onOperation(response);
+                        public void onResponse(DeleteResponse response) {
+
+                            indexTemplateManager.deleteAllUnusedTemplates(
+                                    new ActionListener<Void>() {
+                                        @Override
+                                        public void onResponse(Void unused) {
+                                            onOperation(response);
+                                        }
+
+                                        @Override
+                                        public void onFailure(Exception e) {
+                                            log.error("Error deleting unused templates: " + e.getMessage());
+                                            onOperation(response);
+                                        }
+                                    });
                         }
 
                         @Override
-                        public void onFailure(Exception e) {
-                            log.error("Error deleting unused templates: " + e.getMessage());
-                            onOperation(response);
+                        public void onFailure(Exception t) {
+                            onFailures(t);
                         }
                     });
-
-                }
-
-                @Override
-                public void onFailure(Exception t) {
-                    onFailures(t);
-                }
-            });
         }
 
         private void onOperation(DeleteResponse response) {
@@ -352,26 +404,35 @@ public class TransportDeleteDetectorAction extends HandledTransportAction<Delete
         }
 
         private void finishHim(String detectorId, Exception t) {
-            threadPool.executor(ThreadPool.Names.GENERIC).execute(ActionRunnable.supply(listener, () -> {
-                if (t != null) {
-                    log.error(String.format(Locale.ROOT, "Failed to delete detector %s", detectorId), t.getMessage());
-                    if (t instanceof OpenSearchStatusException) {
-                        throw t;
-                    }
-                    throw SecurityAnalyticsException.wrap(t);
-                } else {
-                    return new DeleteDetectorResponse(detectorId, NO_VERSION, RestStatus.NO_CONTENT);
-                }
-            }));
+            threadPool
+                    .executor(ThreadPool.Names.GENERIC)
+                    .execute(
+                            ActionRunnable.supply(
+                                    listener,
+                                    () -> {
+                                        if (t != null) {
+                                            log.error(
+                                                    String.format(Locale.ROOT, "Failed to delete detector %s", detectorId),
+                                                    t.getMessage());
+                                            if (t instanceof OpenSearchStatusException) {
+                                                throw t;
+                                            }
+                                            throw SecurityAnalyticsException.wrap(t);
+                                        } else {
+                                            return new DeleteDetectorResponse(
+                                                    detectorId, NO_VERSION, RestStatus.NO_CONTENT);
+                                        }
+                                    }));
         }
     }
 
     private void logAcceptableEntityMissingException(final Exception e, final String detectorId) {
-        final String errorMsg = String.format(
-            Locale.ROOT,
-            "Workflow, monitor, or jobs index already deleted." + " Proceeding with detector %s deletion",
-            detectorId
-        );
+        final String errorMsg =
+                String.format(
+                        Locale.ROOT,
+                        "Workflow, monitor, or jobs index already deleted."
+                                + " Proceeding with detector %s deletion",
+                        detectorId);
         log.error(errorMsg, e.getMessage());
     }
 

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -147,6 +147,12 @@ public class TransportIndexDetectorAction
     public static final String TIMESTAMP_FIELD_ALIAS = "timestamp";
     public static final String CHAINED_FINDINGS_MONITOR_STRING = "chained_findings_monitor";
 
+    /**
+     * Thread context header used by internal Wazuh plugin callers (e.g. Content Manager) to bypass
+     * standard-detector modification restrictions.
+     */
+    public static final String WAZUH_INTERNAL_CALLER_HEADER = "_wazuh_internal_caller";
+
     private final Client client;
 
     private final NamedXContentRegistry xContentRegistry;
@@ -250,7 +256,110 @@ public class TransportIndexDetectorAction
             return;
         }
 
-        checkIndicesAndExecute(task, request, listener, user);
+        boolean isInternalCaller = isInternalCaller();
+
+        // For non-internal callers, force source to Custom
+        if (!isInternalCaller) {
+            request.getDetector().setSource(Detector.DEFAULT_SOURCE);
+        }
+
+        if (request.getMethod() == RestRequest.Method.PUT && !isInternalCaller) {
+            // On update, check if the existing detector is a standard detector.
+            // If so, only the enabled field can be changed by users.
+            validateStandardDetectorUpdate(
+                    request, listener, () -> checkIndicesAndExecute(task, request, listener, user));
+        } else {
+            checkIndicesAndExecute(task, request, listener, user);
+        }
+    }
+
+    /**
+     * Returns true if the current request originates from Content Manager plugin (Used the transport
+     * action) as indicated by a thread context header.
+     */
+    private boolean isInternalCaller() {
+        String caller = this.threadPool.getThreadContext().getHeader(WAZUH_INTERNAL_CALLER_HEADER);
+        return "content-manager".equals(caller);
+    }
+
+    /**
+     * Returns true if the only difference between the existing and incoming detector is the {@code
+     * enabled} field (and its derived {@code enabledTime}/{@code lastUpdateTime}). Any change to
+     * name, inputs/rules, triggers, or threat intel is considered a modification and will be rejected
+     * for standard detectors.
+     */
+    private static boolean isOnlyEnabledChange(Detector existing, Detector incoming) {
+        return Objects.equals(existing.getName(), incoming.getName())
+                && Objects.equals(existing.getDetectorType(), incoming.getDetectorType())
+                && Objects.equals(existing.getThreatIntelEnabled(), incoming.getThreatIntelEnabled())
+                && Objects.equals(existing.getInputs(), incoming.getInputs())
+                && Objects.equals(existing.getTriggers(), incoming.getTriggers());
+    }
+
+    /**
+     * Validates that a user update to a standard (Sigma) detector only changes the enabled field. If
+     * the detector is not standard, or the update is valid, the provided continuation is run.
+     */
+    private void validateStandardDetectorUpdate(
+            IndexDetectorRequest request,
+            ActionListener<IndexDetectorResponse> listener,
+            Runnable onValid) {
+        String detectorId = request.getDetectorId();
+        GetRequest getRequest = new GetRequest(Detector.DETECTORS_INDEX, detectorId);
+        client.get(
+                getRequest,
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(GetResponse response) {
+                        if (!response.isExists()) {
+                            onValid.run();
+                            return;
+                        }
+                        try {
+                            XContentParser xcp =
+                                    XContentHelper.createParser(
+                                            xContentRegistry,
+                                            LoggingDeprecationHandler.INSTANCE,
+                                            response.getSourceAsBytesRef(),
+                                            XContentType.JSON);
+                            Detector existingDetector = Detector.docParse(xcp, detectorId, response.getVersion());
+
+                            if (existingDetector.isStandardDetector()) {
+                                // For standard detectors, users can only toggle enabled.
+                                // Reject if any other user-visible field was changed.
+                                Detector incoming = request.getDetector();
+                                if (!isOnlyEnabledChange(existingDetector, incoming)) {
+                                    listener.onFailure(
+                                            new OpenSearchStatusException(
+                                                    "Standard detectors cannot be modified by users. "
+                                                            + "Only enabling or disabling is allowed.",
+                                                    RestStatus.BAD_REQUEST));
+                                    return;
+                                }
+                                // Apply only the enabled toggle on top of the existing
+                                // detector to prevent any silent field mutations.
+                                boolean newEnabled = incoming.getEnabled();
+                                existingDetector.setEnabled(newEnabled);
+                                existingDetector.setEnabledTime(newEnabled ? Instant.now() : null);
+                                existingDetector.setLastUpdateTime(Instant.now());
+                                request.setDetector(existingDetector);
+                                onValid.run();
+                                return;
+                            }
+                            // Not a standard detector allow the update
+                            // Preserve the source from the existing detector
+                            request.getDetector().setSource(existingDetector.getSource());
+                            onValid.run();
+                        } catch (IOException e) {
+                            listener.onFailure(e);
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        listener.onFailure(e);
+                    }
+                });
     }
 
     private void checkIndicesAndExecute(

--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportDeleteDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportDeleteDetectorAction.java
@@ -33,6 +33,8 @@ import com.wazuh.securityanalytics.action.WDeleteDetectorAction;
 import com.wazuh.securityanalytics.action.WDeleteDetectorRequest;
 import com.wazuh.securityanalytics.action.WDeleteDetectorResponse;
 
+import static org.opensearch.securityanalytics.transport.TransportDeleteDetectorAction.WAZUH_INTERNAL_CALLER_HEADER;
+
 public class WTransportDeleteDetectorAction
         extends HandledTransportAction<WDeleteDetectorRequest, WDeleteDetectorResponse>
         implements SecureTransportAction {
@@ -51,6 +53,17 @@ public class WTransportDeleteDetectorAction
             Task task, WDeleteDetectorRequest request, ActionListener<WDeleteDetectorResponse> listener) {
         DeleteDetectorRequest internalRequest =
                 new DeleteDetectorRequest(request.getDetectorId(), request.getRefreshPolicy());
+
+        // Mark this request as coming from the Content Manager so that
+        // TransportDeleteDetectorAction allows deletion of standard detectors.
+        if (this.client.threadPool().getThreadContext().getHeader(WAZUH_INTERNAL_CALLER_HEADER)
+                == null) {
+            this.client
+                    .threadPool()
+                    .getThreadContext()
+                    .putHeader(WAZUH_INTERNAL_CALLER_HEADER, "content-manager");
+        }
+
         this.client.execute(
                 DeleteDetectorAction.INSTANCE,
                 internalRequest,

--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorAction.java
@@ -51,6 +51,8 @@ import com.wazuh.securityanalytics.action.WIndexDetectorAction;
 import com.wazuh.securityanalytics.action.WIndexDetectorRequest;
 import com.wazuh.securityanalytics.action.WIndexDetectorResponse;
 
+import static org.opensearch.securityanalytics.transport.TransportIndexDetectorAction.WAZUH_INTERNAL_CALLER_HEADER;
+
 /**
  * Transport action handler for indexing Wazuh detectors.
  *
@@ -311,6 +313,16 @@ public class WTransportIndexDetectorAction
         IndexDetectorRequest indexDetectorRequest =
                 new IndexDetectorRequest(
                         detector.getId(), request.getRefreshPolicy(), RestRequest.Method.PUT, detector);
+
+        // Mark this request as coming from the Content Manager so that
+        // TransportIndexDetectorAction allows modifications to standard detectors.
+        if (this.client.threadPool().getThreadContext().getHeader(WAZUH_INTERNAL_CALLER_HEADER)
+                == null) {
+            this.client
+                    .threadPool()
+                    .getThreadContext()
+                    .putHeader(WAZUH_INTERNAL_CALLER_HEADER, "content-manager");
+        }
 
         this.client.execute(
                 IndexDetectorAction.INSTANCE,

--- a/src/main/java/org/opensearch/securityanalytics/util/DetectorFactory.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/DetectorFactory.java
@@ -53,6 +53,11 @@ public class DetectorFactory {
      */
     public static Detector createDetector(
             String integration, String category, List<String> detectorRules) {
+        return createDetector(integration, category, detectorRules, Detector.SIGMA_SOURCE);
+    }
+
+    public static Detector createDetector(
+            String integration, String category, List<String> detectorRules, String source) {
 
         List<DetectorRule> rules = new ArrayList<>();
         detectorRules.forEach(rule -> rules.add(new DetectorRule(rule)));
@@ -86,6 +91,7 @@ public class DetectorFactory {
                 null,
                 null,
                 null,
-                false);
+                false,
+                source);
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -1,10 +1,23 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.opensearch.securityanalytics;
 
 import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
+
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -21,7 +34,6 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.script.Script;
 import org.opensearch.script.ScriptType;
-import org.opensearch.securityanalytics.commons.model.IOCType;
 import org.opensearch.securityanalytics.model.CorrelationQuery;
 import org.opensearch.securityanalytics.model.CorrelationRule;
 import org.opensearch.securityanalytics.model.CorrelationRuleTrigger;
@@ -56,78 +68,117 @@ public class TestHelpers {
     }
 
     public static Detector randomDetector(List<String> rules) {
-        DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), Collections.emptyList(),
-                rules.stream().map(DetectorRule::new).collect(Collectors.toList()));
-        return randomDetector(null, null, null, List.of(input), List.of(), null, null, null, null, false);
+        DetectorInput input =
+                new DetectorInput(
+                        "windows detector for security analytics",
+                        List.of("windows"),
+                        Collections.emptyList(),
+                        rules.stream().map(DetectorRule::new).collect(Collectors.toList()));
+        return randomDetector(
+                null, null, null, List.of(input), List.of(), null, null, null, null, false);
     }
 
     public static Detector randomDetector(List<String> rules, String detectorType) {
-        DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), Collections.emptyList(),
-                rules.stream().map(DetectorRule::new).collect(Collectors.toList()));
-        return randomDetector(null, detectorType, null, List.of(input), List.of(), null, null, null, null, false);
+        DetectorInput input =
+                new DetectorInput(
+                        "windows detector for security analytics",
+                        List.of("windows"),
+                        Collections.emptyList(),
+                        rules.stream().map(DetectorRule::new).collect(Collectors.toList()));
+        return randomDetector(
+                null, detectorType, null, List.of(input), List.of(), null, null, null, null, false);
     }
 
     public static Detector randomDetectorWithInputs(List<DetectorInput> inputs) {
         return randomDetector(null, null, null, inputs, List.of(), null, null, null, null, false);
     }
 
-    public static Detector randomDetectorWithInputsAndThreatIntel(List<DetectorInput> inputs, Boolean threatIntel) {
+    public static Detector randomDetectorWithInputsAndThreatIntel(
+            List<DetectorInput> inputs, Boolean threatIntel) {
         return randomDetector(null, null, null, inputs, List.of(), null, null, null, null, threatIntel);
     }
 
-    public static Detector randomDetectorWithInputsAndThreatIntelAndTriggers(List<DetectorInput> inputs, Boolean threatIntel, List<DetectorTrigger> triggers) {
+    public static Detector randomDetectorWithInputsAndThreatIntelAndTriggers(
+            List<DetectorInput> inputs, Boolean threatIntel, List<DetectorTrigger> triggers) {
         return randomDetector(null, null, null, inputs, triggers, null, null, null, null, threatIntel);
     }
 
-    public static Detector randomDetectorWithInputsAndTriggers(List<DetectorInput> inputs, List<DetectorTrigger> triggers) {
+    public static Detector randomDetectorWithInputsAndTriggers(
+            List<DetectorInput> inputs, List<DetectorTrigger> triggers) {
         return randomDetector(null, null, null, inputs, triggers, null, null, null, null, false);
     }
 
     public static Detector randomDetectorWithInputs(List<DetectorInput> inputs, String detectorType) {
-        return randomDetector(null, detectorType, null, inputs, List.of(), null, null, null, null, false);
+        return randomDetector(
+                null, detectorType, null, inputs, List.of(), null, null, null, null, false);
     }
-
 
     public static Detector randomDetectorWithTriggers(List<DetectorTrigger> triggers) {
         return randomDetector(null, null, null, List.of(), triggers, null, null, null, null, false);
     }
 
-    public static Detector randomDetectorWithTriggers(List<String> rules, List<DetectorTrigger> triggers) {
-        DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), Collections.emptyList(),
-                rules.stream().map(DetectorRule::new).collect(Collectors.toList()));
-        return randomDetector(null, null, null, List.of(input), triggers, null, null, null, null, false);
+    public static Detector randomDetectorWithTriggers(
+            List<String> rules, List<DetectorTrigger> triggers) {
+        DetectorInput input =
+                new DetectorInput(
+                        "windows detector for security analytics",
+                        List.of("windows"),
+                        Collections.emptyList(),
+                        rules.stream().map(DetectorRule::new).collect(Collectors.toList()));
+        return randomDetector(
+                null, null, null, List.of(input), triggers, null, null, null, null, false);
     }
 
-    public static Detector randomDetectorWithTriggers(List<String> rules, List<DetectorTrigger> triggers, List<String> inputIndices) {
-        DetectorInput input = new DetectorInput("windows detector for security analytics", inputIndices, Collections.emptyList(),
-                rules.stream().map(DetectorRule::new).collect(Collectors.toList()));
-        return randomDetector(null, null, null, List.of(input), triggers, null, true, null, null, false);
+    public static Detector randomDetectorWithTriggers(
+            List<String> rules, List<DetectorTrigger> triggers, List<String> inputIndices) {
+        DetectorInput input =
+                new DetectorInput(
+                        "windows detector for security analytics",
+                        inputIndices,
+                        Collections.emptyList(),
+                        rules.stream().map(DetectorRule::new).collect(Collectors.toList()));
+        return randomDetector(
+                null, null, null, List.of(input), triggers, null, true, null, null, false);
     }
 
-    public static Detector randomDetectorWithTriggersAndScheduleAndEnabled(List<String> rules, List<DetectorTrigger> triggers, Schedule schedule, boolean enabled) {
-        DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), Collections.emptyList(),
-                rules.stream().map(DetectorRule::new).collect(Collectors.toList()));
-        return randomDetector(null, null, null, List.of(input), triggers, schedule, enabled, null, null, false);
+    public static Detector randomDetectorWithTriggersAndScheduleAndEnabled(
+            List<String> rules, List<DetectorTrigger> triggers, Schedule schedule, boolean enabled) {
+        DetectorInput input =
+                new DetectorInput(
+                        "windows detector for security analytics",
+                        List.of("windows"),
+                        Collections.emptyList(),
+                        rules.stream().map(DetectorRule::new).collect(Collectors.toList()));
+        return randomDetector(
+                null, null, null, List.of(input), triggers, schedule, enabled, null, null, false);
     }
 
-    public static Detector randomDetectorWithTriggers(List<String> rules, List<DetectorTrigger> triggers, String detectorType, DetectorInput input) {
-        return randomDetector(null, detectorType, null, List.of(input), triggers, null, null, null, null, false);
+    public static Detector randomDetectorWithTriggers(
+            List<String> rules,
+            List<DetectorTrigger> triggers,
+            String detectorType,
+            DetectorInput input) {
+        return randomDetector(
+                null, detectorType, null, List.of(input), triggers, null, null, null, null, false);
     }
 
-    public static Detector randomDetectorWithInputsAndTriggersAndType(List<DetectorInput> inputs, List<DetectorTrigger> triggers, String detectorType) {
-        return randomDetector(null, detectorType, null, inputs, triggers, null, null, null, null, false);
+    public static Detector randomDetectorWithInputsAndTriggersAndType(
+            List<DetectorInput> inputs, List<DetectorTrigger> triggers, String detectorType) {
+        return randomDetector(
+                null, detectorType, null, inputs, triggers, null, null, null, null, false);
     }
 
-    public static Detector randomDetector(String name,
-                                          String detectorType,
-                                          User user,
-                                          List<DetectorInput> inputs,
-                                          List<DetectorTrigger> triggers,
-                                          Schedule schedule,
-                                          Boolean enabled,
-                                          Instant enabledTime,
-                                          Instant lastUpdateTime,
-                                          Boolean threatIntel) {
+    public static Detector randomDetector(
+            String name,
+            String detectorType,
+            User user,
+            List<DetectorInput> inputs,
+            List<DetectorTrigger> triggers,
+            Schedule schedule,
+            Boolean enabled,
+            Instant enabledTime,
+            Instant lastUpdateTime,
+            Boolean threatIntel) {
         if (name == null) {
             name = OpenSearchRestTestCase.randomAlphaOfLength(10);
         }
@@ -157,19 +208,57 @@ public class TestHelpers {
         if (inputs.size() == 0) {
             inputs = new ArrayList<>();
 
-            DetectorInput input = new DetectorInput("windows detector for security analytics", List.of("windows"), Collections.emptyList(), null);
+            DetectorInput input =
+                    new DetectorInput(
+                            "windows detector for security analytics",
+                            List.of("windows"),
+                            Collections.emptyList(),
+                            null);
             inputs.add(input);
         }
         if (triggers.size() == 0) {
             triggers = new ArrayList<>();
 
-            DetectorTrigger trigger = new DetectorTrigger(null, "windows-trigger", "1", List.of(randomDetectorType()), List.of("QuarksPwDump Clearing Access History"), List.of("high"), List.of("T0008"), List.of(), List.of());
+            DetectorTrigger trigger =
+                    new DetectorTrigger(
+                            null,
+                            "windows-trigger",
+                            "1",
+                            List.of(randomDetectorType()),
+                            List.of("QuarksPwDump Clearing Access History"),
+                            List.of("high"),
+                            List.of("T0008"),
+                            List.of(),
+                            List.of());
             triggers.add(trigger);
         }
-        return new Detector(null, null, name, enabled, schedule, lastUpdateTime, enabledTime, detectorType, user, inputs, triggers, Collections.singletonList(""), "", "", "", "", "", "", Collections.emptyMap(), Collections.emptyList(), threatIntel);
+        return new Detector(
+                null,
+                null,
+                name,
+                enabled,
+                schedule,
+                lastUpdateTime,
+                enabledTime,
+                detectorType,
+                user,
+                inputs,
+                triggers,
+                Collections.singletonList(""),
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                threatIntel,
+                null);
     }
 
-    public static CustomLogType randomCustomLogType(String name, String description, String category, String source) {
+    public static CustomLogType randomCustomLogType(
+            String name, String description, String category, String source) {
         if (name == null) {
             name = "custom-log-type";
         }
@@ -186,12 +275,7 @@ public class TestHelpers {
     }
 
     public static ThreatIntelFeedData randomThreatIntelFeedData() {
-        return new ThreatIntelFeedData(
-                "IP_ADDRESS",
-                "ip",
-                "alientVault",
-                Instant.now()
-        );
+        return new ThreatIntelFeedData("IP_ADDRESS", "ip", "alientVault", Instant.now());
     }
 
     public static Detector randomDetectorWithNoUser() {
@@ -224,591 +308,611 @@ public class TestHelpers {
                 "",
                 Collections.emptyMap(),
                 Collections.emptyList(),
-                false
-        );
+                false,
+                null);
     }
 
     public static CorrelationRule randomCorrelationRule(String name) {
         name = name.isEmpty() ? "><script>prompt(document.domain)</script>" : name;
-        return new CorrelationRule(CorrelationRule.NO_ID, CorrelationRule.NO_VERSION, name,
+        return new CorrelationRule(
+                CorrelationRule.NO_ID,
+                CorrelationRule.NO_VERSION,
+                name,
                 List.of(
                         new CorrelationQuery("vpc_flow1", "dstaddr:192.168.1.*", "network", null),
-                        new CorrelationQuery("ad_logs1", "azure.platformlogs.result_type:50126", "ad_ldap", null)
-                ), 300000L, null);
+                        new CorrelationQuery(
+                                "ad_logs1", "azure.platformlogs.result_type:50126", "ad_ldap", null)),
+                300000L,
+                null);
     }
 
     public static CorrelationRule randomCorrelationRuleWithTrigger(String name) {
         name = name.isEmpty() ? "><script>prompt(document.domain)</script>" : name;
         List<Action> actions = new ArrayList<Action>();
-        CorrelationRuleTrigger trigger = new CorrelationRuleTrigger("trigger-123", "Trigger 1", "high", actions);
-        return new CorrelationRule(CorrelationRule.NO_ID, CorrelationRule.NO_VERSION, name,
+        CorrelationRuleTrigger trigger =
+                new CorrelationRuleTrigger("trigger-123", "Trigger 1", "high", actions);
+        return new CorrelationRule(
+                CorrelationRule.NO_ID,
+                CorrelationRule.NO_VERSION,
+                name,
                 List.of(
                         new CorrelationQuery("vpc_flow1", "dstaddr:192.168.1.*", "network", null),
-                        new CorrelationQuery("ad_logs1", "azure.platformlogs.result_type:50126", "ad_ldap", null)
-                ), 300000L, trigger);
+                        new CorrelationQuery(
+                                "ad_logs1", "azure.platformlogs.result_type:50126", "ad_ldap", null)),
+                300000L,
+                trigger);
     }
 
     public static String randomRule() {
-        return "title: Remote Encrypting File System Abuse\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.defense_evasion\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "logsource:\n" +
-                "    product: rpc_firewall\n" +
-                "    category: application\n" +
-                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
-                "detection:\n" +
-                "    selection:\n" +
-                "        EventID: 22\n" +
-                "    condition: selection\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: high";
+        return "title: Remote Encrypting File System Abuse\n"
+                + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                + "references:\n"
+                + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                + "tags:\n"
+                + "    - attack.defense_evasion\n"
+                + "status: experimental\n"
+                + "author: Sagie Dulce, Dekel Paz\n"
+                + "date: 2022/01/01\n"
+                + "modified: 2022/01/01\n"
+                + "logsource:\n"
+                + "    product: rpc_firewall\n"
+                + "    category: application\n"
+                + "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n"
+                + "detection:\n"
+                + "    selection:\n"
+                + "        EventID: 22\n"
+                + "    condition: selection\n"
+                + "falsepositives:\n"
+                + "    - Legitimate usage of remote file encryption\n"
+                + "level: high";
     }
 
     public static String randomRuleWithRawField() {
-        return "title: Remote Encrypting File System Abuse\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.defense_evasion\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "logsource:\n" +
-                "    product: rpc_firewall\n" +
-                "    category: application\n" +
-                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
-                "detection:\n" +
-                "    selection:\n" +
-                "        eventName: testinghere\n" +
-                "    condition: selection\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: high";
+        return "title: Remote Encrypting File System Abuse\n"
+                + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                + "references:\n"
+                + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                + "tags:\n"
+                + "    - attack.defense_evasion\n"
+                + "status: experimental\n"
+                + "author: Sagie Dulce, Dekel Paz\n"
+                + "date: 2022/01/01\n"
+                + "modified: 2022/01/01\n"
+                + "logsource:\n"
+                + "    product: rpc_firewall\n"
+                + "    category: application\n"
+                + "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n"
+                + "detection:\n"
+                + "    selection:\n"
+                + "        eventName: testinghere\n"
+                + "    condition: selection\n"
+                + "falsepositives:\n"
+                + "    - Legitimate usage of remote file encryption\n"
+                + "level: high";
     }
 
     public static String randomRuleWithNotCondition() {
-        return "title: Remote Encrypting File System Abuse\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.defense_evasion\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "logsource:\n" +
-                "    product: rpc_firewall\n" +
-                "    category: application\n" +
-                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
-                "detection:\n" +
-                "    selection1:\n" +
-                "        AccountType: TestAccountType\n" +
-                "    selection2:\n" +
-                "        AccountName: TestAccountName\n" +
-                "    selection3:\n" +
-                "        EventID: 22\n" +
-                "    condition: (not selection1 and not selection2) and selection3\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: high";
+        return "title: Remote Encrypting File System Abuse\n"
+                + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                + "references:\n"
+                + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                + "tags:\n"
+                + "    - attack.defense_evasion\n"
+                + "status: experimental\n"
+                + "author: Sagie Dulce, Dekel Paz\n"
+                + "date: 2022/01/01\n"
+                + "modified: 2022/01/01\n"
+                + "logsource:\n"
+                + "    product: rpc_firewall\n"
+                + "    category: application\n"
+                + "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n"
+                + "detection:\n"
+                + "    selection1:\n"
+                + "        AccountType: TestAccountType\n"
+                + "    selection2:\n"
+                + "        AccountName: TestAccountName\n"
+                + "    selection3:\n"
+                + "        EventID: 22\n"
+                + "    condition: (not selection1 and not selection2) and selection3\n"
+                + "falsepositives:\n"
+                + "    - Legitimate usage of remote file encryption\n"
+                + "level: high";
     }
 
     public static String randomRuleWithCriticalSeverity() {
-        return "title: Remote Encrypting File System Abuse\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.defense_evasion\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "logsource:\n" +
-                "    product: rpc_firewall\n" +
-                "    category: application\n" +
-                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
-                "detection:\n" +
-                "    selection:\n" +
-                "        EventID: 22\n" +
-                "    condition: selection\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: critical";
+        return "title: Remote Encrypting File System Abuse\n"
+                + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                + "references:\n"
+                + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                + "tags:\n"
+                + "    - attack.defense_evasion\n"
+                + "status: experimental\n"
+                + "author: Sagie Dulce, Dekel Paz\n"
+                + "date: 2022/01/01\n"
+                + "modified: 2022/01/01\n"
+                + "logsource:\n"
+                + "    product: rpc_firewall\n"
+                + "    category: application\n"
+                + "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n"
+                + "detection:\n"
+                + "    selection:\n"
+                + "        EventID: 22\n"
+                + "    condition: selection\n"
+                + "falsepositives:\n"
+                + "    - Legitimate usage of remote file encryption\n"
+                + "level: critical";
     }
 
     public static String randomRuleWithNotConditionBoolAndNum() {
-        return "title: Remote Encrypting File System Abuse\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.defense_evasion\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "logsource:\n" +
-                "    product: rpc_firewall\n" +
-                "    category: application\n" +
-                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
-                "detection:\n" +
-                "    selection1:\n" +
-                "        Initiated: \"false\"\n" +
-                "    selection2:\n" +
-                "        AccountName: TestAccountName\n" +
-                "    selection3:\n" +
-                "        EventID: 21\n" +
-                "    condition: not selection1 and not selection3\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: high";
+        return "title: Remote Encrypting File System Abuse\n"
+                + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                + "references:\n"
+                + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                + "tags:\n"
+                + "    - attack.defense_evasion\n"
+                + "status: experimental\n"
+                + "author: Sagie Dulce, Dekel Paz\n"
+                + "date: 2022/01/01\n"
+                + "modified: 2022/01/01\n"
+                + "logsource:\n"
+                + "    product: rpc_firewall\n"
+                + "    category: application\n"
+                + "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n"
+                + "detection:\n"
+                + "    selection1:\n"
+                + "        Initiated: \"false\"\n"
+                + "    selection2:\n"
+                + "        AccountName: TestAccountName\n"
+                + "    selection3:\n"
+                + "        EventID: 21\n"
+                + "    condition: not selection1 and not selection3\n"
+                + "falsepositives:\n"
+                + "    - Legitimate usage of remote file encryption\n"
+                + "level: high";
     }
 
     public static String randomNullRule() {
-        return "title: null field\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.defense_evasion\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "logsource:\n" +
-                "    product: rpc_firewall\n" +
-                "    category: application\n" +
-                "    definition: 'Requirements: install and apply the RPC Firew all to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
-                "detection:\n" +
-                "    selection:\n" +
-                "        EventID: 22\n" +
-                "        RecordNumber: null\n" +
-                "    condition: selection\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: high";
+        return "title: null field\n"
+                + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                + "references:\n"
+                + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                + "tags:\n"
+                + "    - attack.defense_evasion\n"
+                + "status: experimental\n"
+                + "author: Sagie Dulce, Dekel Paz\n"
+                + "date: 2022/01/01\n"
+                + "modified: 2022/01/01\n"
+                + "logsource:\n"
+                + "    product: rpc_firewall\n"
+                + "    category: application\n"
+                + "    definition: 'Requirements: install and apply the RPC Firew all to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n"
+                + "detection:\n"
+                + "    selection:\n"
+                + "        EventID: 22\n"
+                + "        RecordNumber: null\n"
+                + "    condition: selection\n"
+                + "falsepositives:\n"
+                + "    - Legitimate usage of remote file encryption\n"
+                + "level: high";
     }
 
     public static String randomCloudtrailRuleForCorrelations(String value) {
-        return "id: 5f92fff9-82e2-48ab-8fc1-8b133556a551\n" +
-                "logsource:\n" +
-                "  product: cloudtrail\n" +
-                "title: AWS User Created\n" +
-                "description: AWS User Created\n" +
-                "tags:\n" +
-                "  - attack.test1\n" +
-                "falsepositives:\n" +
-                "  - Legit User Account Administration\n" +
-                "level: high\n" +
-                "date: 2022/01/01\n" +
-                "status: experimental\n" +
-                "references:\n" +
-                "  - 'https://github.com/RhinoSecurityLabs/AWS-IAM-Privilege-Escalation'\n" +
-                "author: toffeebr33k\n" +
-                "detection:\n" +
-                "  condition: selection_source\n" +
-                "  selection_source:\n" +
-                "    EventName:\n" +
-                "      - " + value;
+        return "id: 5f92fff9-82e2-48ab-8fc1-8b133556a551\n"
+                + "logsource:\n"
+                + "  product: cloudtrail\n"
+                + "title: AWS User Created\n"
+                + "description: AWS User Created\n"
+                + "tags:\n"
+                + "  - attack.test1\n"
+                + "falsepositives:\n"
+                + "  - Legit User Account Administration\n"
+                + "level: high\n"
+                + "date: 2022/01/01\n"
+                + "status: experimental\n"
+                + "references:\n"
+                + "  - 'https://github.com/RhinoSecurityLabs/AWS-IAM-Privilege-Escalation'\n"
+                + "author: toffeebr33k\n"
+                + "detection:\n"
+                + "  condition: selection_source\n"
+                + "  selection_source:\n"
+                + "    EventName:\n"
+                + "      - "
+                + value;
     }
 
     public static String randomRuleForMappingView(String field) {
-        return "title: Remote Encrypting File System Abuse\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.defense_evasion\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "logsource:\n" +
-                "    product: rpc_firewall\n" +
-                "    category: application\n" +
-                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
-                "detection:\n" +
-                "    selection:\n" +
-                "        " + field + ": 'ACL'\n" +
-                "    condition: selection\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: high";
+        return "title: Remote Encrypting File System Abuse\n"
+                + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                + "references:\n"
+                + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                + "tags:\n"
+                + "    - attack.defense_evasion\n"
+                + "status: experimental\n"
+                + "author: Sagie Dulce, Dekel Paz\n"
+                + "date: 2022/01/01\n"
+                + "modified: 2022/01/01\n"
+                + "logsource:\n"
+                + "    product: rpc_firewall\n"
+                + "    category: application\n"
+                + "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n"
+                + "detection:\n"
+                + "    selection:\n"
+                + "        "
+                + field
+                + ": 'ACL'\n"
+                + "    condition: selection\n"
+                + "falsepositives:\n"
+                + "    - Legitimate usage of remote file encryption\n"
+                + "level: high";
     }
 
     public static String randomRuleForCustomLogType() {
-        return "title: Remote Encrypting File System Abuse\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.defense_evasion\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "logsource:\n" +
-                "    product: rpc_firewall\n" +
-                "    category: application\n" +
-                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
-                "detection:\n" +
-                "    selection:\n" +
-                "        EventID: 22\n" +
-                "        Author: 'Hello'\n" +
-                "    condition: selection\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: high";
+        return "title: Remote Encrypting File System Abuse\n"
+                + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                + "references:\n"
+                + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                + "tags:\n"
+                + "    - attack.defense_evasion\n"
+                + "status: experimental\n"
+                + "author: Sagie Dulce, Dekel Paz\n"
+                + "date: 2022/01/01\n"
+                + "modified: 2022/01/01\n"
+                + "logsource:\n"
+                + "    product: rpc_firewall\n"
+                + "    category: application\n"
+                + "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n"
+                + "detection:\n"
+                + "    selection:\n"
+                + "        EventID: 22\n"
+                + "        Author: 'Hello'\n"
+                + "    condition: selection\n"
+                + "falsepositives:\n"
+                + "    - Legitimate usage of remote file encryption\n"
+                + "level: high";
     }
 
     public static String randomRuleWithAlias() {
-        return "title: Remote Encrypting File System Abuse\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.defense_evasion\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "logsource:\n" +
-                "    product: rpc_firewall\n" +
-                "    category: application\n" +
-                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
-                "detection:\n" +
-                "    selection:\n" +
-                "        event_uid: 22\n" +
-                "    condition: selection\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: high";
+        return "title: Remote Encrypting File System Abuse\n"
+                + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                + "references:\n"
+                + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                + "tags:\n"
+                + "    - attack.defense_evasion\n"
+                + "status: experimental\n"
+                + "author: Sagie Dulce, Dekel Paz\n"
+                + "date: 2022/01/01\n"
+                + "modified: 2022/01/01\n"
+                + "logsource:\n"
+                + "    product: rpc_firewall\n"
+                + "    category: application\n"
+                + "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n"
+                + "detection:\n"
+                + "    selection:\n"
+                + "        event_uid: 22\n"
+                + "    condition: selection\n"
+                + "falsepositives:\n"
+                + "    - Legitimate usage of remote file encryption\n"
+                + "level: high";
     }
 
     public static String randomRuleWithKeywords() {
-        return "title: Remote Encrypting File System Abuse\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.defense_evasion\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "logsource:\n" +
-                "    product: rpc_firewall\n" +
-                "    category: application\n" +
-                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
-                "detection:\n" +
-                "    selection:\n" +
-                "        EventID: 21\n" +
-                "    keywords:\n" +
-                "        - 1996\n" +
-                "        - EC2AMAZ*\n" +
-                "    condition: selection or keywords\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: high";
+        return "title: Remote Encrypting File System Abuse\n"
+                + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                + "references:\n"
+                + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                + "tags:\n"
+                + "    - attack.defense_evasion\n"
+                + "status: experimental\n"
+                + "author: Sagie Dulce, Dekel Paz\n"
+                + "date: 2022/01/01\n"
+                + "modified: 2022/01/01\n"
+                + "logsource:\n"
+                + "    product: rpc_firewall\n"
+                + "    category: application\n"
+                + "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n"
+                + "detection:\n"
+                + "    selection:\n"
+                + "        EventID: 21\n"
+                + "    keywords:\n"
+                + "        - 1996\n"
+                + "        - EC2AMAZ*\n"
+                + "    condition: selection or keywords\n"
+                + "falsepositives:\n"
+                + "    - Legitimate usage of remote file encryption\n"
+                + "level: high";
     }
 
     public static String randomRuleWithStringKeywords() {
-        return "title: Remote Encrypting File System Abuse\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.defense_evasion\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "logsource:\n" +
-                "    product: rpc_firewall\n" +
-                "    category: application\n" +
-                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
-                "detection:\n" +
-                "    selection:\n" +
-                "        EventID: 21\n" +
-                "    keywords:\n" +
-                "        - \"INFO\"\n" +
-                "    condition: selection or keywords\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: high";
+        return "title: Remote Encrypting File System Abuse\n"
+                + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                + "references:\n"
+                + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                + "tags:\n"
+                + "    - attack.defense_evasion\n"
+                + "status: experimental\n"
+                + "author: Sagie Dulce, Dekel Paz\n"
+                + "date: 2022/01/01\n"
+                + "modified: 2022/01/01\n"
+                + "logsource:\n"
+                + "    product: rpc_firewall\n"
+                + "    category: application\n"
+                + "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n"
+                + "detection:\n"
+                + "    selection:\n"
+                + "        EventID: 21\n"
+                + "    keywords:\n"
+                + "        - \"INFO\"\n"
+                + "    condition: selection or keywords\n"
+                + "falsepositives:\n"
+                + "    - Legitimate usage of remote file encryption\n"
+                + "level: high";
     }
 
     public static String randomRuleWithDateKeywords() {
-        return "title: Remote Encrypting File System Abuse\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.defense_evasion\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "logsource:\n" +
-                "    product: rpc_firewall\n" +
-                "    category: application\n" +
-                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
-                "detection:\n" +
-                "    selection:\n" +
-                "        EventID: 21\n" +
-                "    keywords:\n" +
-                "        - \"2020-02-04T14:59:39.343541+00:00\"\n" +
-                "    condition: selection or keywords\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: high";
+        return "title: Remote Encrypting File System Abuse\n"
+                + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                + "references:\n"
+                + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                + "tags:\n"
+                + "    - attack.defense_evasion\n"
+                + "status: experimental\n"
+                + "author: Sagie Dulce, Dekel Paz\n"
+                + "date: 2022/01/01\n"
+                + "modified: 2022/01/01\n"
+                + "logsource:\n"
+                + "    product: rpc_firewall\n"
+                + "    category: application\n"
+                + "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n"
+                + "detection:\n"
+                + "    selection:\n"
+                + "        EventID: 21\n"
+                + "    keywords:\n"
+                + "        - \"2020-02-04T14:59:39.343541+00:00\"\n"
+                + "    condition: selection or keywords\n"
+                + "falsepositives:\n"
+                + "    - Legitimate usage of remote file encryption\n"
+                + "level: high";
     }
 
     public static String countAggregationTestRule() {
-        return "            title: Test\n" +
-                "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2b\n" +
-                "            status: test\n" +
-                "            level: critical\n" +
-                "            description: Detects QuarksPwDump clearing access history in hive\n" +
-                "            author: Florian Roth\n" +
-                "            date: 2017/05/15\n" +
-                "            logsource:\n" +
-                "                category: test_category\n" +
-                "                product: test_product\n" +
-                "            detection:\n" +
-                "                sel:\n" +
-                "                    fieldA: valueA\n" +
-                "                    fieldB: valueB\n" +
-                "                    fieldC: valueC\n" +
-                "                condition: sel | count(*) > 1";
+        return "            title: Test\n"
+                + "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2b\n"
+                + "            status: test\n"
+                + "            level: critical\n"
+                + "            description: Detects QuarksPwDump clearing access history in hive\n"
+                + "            author: Florian Roth\n"
+                + "            date: 2017/05/15\n"
+                + "            logsource:\n"
+                + "                category: test_category\n"
+                + "                product: test_product\n"
+                + "            detection:\n"
+                + "                sel:\n"
+                + "                    fieldA: valueA\n"
+                + "                    fieldB: valueB\n"
+                + "                    fieldC: valueC\n"
+                + "                condition: sel | count(*) > 1";
     }
 
     public static String sumAggregationTestRule() {
-        return "            title: Test\n" +
-                "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2b\n" +
-                "            status: test\n" +
-                "            level: critical\n" +
-                "            description: Detects QuarksPwDump clearing access history in hive\n" +
-                "            author: Florian Roth\n" +
-                "            date: 2017/05/15\n" +
-                "            logsource:\n" +
-                "                category: test_category\n" +
-                "                product: test_product\n" +
-                "            detection:\n" +
-                "                sel:\n" +
-                "                    fieldA: 123\n" +
-                "                    fieldB: 111\n" +
-                "                    fieldC: valueC\n" +
-                "                condition: sel | sum(fieldA) by fieldB > 110";
+        return "            title: Test\n"
+                + "            id: 39f919f3-980b-4e6f-a975-8af7e507ef2b\n"
+                + "            status: test\n"
+                + "            level: critical\n"
+                + "            description: Detects QuarksPwDump clearing access history in hive\n"
+                + "            author: Florian Roth\n"
+                + "            date: 2017/05/15\n"
+                + "            logsource:\n"
+                + "                category: test_category\n"
+                + "                product: test_product\n"
+                + "            detection:\n"
+                + "                sel:\n"
+                + "                    fieldA: 123\n"
+                + "                    fieldB: 111\n"
+                + "                    fieldC: valueC\n"
+                + "                condition: sel | sum(fieldA) by fieldB > 110";
     }
 
     public static String productIndexMaxAggRule() {
-        return "            title: Test\n" +
-                "            id: 5f92fff9-82e3-48eb-8fc1-8b133556a551\n" +
-                "            status: test\n" +
-                "            level: critical\n" +
-                "            description: Detects QuarksPwDump clearing access history in hive\n" +
-                "            author: Florian Roth\n" +
-                "            date: 2017/05/15\n" +
-                "            logsource:\n" +
-                "                category: test_category\n" +
-                "                product: test_product\n" +
-                "            detection:\n" +
-                "                sel:\n" +
-                "                    fieldA: 123\n" +
-                "                    fieldB: 111\n" +
-                "                    fieldC: valueC\n" +
-                "                condition: sel | max(fieldA) by fieldB > 110";
+        return "            title: Test\n"
+                + "            id: 5f92fff9-82e3-48eb-8fc1-8b133556a551\n"
+                + "            status: test\n"
+                + "            level: critical\n"
+                + "            description: Detects QuarksPwDump clearing access history in hive\n"
+                + "            author: Florian Roth\n"
+                + "            date: 2017/05/15\n"
+                + "            logsource:\n"
+                + "                category: test_category\n"
+                + "                product: test_product\n"
+                + "            detection:\n"
+                + "                sel:\n"
+                + "                    fieldA: 123\n"
+                + "                    fieldB: 111\n"
+                + "                    fieldC: valueC\n"
+                + "                condition: sel | max(fieldA) by fieldB > 110";
     }
 
     public static String randomProductDocument() {
-        return "{\n" +
-                "  \"name\": \"laptop\",\n" +
-                "  \"fieldA\": 123,\n" +
-                "  \"mappedB\": 111,\n" +
-                "  \"fieldC\": \"valueC\"\n" +
-                "}\n";
+        return "{\n"
+                + "  \"name\": \"laptop\",\n"
+                + "  \"fieldA\": 123,\n"
+                + "  \"mappedB\": 111,\n"
+                + "  \"fieldC\": \"valueC\"\n"
+                + "}\n";
     }
 
     public static String randomProductDocumentWithTime(long time) {
-        return "{\n" +
-                "  \"fieldA\": 123,\n" +
-                "  \"mappedB\": 111,\n" +
-                "  \"time\": " + (time) + ",\n" +
-                "  \"fieldC\": \"valueC\"\n" +
-                "}\n";
+        return "{\n"
+                + "  \"fieldA\": 123,\n"
+                + "  \"mappedB\": 111,\n"
+                + "  \"time\": "
+                + (time)
+                + ",\n"
+                + "  \"fieldC\": \"valueC\"\n"
+                + "}\n";
     }
 
     public static String randomEditedRule() {
-        return "title: Remote Encrypting File System Abuse\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.lateral_movement\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "logsource:\n" +
-                "    product: rpc_firewall\n" +
-                "    category: application\n" +
-                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
-                "detection:\n" +
-                "    selection:\n" +
-                "        EventID: 24\n" +
-                "    condition: selection\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: high";
+        return "title: Remote Encrypting File System Abuse\n"
+                + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                + "references:\n"
+                + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                + "tags:\n"
+                + "    - attack.lateral_movement\n"
+                + "status: experimental\n"
+                + "author: Sagie Dulce, Dekel Paz\n"
+                + "date: 2022/01/01\n"
+                + "modified: 2022/01/01\n"
+                + "logsource:\n"
+                + "    product: rpc_firewall\n"
+                + "    category: application\n"
+                + "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n"
+                + "detection:\n"
+                + "    selection:\n"
+                + "        EventID: 24\n"
+                + "    condition: selection\n"
+                + "falsepositives:\n"
+                + "    - Legitimate usage of remote file encryption\n"
+                + "level: high";
     }
 
     public static String randomEditedRuleInvalidSyntax(String title) {
-        return "title: " + title + "\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.lateral_movement\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "logsource:\n" +
-                "    product: rpc_firewall\n" +
-                "    category: application\n" +
-                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
-                "detection:\n" +
-                "    selection:\n" +
-                "        EventID: 24\n" +
-                "    condition: selection\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: high";
+        return "title: "
+                + title
+                + "\n"
+                + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                + "references:\n"
+                + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                + "tags:\n"
+                + "    - attack.lateral_movement\n"
+                + "status: experimental\n"
+                + "author: Sagie Dulce, Dekel Paz\n"
+                + "date: 2022/01/01\n"
+                + "modified: 2022/01/01\n"
+                + "logsource:\n"
+                + "    product: rpc_firewall\n"
+                + "    category: application\n"
+                + "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n"
+                + "detection:\n"
+                + "    selection:\n"
+                + "        EventID: 24\n"
+                + "    condition: selection\n"
+                + "falsepositives:\n"
+                + "    - Legitimate usage of remote file encryption\n"
+                + "level: high";
     }
 
     public static String randomRuleWithErrors() {
-        return "title: Remote Encrypting File System Abuse\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.lateral_movement\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: high";
+        return "title: Remote Encrypting File System Abuse\n"
+                + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                + "references:\n"
+                + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                + "tags:\n"
+                + "    - attack.lateral_movement\n"
+                + "status: experimental\n"
+                + "author: Sagie Dulce, Dekel Paz\n"
+                + "date: 2022/01/01\n"
+                + "modified: 2022/01/01\n"
+                + "falsepositives:\n"
+                + "    - Legitimate usage of remote file encryption\n"
+                + "level: high";
     }
 
     public static String randomRuleWithErrors(String title) {
-        return "title: " + title + "\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.lateral_movement\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: high";
+        return "title: "
+                + title
+                + "\n"
+                + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                + "references:\n"
+                + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                + "tags:\n"
+                + "    - attack.lateral_movement\n"
+                + "status: experimental\n"
+                + "author: Sagie Dulce, Dekel Paz\n"
+                + "date: 2022/01/01\n"
+                + "modified: 2022/01/01\n"
+                + "falsepositives:\n"
+                + "    - Legitimate usage of remote file encryption\n"
+                + "level: high";
     }
 
     public static String toJsonStringWithUser(Detector detector) throws IOException {
@@ -840,20 +944,13 @@ public class TestHelpers {
                 OpenSearchRestTestCase.randomAlphaOfLength(10),
                 List.of(
                         OpenSearchRestTestCase.randomAlphaOfLength(10),
-                        OpenSearchRestTestCase.randomAlphaOfLength(10)
-                ),
+                        OpenSearchRestTestCase.randomAlphaOfLength(10)),
                 List.of(OpenSearchRestTestCase.randomAlphaOfLength(10), AccessRoles.ALL_ACCESS_ROLE),
-                Map.of("test_attr", "test")
-        );
+                Map.of("test_attr", "test"));
     }
 
     public static User randomUserEmpty() {
-        return new User(
-                "",
-                List.of(),
-                List.of(),
-                List.of()
-        );
+        return new User("", List.of(), List.of(), List.of());
     }
 
     public static String randomDetectorType() {
@@ -883,22 +980,44 @@ public class TestHelpers {
 
     public static Action randomAction(String destinationId) {
         String name = OpenSearchRestTestCase.randomUnicodeOfLength(10);
-        Script template = randomTemplateScript("Detector {{ctx.detector.name}} just entered alert status. Please investigate the issue.\n" +
-                "  - Trigger: {{ctx.trigger.name}}\n" +
-                "  - Severity: {{ctx.trigger.severity}}", null);
+        Script template =
+                randomTemplateScript(
+                        "Detector {{ctx.detector.name}} just entered alert status. Please investigate the issue.\n"
+                                + "  - Trigger: {{ctx.trigger.name}}\n"
+                                + "  - Severity: {{ctx.trigger.severity}}",
+                        null);
         Boolean throttleEnabled = false;
         Throttle throttle = randomThrottle(null, null);
-        return new Action(name, destinationId, template, template, throttleEnabled, throttle, OpenSearchRestTestCase.randomAlphaOfLength(10), null);
+        return new Action(
+                name,
+                destinationId,
+                template,
+                template,
+                throttleEnabled,
+                throttle,
+                OpenSearchRestTestCase.randomAlphaOfLength(10),
+                null);
     }
 
     public static Action randomThreatInteMonitorAction(String destinationId) {
         String name = OpenSearchRestTestCase.randomUnicodeOfLength(10);
-        Script template = randomTemplateScript("Threat intel Monitor {{ctx.monitor.name}} just entered alert status. Please investigate the issue.\n" +
-                "  - Trigger: {{ctx.trigger.name}}\n" +
-                "  - Severity: {{ctx.trigger.severity}}", null);
+        Script template =
+                randomTemplateScript(
+                        "Threat intel Monitor {{ctx.monitor.name}} just entered alert status. Please investigate the issue.\n"
+                                + "  - Trigger: {{ctx.trigger.name}}\n"
+                                + "  - Severity: {{ctx.trigger.severity}}",
+                        null);
         Boolean throttleEnabled = false;
         Throttle throttle = randomThrottle(null, null);
-        return new Action(name, destinationId, template, template, throttleEnabled, throttle, OpenSearchRestTestCase.randomAlphaOfLength(10), null);
+        return new Action(
+                name,
+                destinationId,
+                template,
+                template,
+                throttleEnabled,
+                throttle,
+                OpenSearchRestTestCase.randomAlphaOfLength(10),
+                null);
     }
 
     public static Script randomTemplateScript(String source, Map<String, Object> params) {
@@ -923,1855 +1042,1872 @@ public class TestHelpers {
     }
 
     public static String randomNetFlowDoc() {
-        return "{" +
-                "  \"netflow.event_data.SourceAddress\":\"10.50.221.10\"," +
-                "  \"netflow.event_data.DestinationPort\":1234," +
-                "  \"netflow.event_data.DestAddress\":\"10.53.111.14\"," +
-                "  \"netflow.event_data.SourcePort\":4444" +
-                "}";
+        return "{"
+                + "  \"netflow.event_data.SourceAddress\":\"10.50.221.10\","
+                + "  \"netflow.event_data.DestinationPort\":1234,"
+                + "  \"netflow.event_data.DestAddress\":\"10.53.111.14\","
+                + "  \"netflow.event_data.SourcePort\":4444"
+                + "}";
     }
 
     public static String netFlowMappings() {
-        return "    \"properties\": {" +
-                "        \"netflow.event_data.SourceAddress\": {" +
-                "          \"type\": \"ip\"" +
-                "        }," +
-                "        \"netflow.event_data.DestinationPort\": {" +
-                "          \"type\": \"integer\"" +
-                "        }," +
-                "        \"netflow.event_data.DestAddress\": {" +
-                "          \"type\": \"ip\"" +
-                "        }," +
-                "        \"netflow.event_data.SourcePort\": {" +
-                "          \"type\": \"integer\"" +
-                "        }," +
-                "        \"netflow.event.stop\": {" +
-                "          \"type\": \"integer\"" +
-                "        }," +
-                "        \"dns.event.stop\": {" +
-                "          \"type\": \"integer\"" +
-                "        }," +
-                "        \"ipx.event.stop\": {" +
-                "          \"type\": \"integer\"" +
-                "        }," +
-                "        \"plain1\": {" +
-                "          \"type\": \"integer\"" +
-                "        }," +
-                "        \"user\":{" +
-                "          \"type\":\"nested\"," +
-                "            \"properties\":{" +
-                "              \"first\":{" +
-                "                \"type\":\"text\"," +
-                "                  \"fields\":{" +
-                "                    \"keyword\":{" +
-                "                      \"type\":\"keyword\"," +
-                "                      \"ignore_above\":256" +
-                "}" +
-                "}" +
-                "}," +
-                "              \"last\":{" +
-                "\"type\":\"text\"," +
-                "\"fields\":{" +
-                "                      \"keyword\":{" +
-                "                           \"type\":\"keyword\"," +
-                "                           \"ignore_above\":256" +
-                "}" +
-                "}" +
-                "}" +
-                "}" +
-                "}" +
-                "    }";
+        return "    \"properties\": {"
+                + "        \"netflow.event_data.SourceAddress\": {"
+                + "          \"type\": \"ip\""
+                + "        },"
+                + "        \"netflow.event_data.DestinationPort\": {"
+                + "          \"type\": \"integer\""
+                + "        },"
+                + "        \"netflow.event_data.DestAddress\": {"
+                + "          \"type\": \"ip\""
+                + "        },"
+                + "        \"netflow.event_data.SourcePort\": {"
+                + "          \"type\": \"integer\""
+                + "        },"
+                + "        \"netflow.event.stop\": {"
+                + "          \"type\": \"integer\""
+                + "        },"
+                + "        \"dns.event.stop\": {"
+                + "          \"type\": \"integer\""
+                + "        },"
+                + "        \"ipx.event.stop\": {"
+                + "          \"type\": \"integer\""
+                + "        },"
+                + "        \"plain1\": {"
+                + "          \"type\": \"integer\""
+                + "        },"
+                + "        \"user\":{"
+                + "          \"type\":\"nested\","
+                + "            \"properties\":{"
+                + "              \"first\":{"
+                + "                \"type\":\"text\","
+                + "                  \"fields\":{"
+                + "                    \"keyword\":{"
+                + "                      \"type\":\"keyword\","
+                + "                      \"ignore_above\":256"
+                + "}"
+                + "}"
+                + "},"
+                + "              \"last\":{"
+                + "\"type\":\"text\","
+                + "\"fields\":{"
+                + "                      \"keyword\":{"
+                + "                           \"type\":\"keyword\","
+                + "                           \"ignore_above\":256"
+                + "}"
+                + "}"
+                + "}"
+                + "}"
+                + "}"
+                + "    }";
     }
 
     public static String productIndexMapping() {
-        return "\"properties\":{\n" +
-                "   \"name\":{\n" +
-                "      \"type\":\"keyword\"\n" +
-                "   },\n" +
-                "   \"fieldA\":{\n" +
-                "      \"type\":\"long\"\n" +
-                "   },\n" +
-                "   \"mappedB\":{\n" +
-                "      \"type\":\"long\"\n" +
-                "   },\n" +
-                "   \"time\":{\n" +
-                "      \"type\":\"date\"\n" +
-                "   },\n" +
-                "   \"fieldC\":{\n" +
-                "      \"type\":\"keyword\"\n" +
-                "   }\n" +
-                "}\n" +
-                "}";
+        return "\"properties\":{\n"
+                + "   \"name\":{\n"
+                + "      \"type\":\"keyword\"\n"
+                + "   },\n"
+                + "   \"fieldA\":{\n"
+                + "      \"type\":\"long\"\n"
+                + "   },\n"
+                + "   \"mappedB\":{\n"
+                + "      \"type\":\"long\"\n"
+                + "   },\n"
+                + "   \"time\":{\n"
+                + "      \"type\":\"date\"\n"
+                + "   },\n"
+                + "   \"fieldC\":{\n"
+                + "      \"type\":\"keyword\"\n"
+                + "   }\n"
+                + "}\n"
+                + "}";
     }
 
     public static String productIndexAvgAggRule() {
-        return "            title: Test\n" +
-                "            id: 39f918f3-981b-4e6f-a975-8af7e507ef2b\n" +
-                "            status: test\n" +
-                "            level: critical\n" +
-                "            description: Detects QuarksPwDump clearing access history in hive\n" +
-                "            author: Florian Roth\n" +
-                "            date: 2017/05/15\n" +
-                "            logsource:\n" +
-                "                category: test_category\n" +
-                "                product: test_product\n" +
-                "            detection:\n" +
-                "                timeframe: 5m\n" +
-                "                sel:\n" +
-                "                    fieldA: 123\n" +
-                "                    fieldB: 111\n" +
-                "                    fieldC: valueC\n" +
-                "                condition: sel | avg(fieldA) by fieldC > 110";
+        return "            title: Test\n"
+                + "            id: 39f918f3-981b-4e6f-a975-8af7e507ef2b\n"
+                + "            status: test\n"
+                + "            level: critical\n"
+                + "            description: Detects QuarksPwDump clearing access history in hive\n"
+                + "            author: Florian Roth\n"
+                + "            date: 2017/05/15\n"
+                + "            logsource:\n"
+                + "                category: test_category\n"
+                + "                product: test_product\n"
+                + "            detection:\n"
+                + "                timeframe: 5m\n"
+                + "                sel:\n"
+                + "                    fieldA: 123\n"
+                + "                    fieldB: 111\n"
+                + "                    fieldC: valueC\n"
+                + "                condition: sel | avg(fieldA) by fieldC > 110";
     }
 
     public static String productIndexCountAggRule() {
-        return "            title: Test\n" +
-                "            id: 39f918f3-981b-4e6f-a975-8af7e507ef2b\n" +
-                "            status: test\n" +
-                "            level: critical\n" +
-                "            description: Detects QuarksPwDump clearing access history in hive\n" +
-                "            author: Florian Roth\n" +
-                "            date: 2017/05/15\n" +
-                "            logsource:\n" +
-                "                category: test_category\n" +
-                "                product: test_product\n" +
-                "            detection:\n" +
-                "                timeframe: 5m\n" +
-                "                sel:\n" +
-                "                    name: laptop\n" +
-                "                condition: sel | count(*) by name > 2";
+        return "            title: Test\n"
+                + "            id: 39f918f3-981b-4e6f-a975-8af7e507ef2b\n"
+                + "            status: test\n"
+                + "            level: critical\n"
+                + "            description: Detects QuarksPwDump clearing access history in hive\n"
+                + "            author: Florian Roth\n"
+                + "            date: 2017/05/15\n"
+                + "            logsource:\n"
+                + "                category: test_category\n"
+                + "                product: test_product\n"
+                + "            detection:\n"
+                + "                timeframe: 5m\n"
+                + "                sel:\n"
+                + "                    name: laptop\n"
+                + "                condition: sel | count(*) by name > 2";
     }
 
     public static String randomAggregationRule(String aggFunction, String signAndValue) {
-        String rule = "title: Remote Encrypting File System Abuse\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.defense_evasion\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "logsource:\n" +
-                "    product: rpc_firewall\n" +
-                "    category: application\n" +
-                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
-                "detection:\n" +
-                "    timeframe: 5m\n" +
-                "    sel:\n" +
-                "        Opcode: Info\n" +
-                "    condition: sel | %s(SeverityValue) by Version %s\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: high";
+        String rule =
+                "title: Remote Encrypting File System Abuse\n"
+                        + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                        + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                        + "references:\n"
+                        + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                        + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                        + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                        + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                        + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                        + "tags:\n"
+                        + "    - attack.defense_evasion\n"
+                        + "status: experimental\n"
+                        + "author: Sagie Dulce, Dekel Paz\n"
+                        + "date: 2022/01/01\n"
+                        + "modified: 2022/01/01\n"
+                        + "logsource:\n"
+                        + "    product: rpc_firewall\n"
+                        + "    category: application\n"
+                        + "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n"
+                        + "detection:\n"
+                        + "    timeframe: 5m\n"
+                        + "    sel:\n"
+                        + "        Opcode: Info\n"
+                        + "    condition: sel | %s(SeverityValue) by Version %s\n"
+                        + "falsepositives:\n"
+                        + "    - Legitimate usage of remote file encryption\n"
+                        + "level: high";
         return String.format(Locale.ROOT, rule, aggFunction, signAndValue);
     }
 
-    public static String randomAggregationRule(String aggFunction, String signAndValue, String opCode) {
-        String rule = "title: Remote Encrypting File System Abuse\n" +
-                "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n" +
-                "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n" +
-                "references:\n" +
-                "    - https://attack.mitre.org/tactics/TA0008/\n" +
-                "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n" +
-                "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n" +
-                "    - https://github.com/zeronetworks/rpcfirewall\n" +
-                "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n" +
-                "tags:\n" +
-                "    - attack.defense_evasion\n" +
-                "status: experimental\n" +
-                "author: Sagie Dulce, Dekel Paz\n" +
-                "date: 2022/01/01\n" +
-                "modified: 2022/01/01\n" +
-                "logsource:\n" +
-                "    product: rpc_firewall\n" +
-                "    category: application\n" +
-                "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n" +
-                "detection:\n" +
-                "    timeframe: 5m\n" +
-                "    sel:\n" +
-                "        Opcode: %s\n" +
-                "    condition: sel | %s(SeverityValue) by Version %s\n" +
-                "falsepositives:\n" +
-                "    - Legitimate usage of remote file encryption\n" +
-                "level: high";
+    public static String randomAggregationRule(
+            String aggFunction, String signAndValue, String opCode) {
+        String rule =
+                "title: Remote Encrypting File System Abuse\n"
+                        + "id: 5f92fff9-82e2-48eb-8fc1-8b133556a551\n"
+                        + "description: Detects remote RPC calls to possibly abuse remote encryption service via MS-EFSR\n"
+                        + "references:\n"
+                        + "    - https://attack.mitre.org/tactics/TA0008/\n"
+                        + "    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942\n"
+                        + "    - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/main/documents/MS-EFSR.md\n"
+                        + "    - https://github.com/zeronetworks/rpcfirewall\n"
+                        + "    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/\n"
+                        + "tags:\n"
+                        + "    - attack.defense_evasion\n"
+                        + "status: experimental\n"
+                        + "author: Sagie Dulce, Dekel Paz\n"
+                        + "date: 2022/01/01\n"
+                        + "modified: 2022/01/01\n"
+                        + "logsource:\n"
+                        + "    product: rpc_firewall\n"
+                        + "    category: application\n"
+                        + "    definition: 'Requirements: install and apply the RPC Firewall to all processes with \"audit:true action:block uuid:df1941c5-fe89-4e79-bf10-463657acf44d or c681d488-d850-11d0-8c52-00c04fd90f7e'\n"
+                        + "detection:\n"
+                        + "    timeframe: 5m\n"
+                        + "    sel:\n"
+                        + "        Opcode: %s\n"
+                        + "    condition: sel | %s(SeverityValue) by Version %s\n"
+                        + "falsepositives:\n"
+                        + "    - Legitimate usage of remote file encryption\n"
+                        + "level: high";
         return String.format(Locale.ROOT, rule, opCode, aggFunction, signAndValue);
     }
 
     public static String randomCloudtrailAggrRule() {
-        return "id: c64c5175-5189-431b-a55e-6d9882158250\n" +
-                "logsource:\n" +
-                "  product: cloudtrail\n" +
-                "title: Accounts created and deleted within 24h\n" +
-                "description: Flag suspicious activity of accounts created and deleted within 24h\n" +
-                "date: 2021/09/23\n" +
-                "tags:\n" +
-                "  - attack.exfiltration\n" +
-                "falsepositives: [ ]\n" +
-                "level: high\n" +
-                "status: test\n" +
-                "references: [ ]\n" +
-                "author: Sashank\n" +
-                "detection:\n" +
-                "  selection:\n" +
-                "    EventName:\n" +
-                "      - CREATED\n" +
-                "      - DELETED\n" +
-                "  timeframe: 24h\n" +
-                "  condition: selection | count(*) by AccountName >= 2";
+        return "id: c64c5175-5189-431b-a55e-6d9882158250\n"
+                + "logsource:\n"
+                + "  product: cloudtrail\n"
+                + "title: Accounts created and deleted within 24h\n"
+                + "description: Flag suspicious activity of accounts created and deleted within 24h\n"
+                + "date: 2021/09/23\n"
+                + "tags:\n"
+                + "  - attack.exfiltration\n"
+                + "falsepositives: [ ]\n"
+                + "level: high\n"
+                + "status: test\n"
+                + "references: [ ]\n"
+                + "author: Sashank\n"
+                + "detection:\n"
+                + "  selection:\n"
+                + "    EventName:\n"
+                + "      - CREATED\n"
+                + "      - DELETED\n"
+                + "  timeframe: 24h\n"
+                + "  condition: selection | count(*) by AccountName >= 2";
     }
 
     public static String randomCloudtrailAggrRuleWithDotFields() {
-        return "id: 25b9c01c-350d-4c96-bed1-836d04a4f324\n" +
-                "title: test\n" +
-                "description: Detects when an user creates or invokes a lambda function.\n" +
-                "status: experimental\n" +
-                "author: deysubho\n" +
-                "date: 2023/12/07\n" +
-                "modified: 2023/12/07\n" +
-                "logsource:\n" +
-                "  category: cloudtrail\n" +
-                "level: low\n" +
-                "detection:\n" +
-                "  condition: selection1 or selection2 | count(api.operation) by cloud.region > 1\n" +
-                "  selection1:\n" +
-                "    api.service.name:\n" +
-                "      - lambda.amazonaws.com\n" +
-                "    api.operation:\n" +
-                "      - CreateFunction\n" +
-                "  selection2:\n" +
-                "    api.service.name:\n" +
-                "      - lambda.amazonaws.com\n" +
-                "    api.operation:      \n" +
-                "      - Invoke\n" +
-                "  timeframe: 1m\n" +
-                "  tags:\n" +
-                "    - attack.privilege_escalation\n" +
-                "    - attack.t1078";
+        return "id: 25b9c01c-350d-4c96-bed1-836d04a4f324\n"
+                + "title: test\n"
+                + "description: Detects when an user creates or invokes a lambda function.\n"
+                + "status: experimental\n"
+                + "author: deysubho\n"
+                + "date: 2023/12/07\n"
+                + "modified: 2023/12/07\n"
+                + "logsource:\n"
+                + "  category: cloudtrail\n"
+                + "level: low\n"
+                + "detection:\n"
+                + "  condition: selection1 or selection2 | count(api.operation) by cloud.region > 1\n"
+                + "  selection1:\n"
+                + "    api.service.name:\n"
+                + "      - lambda.amazonaws.com\n"
+                + "    api.operation:\n"
+                + "      - CreateFunction\n"
+                + "  selection2:\n"
+                + "    api.service.name:\n"
+                + "      - lambda.amazonaws.com\n"
+                + "    api.operation:      \n"
+                + "      - Invoke\n"
+                + "  timeframe: 1m\n"
+                + "  tags:\n"
+                + "    - attack.privilege_escalation\n"
+                + "    - attack.t1078";
     }
 
     public static String randomCloudtrailAggrRuleWithEcsFields() {
-        return "id: 25b9c01c-350d-4c96-bed1-836d04a4f324\n" +
-                "title: test\n" +
-                "description: Detects when an user creates or invokes a lambda function.\n" +
-                "status: experimental\n" +
-                "author: deysubho\n" +
-                "date: 2023/12/07\n" +
-                "modified: 2023/12/07\n" +
-                "logsource:\n" +
-                "  category: cloudtrail\n" +
-                "level: low\n" +
-                "detection:\n" +
-                "  condition: selection1 or selection2 | count(eventName) by awsRegion > 1\n" +
-                "  selection1:\n" +
-                "    eventSource:\n" +
-                "      - lambda.amazonaws.com\n" +
-                "    eventName:\n" +
-                "      - CreateFunction\n" +
-                "  selection2:\n" +
-                "    eventSource:\n" +
-                "      - lambda.amazonaws.com\n" +
-                "    eventName:      \n" +
-                "      - Invoke\n" +
-                "  timeframe: 20m\n" +
-                "  tags:\n" +
-                "    - attack.privilege_escalation\n" +
-                "    - attack.t1078";
+        return "id: 25b9c01c-350d-4c96-bed1-836d04a4f324\n"
+                + "title: test\n"
+                + "description: Detects when an user creates or invokes a lambda function.\n"
+                + "status: experimental\n"
+                + "author: deysubho\n"
+                + "date: 2023/12/07\n"
+                + "modified: 2023/12/07\n"
+                + "logsource:\n"
+                + "  category: cloudtrail\n"
+                + "level: low\n"
+                + "detection:\n"
+                + "  condition: selection1 or selection2 | count(eventName) by awsRegion > 1\n"
+                + "  selection1:\n"
+                + "    eventSource:\n"
+                + "      - lambda.amazonaws.com\n"
+                + "    eventName:\n"
+                + "      - CreateFunction\n"
+                + "  selection2:\n"
+                + "    eventSource:\n"
+                + "      - lambda.amazonaws.com\n"
+                + "    eventName:      \n"
+                + "      - Invoke\n"
+                + "  timeframe: 20m\n"
+                + "  tags:\n"
+                + "    - attack.privilege_escalation\n"
+                + "    - attack.t1078";
     }
 
     public static String cloudtrailOcsfMappings() {
-        return "\"properties\": {\n" +
-                "      \"time\": {\n" +
-                "        \"type\": \"date\"\n" +
-                "      },\n" +
-                "      \"cloud.region\": {\n" +
-                "        \"type\": \"keyword\"\n" +
-                "      },\n" +
-                "      \"api\": {\n" +
-                "        \"properties\": {\n" +
-                "           \"operation\": {\"type\": \"keyword\"},\n" +
-                "            \"service\": {\n" +
-                "               \"properties\": {\n" +
-                "                   \"name\": {\"type\": \"text\"}\n" +
-                "               }\n" +
-                "            }\n" +
-                "        }\n" +
-                "      }\n" +
-                "    }\n" +
-                "        }";
+        return "\"properties\": {\n"
+                + "      \"time\": {\n"
+                + "        \"type\": \"date\"\n"
+                + "      },\n"
+                + "      \"cloud.region\": {\n"
+                + "        \"type\": \"keyword\"\n"
+                + "      },\n"
+                + "      \"api\": {\n"
+                + "        \"properties\": {\n"
+                + "           \"operation\": {\"type\": \"keyword\"},\n"
+                + "            \"service\": {\n"
+                + "               \"properties\": {\n"
+                + "                   \"name\": {\"type\": \"text\"}\n"
+                + "               }\n"
+                + "            }\n"
+                + "        }\n"
+                + "      }\n"
+                + "    }\n"
+                + "        }";
     }
 
     public static String windowsIndexMapping() {
-        return "\"properties\": {\n" +
-                "      \"@timestamp\": {\"type\":\"date\"},\n" +
-                "      \"AccessList\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"AccessMask\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Accesses\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"AccountName\": {\n" +
-                "        \"type\": \"keyword\"\n" +
-                "      },\n" +
-                "      \"EventName\": {\n" +
-                "        \"type\": \"keyword\"\n" +
-                "      },\n" +
-                "      \"AccountType\": {\n" +
-                "        \"type\": \"text\",\n" +
-                "        \"fields\": {\n" +
-                "          \"keyword\": {\n" +
-                "            \"type\": \"keyword\",\n" +
-                "            \"ignore_above\": 256\n" +
-                "          }\n" +
-                "        }\n" +
-                "      },\n" +
-                "      \"Action\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      },\n" +
-                "      \"Address\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"AllowedToDelegateTo\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Application\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ApplicationPath\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"AttributeLDAPDisplayName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"AttributeValue\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"AuditPolicyChanges\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"AuditSourceName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"AuthenticationPackageName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"CallTrace\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"CallerProcessName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Caption\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Category\": {\n" +
-                "        \"type\": \"text\",\n" +
-                "        \"fields\": {\n" +
-                "          \"keyword\": {\n" +
-                "            \"type\": \"keyword\",\n" +
-                "            \"ignore_above\": 256\n" +
-                "          }\n" +
-                "        }\n" +
-                "      },\n" +
-                "      \"CertThumbprint\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Channel\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ClassName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"CommandLine\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Company\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ComputerName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ContextInfo\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"CurrentDirectory\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Description\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"DestAddress\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"DestPort\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      },\n" +
-                "      \"Destination\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"DestinationHostname\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"DestinationIp\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"DestinationIsIpv6\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"DestinationPort\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      },\n" +
-                "      \"Details\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Device\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"DeviceDescription\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"DeviceName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Domain\": {\n" +
-                "        \"type\": \"text\",\n" +
-                "        \"fields\": {\n" +
-                "          \"keyword\": {\n" +
-                "            \"type\": \"keyword\",\n" +
-                "            \"ignore_above\": 256\n" +
-                "          }\n" +
-                "        }\n" +
-                "      },\n" +
-                "      \"EngineVersion\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ErrorCode\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"EventReceivedTime\": {\n" +
-                "        \"type\": \"date\"\n" +
-                "      },\n" +
-                "      \"EventTime\": {\n" +
-                "        \"type\": \"date\"\n" +
-                "      },\n" +
-                "      \"EventType\": {\n" +
-                "        \"type\": \"keyword\"\n" +
-                "      },\n" +
-                "      \"ExecutionProcessID\": {\n" +
-                "        \"type\": \"long\"\n" +
-                "      },\n" +
-                "      \"ExecutionThreadID\": {\n" +
-                "        \"type\": \"long\"\n" +
-                "      },\n" +
-                "      \"FailureCode\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"FileName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"FileVersion\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"GrantedAccess\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Hashes\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"HostApplication\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"HostName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"HostVersion\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Image\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ImageFileName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ImageLoaded\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ImagePath\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Imphash\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Initiated\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"IntegrityLevel\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"IpAddress\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"KeyLength\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Keywords\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"LayerRTID\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      },\n" +
-                "      \"Level\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"LocalName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"LogonId\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"LogonProcessName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"LogonType\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      },\n" +
-                "      \"Message\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ModifyingApplication\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"NewName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"NewTargetUserName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"NewTemplateContent\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"NewUacValue\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"NewValue\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ObjectClass\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ObjectName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ObjectServer\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ObjectType\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ObjectValueName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"OldTargetUserName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"OldUacValue\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Opcode\": {\n" +
-                "        \"type\": \"text\",\n" +
-                "        \"fields\": {\n" +
-                "          \"keyword\": {\n" +
-                "            \"type\": \"keyword\",\n" +
-                "            \"ignore_above\": 256\n" +
-                "          }\n" +
-                "        }\n" +
-                "      },\n" +
-                "      \"OpcodeValue\": {\n" +
-                "        \"type\": \"long\"\n" +
-                "      },\n" +
-                "      \"Origin\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"OriginalFileName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"OriginalFilename\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"OriginalName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ParentCommandLine\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ParentImage\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ParentUser\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"PasswordLastSet\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Path\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Payload\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"PipeName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"PossibleCause\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"PrivilegeList\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ProcessGuid\": {\n" +
-                "        \"type\": \"text\",\n" +
-                "        \"fields\": {\n" +
-                "          \"keyword\": {\n" +
-                "            \"type\": \"keyword\",\n" +
-                "            \"ignore_above\": 256\n" +
-                "          }\n" +
-                "        }\n" +
-                "      },\n" +
-                "      \"ProcessId\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      },\n" +
-                "      \"ProcessName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Product\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Properties\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Provider\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ProviderGuid\": {\n" +
-                "        \"type\": \"text\",\n" +
-                "        \"fields\": {\n" +
-                "          \"keyword\": {\n" +
-                "            \"type\": \"keyword\",\n" +
-                "            \"ignore_above\": 256\n" +
-                "          }\n" +
-                "        }\n" +
-                "      },\n" +
-                "      \"ProviderName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Provider_Name\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"QNAME\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Query\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"QueryName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"QueryResults\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"QueryStatus\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"RecordNumber\": {\n" +
-                "        \"type\": \"long\"\n" +
-                "      },\n" +
-                "      \"RelativeTargetName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"RemoteAddress\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"RemoteName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"SamAccountName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ScriptBlockText\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"SearchFilter\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ServerName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Service\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ServiceFileName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ServiceName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ServicePrincipalNames\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ServiceStartType\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ServiceType\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Severity\": {\n" +
-                "        \"type\": \"text\",\n" +
-                "        \"fields\": {\n" +
-                "          \"keyword\": {\n" +
-                "            \"type\": \"keyword\",\n" +
-                "            \"ignore_above\": 256\n" +
-                "          }\n" +
-                "        }\n" +
-                "      },\n" +
-                "      \"SeverityValue\": {\n" +
-                "        \"type\": \"long\"\n" +
-                "      },\n" +
-                "      \"ShareName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"SidHistory\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Signed\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"SourceAddress\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"SourceImage\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"SourceIp\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"SourceModuleName\": {\n" +
-                "        \"type\": \"text\",\n" +
-                "        \"fields\": {\n" +
-                "          \"keyword\": {\n" +
-                "            \"type\": \"keyword\",\n" +
-                "            \"ignore_above\": 256\n" +
-                "          }\n" +
-                "        }\n" +
-                "      },\n" +
-                "      \"SourceModuleType\": {\n" +
-                "        \"type\": \"text\",\n" +
-                "        \"fields\": {\n" +
-                "          \"keyword\": {\n" +
-                "            \"type\": \"keyword\",\n" +
-                "            \"ignore_above\": 256\n" +
-                "          }\n" +
-                "        }\n" +
-                "      },\n" +
-                "      \"SourceName\": {\n" +
-                "        \"type\": \"text\",\n" +
-                "        \"fields\": {\n" +
-                "          \"keyword\": {\n" +
-                "            \"type\": \"keyword\",\n" +
-                "            \"ignore_above\": 256\n" +
-                "          }\n" +
-                "        }\n" +
-                "      },\n" +
-                "      \"SourcePort\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      },\n" +
-                "      \"Source_Name\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"StartAddress\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"StartFunction\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"StartModule\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"State\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Status\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"SubjectDomainName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"SubjectLogonId\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"SubjectUserName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"SubjectUserSid\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"TargetFilename\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"TargetImage\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"TargetLogonId\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"TargetName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"TargetObject\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"TargetParentProcessId\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      },\n" +
-                "      \"TargetPort\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      },\n" +
-                "      \"TargetServerName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"TargetSid\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"TargetUserName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"TargetUserSid\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"TaskName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"TaskValue\": {\n" +
-                "        \"type\": \"long\"\n" +
-                "      },\n" +
-                "      \"TemplateContent\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"TicketEncryptionType\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"TicketOptions\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Type\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"User\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"UserID\": {\n" +
-                "        \"type\": \"text\",\n" +
-                "        \"fields\": {\n" +
-                "          \"keyword\": {\n" +
-                "            \"type\": \"keyword\",\n" +
-                "            \"ignore_above\": 256\n" +
-                "          }\n" +
-                "        }\n" +
-                "      },\n" +
-                "      \"UserName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"UtcTime\": {\n" +
-                "        \"type\": \"text\",\n" +
-                "        \"fields\": {\n" +
-                "          \"keyword\": {\n" +
-                "            \"type\": \"keyword\",\n" +
-                "            \"ignore_above\": 256\n" +
-                "          }\n" +
-                "        }\n" +
-                "      },\n" +
-                "      \"Value\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"Version\": {\n" +
-                "        \"type\": \"long\"\n" +
-                "      },\n" +
-                "      \"Workstation\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"WorkstationName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"EventID\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      },\n" +
-                "      \"param1\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"param2\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"processPath\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"sha1\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"src_ip\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"unmapped_HiveName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      }\n" +
-                "    }";
+        return "\"properties\": {\n"
+                + "      \"@timestamp\": {\"type\":\"date\"},\n"
+                + "      \"AccessList\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"AccessMask\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Accesses\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"AccountName\": {\n"
+                + "        \"type\": \"keyword\"\n"
+                + "      },\n"
+                + "      \"EventName\": {\n"
+                + "        \"type\": \"keyword\"\n"
+                + "      },\n"
+                + "      \"AccountType\": {\n"
+                + "        \"type\": \"text\",\n"
+                + "        \"fields\": {\n"
+                + "          \"keyword\": {\n"
+                + "            \"type\": \"keyword\",\n"
+                + "            \"ignore_above\": 256\n"
+                + "          }\n"
+                + "        }\n"
+                + "      },\n"
+                + "      \"Action\": {\n"
+                + "        \"type\": \"integer\"\n"
+                + "      },\n"
+                + "      \"Address\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"AllowedToDelegateTo\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Application\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ApplicationPath\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"AttributeLDAPDisplayName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"AttributeValue\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"AuditPolicyChanges\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"AuditSourceName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"AuthenticationPackageName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"CallTrace\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"CallerProcessName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Caption\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Category\": {\n"
+                + "        \"type\": \"text\",\n"
+                + "        \"fields\": {\n"
+                + "          \"keyword\": {\n"
+                + "            \"type\": \"keyword\",\n"
+                + "            \"ignore_above\": 256\n"
+                + "          }\n"
+                + "        }\n"
+                + "      },\n"
+                + "      \"CertThumbprint\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Channel\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ClassName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"CommandLine\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Company\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ComputerName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ContextInfo\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"CurrentDirectory\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Description\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"DestAddress\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"DestPort\": {\n"
+                + "        \"type\": \"integer\"\n"
+                + "      },\n"
+                + "      \"Destination\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"DestinationHostname\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"DestinationIp\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"DestinationIsIpv6\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"DestinationPort\": {\n"
+                + "        \"type\": \"integer\"\n"
+                + "      },\n"
+                + "      \"Details\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Device\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"DeviceDescription\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"DeviceName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Domain\": {\n"
+                + "        \"type\": \"text\",\n"
+                + "        \"fields\": {\n"
+                + "          \"keyword\": {\n"
+                + "            \"type\": \"keyword\",\n"
+                + "            \"ignore_above\": 256\n"
+                + "          }\n"
+                + "        }\n"
+                + "      },\n"
+                + "      \"EngineVersion\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ErrorCode\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"EventReceivedTime\": {\n"
+                + "        \"type\": \"date\"\n"
+                + "      },\n"
+                + "      \"EventTime\": {\n"
+                + "        \"type\": \"date\"\n"
+                + "      },\n"
+                + "      \"EventType\": {\n"
+                + "        \"type\": \"keyword\"\n"
+                + "      },\n"
+                + "      \"ExecutionProcessID\": {\n"
+                + "        \"type\": \"long\"\n"
+                + "      },\n"
+                + "      \"ExecutionThreadID\": {\n"
+                + "        \"type\": \"long\"\n"
+                + "      },\n"
+                + "      \"FailureCode\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"FileName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"FileVersion\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"GrantedAccess\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Hashes\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"HostApplication\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"HostName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"HostVersion\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Image\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ImageFileName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ImageLoaded\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ImagePath\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Imphash\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Initiated\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"IntegrityLevel\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"IpAddress\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"KeyLength\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Keywords\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"LayerRTID\": {\n"
+                + "        \"type\": \"integer\"\n"
+                + "      },\n"
+                + "      \"Level\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"LocalName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"LogonId\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"LogonProcessName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"LogonType\": {\n"
+                + "        \"type\": \"integer\"\n"
+                + "      },\n"
+                + "      \"Message\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ModifyingApplication\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"NewName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"NewTargetUserName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"NewTemplateContent\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"NewUacValue\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"NewValue\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ObjectClass\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ObjectName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ObjectServer\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ObjectType\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ObjectValueName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"OldTargetUserName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"OldUacValue\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Opcode\": {\n"
+                + "        \"type\": \"text\",\n"
+                + "        \"fields\": {\n"
+                + "          \"keyword\": {\n"
+                + "            \"type\": \"keyword\",\n"
+                + "            \"ignore_above\": 256\n"
+                + "          }\n"
+                + "        }\n"
+                + "      },\n"
+                + "      \"OpcodeValue\": {\n"
+                + "        \"type\": \"long\"\n"
+                + "      },\n"
+                + "      \"Origin\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"OriginalFileName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"OriginalFilename\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"OriginalName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ParentCommandLine\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ParentImage\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ParentUser\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"PasswordLastSet\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Path\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Payload\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"PipeName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"PossibleCause\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"PrivilegeList\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ProcessGuid\": {\n"
+                + "        \"type\": \"text\",\n"
+                + "        \"fields\": {\n"
+                + "          \"keyword\": {\n"
+                + "            \"type\": \"keyword\",\n"
+                + "            \"ignore_above\": 256\n"
+                + "          }\n"
+                + "        }\n"
+                + "      },\n"
+                + "      \"ProcessId\": {\n"
+                + "        \"type\": \"integer\"\n"
+                + "      },\n"
+                + "      \"ProcessName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Product\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Properties\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Provider\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ProviderGuid\": {\n"
+                + "        \"type\": \"text\",\n"
+                + "        \"fields\": {\n"
+                + "          \"keyword\": {\n"
+                + "            \"type\": \"keyword\",\n"
+                + "            \"ignore_above\": 256\n"
+                + "          }\n"
+                + "        }\n"
+                + "      },\n"
+                + "      \"ProviderName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Provider_Name\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"QNAME\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Query\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"QueryName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"QueryResults\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"QueryStatus\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"RecordNumber\": {\n"
+                + "        \"type\": \"long\"\n"
+                + "      },\n"
+                + "      \"RelativeTargetName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"RemoteAddress\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"RemoteName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"SamAccountName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ScriptBlockText\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"SearchFilter\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ServerName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Service\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ServiceFileName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ServiceName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ServicePrincipalNames\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ServiceStartType\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ServiceType\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Severity\": {\n"
+                + "        \"type\": \"text\",\n"
+                + "        \"fields\": {\n"
+                + "          \"keyword\": {\n"
+                + "            \"type\": \"keyword\",\n"
+                + "            \"ignore_above\": 256\n"
+                + "          }\n"
+                + "        }\n"
+                + "      },\n"
+                + "      \"SeverityValue\": {\n"
+                + "        \"type\": \"long\"\n"
+                + "      },\n"
+                + "      \"ShareName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"SidHistory\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Signed\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"SourceAddress\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"SourceImage\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"SourceIp\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"SourceModuleName\": {\n"
+                + "        \"type\": \"text\",\n"
+                + "        \"fields\": {\n"
+                + "          \"keyword\": {\n"
+                + "            \"type\": \"keyword\",\n"
+                + "            \"ignore_above\": 256\n"
+                + "          }\n"
+                + "        }\n"
+                + "      },\n"
+                + "      \"SourceModuleType\": {\n"
+                + "        \"type\": \"text\",\n"
+                + "        \"fields\": {\n"
+                + "          \"keyword\": {\n"
+                + "            \"type\": \"keyword\",\n"
+                + "            \"ignore_above\": 256\n"
+                + "          }\n"
+                + "        }\n"
+                + "      },\n"
+                + "      \"SourceName\": {\n"
+                + "        \"type\": \"text\",\n"
+                + "        \"fields\": {\n"
+                + "          \"keyword\": {\n"
+                + "            \"type\": \"keyword\",\n"
+                + "            \"ignore_above\": 256\n"
+                + "          }\n"
+                + "        }\n"
+                + "      },\n"
+                + "      \"SourcePort\": {\n"
+                + "        \"type\": \"integer\"\n"
+                + "      },\n"
+                + "      \"Source_Name\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"StartAddress\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"StartFunction\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"StartModule\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"State\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Status\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"SubjectDomainName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"SubjectLogonId\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"SubjectUserName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"SubjectUserSid\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"TargetFilename\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"TargetImage\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"TargetLogonId\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"TargetName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"TargetObject\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"TargetParentProcessId\": {\n"
+                + "        \"type\": \"integer\"\n"
+                + "      },\n"
+                + "      \"TargetPort\": {\n"
+                + "        \"type\": \"integer\"\n"
+                + "      },\n"
+                + "      \"TargetServerName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"TargetSid\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"TargetUserName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"TargetUserSid\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"TaskName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"TaskValue\": {\n"
+                + "        \"type\": \"long\"\n"
+                + "      },\n"
+                + "      \"TemplateContent\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"TicketEncryptionType\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"TicketOptions\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Type\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"User\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"UserID\": {\n"
+                + "        \"type\": \"text\",\n"
+                + "        \"fields\": {\n"
+                + "          \"keyword\": {\n"
+                + "            \"type\": \"keyword\",\n"
+                + "            \"ignore_above\": 256\n"
+                + "          }\n"
+                + "        }\n"
+                + "      },\n"
+                + "      \"UserName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"UtcTime\": {\n"
+                + "        \"type\": \"text\",\n"
+                + "        \"fields\": {\n"
+                + "          \"keyword\": {\n"
+                + "            \"type\": \"keyword\",\n"
+                + "            \"ignore_above\": 256\n"
+                + "          }\n"
+                + "        }\n"
+                + "      },\n"
+                + "      \"Value\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"Version\": {\n"
+                + "        \"type\": \"long\"\n"
+                + "      },\n"
+                + "      \"Workstation\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"WorkstationName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"EventID\": {\n"
+                + "        \"type\": \"integer\"\n"
+                + "      },\n"
+                + "      \"param1\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"param2\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"processPath\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"sha1\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"src_ip\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"unmapped_HiveName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      }\n"
+                + "    }";
     }
 
     public static String windowsIndexMappingOnlyNumericAndDate() {
-        return "\"properties\": {\n" +
-                "      \"@timestamp\": {\"type\":\"date\"},\n" +
-                "      \"EventTime\": {\n" +
-                "        \"type\": \"date\"\n" +
-                "      },\n" +
-                "      \"ExecutionProcessID\": {\n" +
-                "        \"type\": \"long\"\n" +
-                "      },\n" +
-                "      \"ExecutionThreadID\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      },\n" +
-                "      \"EventID\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      },\n" +
-                "      \"TaskValue\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      }\n" +
-                "    }";
+        return "\"properties\": {\n"
+                + "      \"@timestamp\": {\"type\":\"date\"},\n"
+                + "      \"EventTime\": {\n"
+                + "        \"type\": \"date\"\n"
+                + "      },\n"
+                + "      \"ExecutionProcessID\": {\n"
+                + "        \"type\": \"long\"\n"
+                + "      },\n"
+                + "      \"ExecutionThreadID\": {\n"
+                + "        \"type\": \"integer\"\n"
+                + "      },\n"
+                + "      \"EventID\": {\n"
+                + "        \"type\": \"integer\"\n"
+                + "      },\n"
+                + "      \"TaskValue\": {\n"
+                + "        \"type\": \"integer\"\n"
+                + "      }\n"
+                + "    }";
     }
 
     public static String windowsIndexMappingOnlyNumericAndText() {
-        return "\"properties\": {\n" +
-                "      \"TaskName\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"ExecutionProcessID\": {\n" +
-                "        \"type\": \"long\"\n" +
-                "      },\n" +
-                "      \"ExecutionThreadID\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      },\n" +
-                "      \"EventID\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      },\n" +
-                "      \"TaskValue\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      }\n" +
-                "    }";
+        return "\"properties\": {\n"
+                + "      \"TaskName\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"ExecutionProcessID\": {\n"
+                + "        \"type\": \"long\"\n"
+                + "      },\n"
+                + "      \"ExecutionThreadID\": {\n"
+                + "        \"type\": \"integer\"\n"
+                + "      },\n"
+                + "      \"EventID\": {\n"
+                + "        \"type\": \"integer\"\n"
+                + "      },\n"
+                + "      \"TaskValue\": {\n"
+                + "        \"type\": \"integer\"\n"
+                + "      }\n"
+                + "    }";
     }
 
     public static String oldThreatIntelJobMapping() {
-        return "  \"dynamic\": \"strict\",\n" +
-                "  \"_meta\": {\n" +
-                "    \"schema_version\": 1\n" +
-                "  },\n" +
-                "  \"properties\": {\n" +
-                "    \"schema_version\": {\n" +
-                "      \"type\": \"integer\"\n" +
-                "    },\n" +
-                "    \"enabled_time\": {\n" +
-                "      \"type\": \"long\"\n" +
-                "    },\n" +
-                "    \"indices\": {\n" +
-                "      \"type\": \"text\"\n" +
-                "    },\n" +
-                "    \"last_update_time\": {\n" +
-                "      \"type\": \"long\"\n" +
-                "    },\n" +
-                "    \"name\": {\n" +
-                "      \"type\": \"text\"\n" +
-                "    },\n" +
-                "    \"schedule\": {\n" +
-                "      \"properties\": {\n" +
-                "        \"interval\": {\n" +
-                "          \"properties\": {\n" +
-                "            \"period\": {\n" +
-                "              \"type\": \"long\"\n" +
-                "            },\n" +
-                "            \"start_time\": {\n" +
-                "              \"type\": \"long\"\n" +
-                "            },\n" +
-                "            \"unit\": {\n" +
-                "              \"type\": \"text\"\n" +
-                "            }\n" +
-                "          }\n" +
-                "        }\n" +
-                "      }\n" +
-                "    },\n" +
-                "    \"state\": {\n" +
-                "      \"type\": \"text\"\n" +
-                "    },\n" +
-                "    \"update_enabled\": {\n" +
-                "      \"type\": \"boolean\"\n" +
-                "    },\n" +
-                "    \"update_stats\": {\n" +
-                "      \"properties\": {\n" +
-                "        \"last_failed_at_in_epoch_millis\": {\n" +
-                "          \"type\": \"long\"\n" +
-                "        },\n" +
-                "        \"last_processing_time_in_millis\": {\n" +
-                "          \"type\": \"long\"\n" +
-                "        },\n" +
-                "        \"last_skipped_at_in_epoch_millis\": {\n" +
-                "          \"type\": \"long\"\n" +
-                "        },\n" +
-                "        \"last_succeeded_at_in_epoch_millis\": {\n" +
-                "          \"type\": \"long\"\n" +
-                "        }\n" +
-                "      }\n" +
-                "    }\n" +
-                "  }";
+        return "  \"dynamic\": \"strict\",\n"
+                + "  \"_meta\": {\n"
+                + "    \"schema_version\": 1\n"
+                + "  },\n"
+                + "  \"properties\": {\n"
+                + "    \"schema_version\": {\n"
+                + "      \"type\": \"integer\"\n"
+                + "    },\n"
+                + "    \"enabled_time\": {\n"
+                + "      \"type\": \"long\"\n"
+                + "    },\n"
+                + "    \"indices\": {\n"
+                + "      \"type\": \"text\"\n"
+                + "    },\n"
+                + "    \"last_update_time\": {\n"
+                + "      \"type\": \"long\"\n"
+                + "    },\n"
+                + "    \"name\": {\n"
+                + "      \"type\": \"text\"\n"
+                + "    },\n"
+                + "    \"schedule\": {\n"
+                + "      \"properties\": {\n"
+                + "        \"interval\": {\n"
+                + "          \"properties\": {\n"
+                + "            \"period\": {\n"
+                + "              \"type\": \"long\"\n"
+                + "            },\n"
+                + "            \"start_time\": {\n"
+                + "              \"type\": \"long\"\n"
+                + "            },\n"
+                + "            \"unit\": {\n"
+                + "              \"type\": \"text\"\n"
+                + "            }\n"
+                + "          }\n"
+                + "        }\n"
+                + "      }\n"
+                + "    },\n"
+                + "    \"state\": {\n"
+                + "      \"type\": \"text\"\n"
+                + "    },\n"
+                + "    \"update_enabled\": {\n"
+                + "      \"type\": \"boolean\"\n"
+                + "    },\n"
+                + "    \"update_stats\": {\n"
+                + "      \"properties\": {\n"
+                + "        \"last_failed_at_in_epoch_millis\": {\n"
+                + "          \"type\": \"long\"\n"
+                + "        },\n"
+                + "        \"last_processing_time_in_millis\": {\n"
+                + "          \"type\": \"long\"\n"
+                + "        },\n"
+                + "        \"last_skipped_at_in_epoch_millis\": {\n"
+                + "          \"type\": \"long\"\n"
+                + "        },\n"
+                + "        \"last_succeeded_at_in_epoch_millis\": {\n"
+                + "          \"type\": \"long\"\n"
+                + "        }\n"
+                + "      }\n"
+                + "    }\n"
+                + "  }";
     }
 
     public static String randomDoc(int severity, int version, String opCode) {
-        String doc = "{\n" +
-                "\"EventTime\":\"2020-02-04T14:59:39.343541+00:00\",\n" +
-                "\"HostName\":\"EC2AMAZ-EPO7HKA\",\n" +
-                "\"Keywords\":\"9223372036854775808\",\n" +
-                "\"SeverityValue\":%s,\n" +
-                "\"Severity\":\"INFO\",\n" +
-                "\"EventID\":22,\n" +
-                "\"SourceName\":\"Microsoft-Windows-Sysmon\",\n" +
-                "\"ProviderGuid\":\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\",\n" +
-                "\"Version\":%s,\n" +
-                "\"TaskValue\":22,\n" +
-                "\"OpcodeValue\":0,\n" +
-                "\"RecordNumber\":9532,\n" +
-                "\"ExecutionProcessID\":1996,\n" +
-                "\"ExecutionThreadID\":2616,\n" +
-                "\"Channel\":\"Microsoft-Windows-Sysmon/Operational\",\n" +
-                "\"Domain\":\"NT AUTHORITY\",\n" +
-                "\"AccountName\":\"SYSTEM\",\n" +
-                "\"UserID\":\"S-1-5-18\",\n" +
-                "\"AccountType\":\"User\",\n" +
-                "\"Message\":\"Dns query:\\r\\nRuleName: \\r\\nUtcTime: 2020-02-04 14:59:38.349\\r\\nProcessGuid: {b3c285a4-3cda-5dc0-0000-001077270b00}\\r\\nProcessId: 1904\\r\\nQueryName: EC2AMAZ-EPO7HKA\\r\\nQueryStatus: 0\\r\\nQueryResults: 172.31.46.38;\\r\\nImage: C:\\\\Program Files\\\\nxlog\\\\nxlog.exe\",\n" +
-                "\"Category\":\"Dns query (rule: DnsQuery)\",\n" +
-                "\"Opcode\":\"%s\",\n" +
-                "\"UtcTime\":\"2020-02-04 14:59:38.349\",\n" +
-                "\"ProcessGuid\":\"{b3c285a4-3cda-5dc0-0000-001077270b00}\",\n" +
-                "\"ProcessId\":\"1904\",\"QueryName\":\"EC2AMAZ-EPO7HKA\",\"QueryStatus\":\"0\",\n" +
-                "\"QueryResults\":\"172.31.46.38;\",\n" +
-                "\"Image\":\"C:\\\\Program Files\\\\nxlog\\\\regsvr32.exe\",\n" +
-                "\"EventReceivedTime\":\"2020-02-04T14:59:40.780905+00:00\",\n" +
-                "\"SourceModuleName\":\"in\",\n" +
-                "\"SourceModuleType\":\"im_msvistalog\",\n" +
-                "\"CommandLine\": \"eachtest\",\n" +
-                "\"Initiated\": \"true\"\n" +
-                "}";
+        String doc =
+                "{\n"
+                        + "\"EventTime\":\"2020-02-04T14:59:39.343541+00:00\",\n"
+                        + "\"HostName\":\"EC2AMAZ-EPO7HKA\",\n"
+                        + "\"Keywords\":\"9223372036854775808\",\n"
+                        + "\"SeverityValue\":%s,\n"
+                        + "\"Severity\":\"INFO\",\n"
+                        + "\"EventID\":22,\n"
+                        + "\"SourceName\":\"Microsoft-Windows-Sysmon\",\n"
+                        + "\"ProviderGuid\":\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\",\n"
+                        + "\"Version\":%s,\n"
+                        + "\"TaskValue\":22,\n"
+                        + "\"OpcodeValue\":0,\n"
+                        + "\"RecordNumber\":9532,\n"
+                        + "\"ExecutionProcessID\":1996,\n"
+                        + "\"ExecutionThreadID\":2616,\n"
+                        + "\"Channel\":\"Microsoft-Windows-Sysmon/Operational\",\n"
+                        + "\"Domain\":\"NT AUTHORITY\",\n"
+                        + "\"AccountName\":\"SYSTEM\",\n"
+                        + "\"UserID\":\"S-1-5-18\",\n"
+                        + "\"AccountType\":\"User\",\n"
+                        + "\"Message\":\"Dns query:\\r\\nRuleName: \\r\\nUtcTime: 2020-02-04 14:59:38.349\\r\\nProcessGuid: {b3c285a4-3cda-5dc0-0000-001077270b00}\\r\\nProcessId: 1904\\r\\nQueryName: EC2AMAZ-EPO7HKA\\r\\nQueryStatus: 0\\r\\nQueryResults: 172.31.46.38;\\r\\nImage: C:\\\\Program Files\\\\nxlog\\\\nxlog.exe\",\n"
+                        + "\"Category\":\"Dns query (rule: DnsQuery)\",\n"
+                        + "\"Opcode\":\"%s\",\n"
+                        + "\"UtcTime\":\"2020-02-04 14:59:38.349\",\n"
+                        + "\"ProcessGuid\":\"{b3c285a4-3cda-5dc0-0000-001077270b00}\",\n"
+                        + "\"ProcessId\":\"1904\",\"QueryName\":\"EC2AMAZ-EPO7HKA\",\"QueryStatus\":\"0\",\n"
+                        + "\"QueryResults\":\"172.31.46.38;\",\n"
+                        + "\"Image\":\"C:\\\\Program Files\\\\nxlog\\\\regsvr32.exe\",\n"
+                        + "\"EventReceivedTime\":\"2020-02-04T14:59:40.780905+00:00\",\n"
+                        + "\"SourceModuleName\":\"in\",\n"
+                        + "\"SourceModuleType\":\"im_msvistalog\",\n"
+                        + "\"CommandLine\": \"eachtest\",\n"
+                        + "\"Initiated\": \"true\"\n"
+                        + "}";
         return String.format(Locale.ROOT, doc, severity, version, opCode);
-
     }
 
     public static String randomDocForNotCondition(int severity, int version, String opCode) {
-        String doc = "{\n" +
-                "\"EventTime\":\"2020-02-04T14:59:39.343541+00:00\",\n" +
-                "\"HostName\":\"EC2AMAZ-EPO7HKA\",\n" +
-                "\"Keywords\":\"9223372036854775808\",\n" +
-                "\"SeverityValue\":%s,\n" +
-                "\"Severity\":\"INFO\",\n" +
-                "\"EventID\":22,\n" +
-                "\"SourceName\":\"Microsoft-Windows-Sysmon\",\n" +
-                "\"ProviderGuid\":\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\",\n" +
-                "\"Version\":%s,\n" +
-                "\"TaskValue\":22,\n" +
-                "\"OpcodeValue\":0,\n" +
-                "\"RecordNumber\":9532,\n" +
-                "\"ExecutionProcessID\":1996,\n" +
-                "\"ExecutionThreadID\":2616,\n" +
-                "\"Channel\":\"Microsoft-Windows-Sysmon/Operational\",\n" +
-                "\"Domain\":\"NT AUTHORITY\",\n" +
-                "\"UserID\":\"S-1-5-18\",\n" +
-                "\"AccountType\":\"User\",\n" +
-                "\"Message\":\"Dns query:\\r\\nRuleName: \\r\\nUtcTime: 2020-02-04 14:59:38.349\\r\\nProcessGuid: {b3c285a4-3cda-5dc0-0000-001077270b00}\\r\\nProcessId: 1904\\r\\nQueryName: EC2AMAZ-EPO7HKA\\r\\nQueryStatus: 0\\r\\nQueryResults: 172.31.46.38;\\r\\nImage: C:\\\\Program Files\\\\nxlog\\\\nxlog.exe\",\n" +
-                "\"Category\":\"Dns query (rule: DnsQuery)\",\n" +
-                "\"Opcode\":\"%s\",\n" +
-                "\"UtcTime\":\"2020-02-04 14:59:38.349\",\n" +
-                "\"ProcessGuid\":\"{b3c285a4-3cda-5dc0-0000-001077270b00}\",\n" +
-                "\"ProcessId\":\"1904\",\"QueryName\":\"EC2AMAZ-EPO7HKA\",\"QueryStatus\":\"0\",\n" +
-                "\"QueryResults\":\"172.31.46.38;\",\n" +
-                "\"Image\":\"C:\\\\Program Files\\\\nxlog\\\\regsvr32.exe\",\n" +
-                "\"EventReceivedTime\":\"2020-02-04T14:59:40.780905+00:00\",\n" +
-                "\"SourceModuleName\":\"in\",\n" +
-                "\"SourceModuleType\":\"im_msvistalog\",\n" +
-                "\"CommandLine\": \"eachtest\",\n" +
-                "\"Initiated\": \"true\"\n" +
-                "}";
+        String doc =
+                "{\n"
+                        + "\"EventTime\":\"2020-02-04T14:59:39.343541+00:00\",\n"
+                        + "\"HostName\":\"EC2AMAZ-EPO7HKA\",\n"
+                        + "\"Keywords\":\"9223372036854775808\",\n"
+                        + "\"SeverityValue\":%s,\n"
+                        + "\"Severity\":\"INFO\",\n"
+                        + "\"EventID\":22,\n"
+                        + "\"SourceName\":\"Microsoft-Windows-Sysmon\",\n"
+                        + "\"ProviderGuid\":\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\",\n"
+                        + "\"Version\":%s,\n"
+                        + "\"TaskValue\":22,\n"
+                        + "\"OpcodeValue\":0,\n"
+                        + "\"RecordNumber\":9532,\n"
+                        + "\"ExecutionProcessID\":1996,\n"
+                        + "\"ExecutionThreadID\":2616,\n"
+                        + "\"Channel\":\"Microsoft-Windows-Sysmon/Operational\",\n"
+                        + "\"Domain\":\"NT AUTHORITY\",\n"
+                        + "\"UserID\":\"S-1-5-18\",\n"
+                        + "\"AccountType\":\"User\",\n"
+                        + "\"Message\":\"Dns query:\\r\\nRuleName: \\r\\nUtcTime: 2020-02-04 14:59:38.349\\r\\nProcessGuid: {b3c285a4-3cda-5dc0-0000-001077270b00}\\r\\nProcessId: 1904\\r\\nQueryName: EC2AMAZ-EPO7HKA\\r\\nQueryStatus: 0\\r\\nQueryResults: 172.31.46.38;\\r\\nImage: C:\\\\Program Files\\\\nxlog\\\\nxlog.exe\",\n"
+                        + "\"Category\":\"Dns query (rule: DnsQuery)\",\n"
+                        + "\"Opcode\":\"%s\",\n"
+                        + "\"UtcTime\":\"2020-02-04 14:59:38.349\",\n"
+                        + "\"ProcessGuid\":\"{b3c285a4-3cda-5dc0-0000-001077270b00}\",\n"
+                        + "\"ProcessId\":\"1904\",\"QueryName\":\"EC2AMAZ-EPO7HKA\",\"QueryStatus\":\"0\",\n"
+                        + "\"QueryResults\":\"172.31.46.38;\",\n"
+                        + "\"Image\":\"C:\\\\Program Files\\\\nxlog\\\\regsvr32.exe\",\n"
+                        + "\"EventReceivedTime\":\"2020-02-04T14:59:40.780905+00:00\",\n"
+                        + "\"SourceModuleName\":\"in\",\n"
+                        + "\"SourceModuleType\":\"im_msvistalog\",\n"
+                        + "\"CommandLine\": \"eachtest\",\n"
+                        + "\"Initiated\": \"true\"\n"
+                        + "}";
         return String.format(Locale.ROOT, doc, severity, version, opCode);
-
     }
 
     public static String randomDocOnlyNumericAndDate(int severity, int version, String opCode) {
-        String doc = "{\n" +
-                "\"EventTime\":\"2020-02-04T14:59:39.343541+00:00\",\n" +
-                "\"ExecutionProcessID\":2001,\n" +
-                "\"ExecutionThreadID\":2616,\n" +
-                "\"EventID\": 1234,\n" +
-                "\"TaskValue\":22\n" +
-                "}";
+        String doc =
+                "{\n"
+                        + "\"EventTime\":\"2020-02-04T14:59:39.343541+00:00\",\n"
+                        + "\"ExecutionProcessID\":2001,\n"
+                        + "\"ExecutionThreadID\":2616,\n"
+                        + "\"EventID\": 1234,\n"
+                        + "\"TaskValue\":22\n"
+                        + "}";
         return String.format(Locale.ROOT, doc, severity, version, opCode);
     }
 
     public static String randomDocOnlyNumericAndText(int severity, int version, String opCode) {
-        String doc = "{\n" +
-                "\"TaskName\":\"SYSTEM\",\n" +
-                "\"ExecutionProcessID\":2001,\n" +
-                "\"ExecutionThreadID\":2616,\n" +
-                "\"EventID\": 1234,\n" +
-                "\"TaskValue\":22\n" +
-                "}";
+        String doc =
+                "{\n"
+                        + "\"TaskName\":\"SYSTEM\",\n"
+                        + "\"ExecutionProcessID\":2001,\n"
+                        + "\"ExecutionThreadID\":2616,\n"
+                        + "\"EventID\": 1234,\n"
+                        + "\"TaskValue\":22\n"
+                        + "}";
         return String.format(Locale.ROOT, doc, severity, version, opCode);
     }
 
-    //Add IPs in HostName field.
+    // Add IPs in HostName field.
     public static String randomDocWithIpIoc(int severity, int version, String ioc) {
-        String doc = "{\n" +
-                "\"EventTime\":\"2020-02-04T14:59:39.343541+00:00\",\n" +
-                "\"HostName\":\"%s\",\n" +
-                "\"Keywords\":\"9223372036854775808\",\n" +
-                "\"SeverityValue\":%s,\n" +
-                "\"Severity\":\"INFO\",\n" +
-                "\"EventID\":22,\n" +
-                "\"SourceName\":\"Microsoft-Windows-Sysmon\",\n" +
-                "\"ProviderGuid\":\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\",\n" +
-                "\"Version\":%s,\n" +
-                "\"TaskValue\":22,\n" +
-                "\"OpcodeValue\":0,\n" +
-                "\"RecordNumber\":9532,\n" +
-                "\"ExecutionProcessID\":1996,\n" +
-                "\"ExecutionThreadID\":2616,\n" +
-                "\"Channel\":\"Microsoft-Windows-Sysmon/Operational\",\n" +
-                "\"Domain\":\"NT AUTHORITY\",\n" +
-                "\"AccountName\":\"SYSTEM\",\n" +
-                "\"UserID\":\"S-1-5-18\",\n" +
-                "\"AccountType\":\"User\",\n" +
-                "\"Message\":\"Dns query:\\r\\nRuleName: \\r\\nUtcTime: 2020-02-04 14:59:38.349\\r\\nProcessGuid: {b3c285a4-3cda-5dc0-0000-001077270b00}\\r\\nProcessId: 1904\\r\\nQueryName: EC2AMAZ-EPO7HKA\\r\\nQueryStatus: 0\\r\\nQueryResults: 172.31.46.38;\\r\\nImage: C:\\\\Program Files\\\\nxlog\\\\nxlog.exe\",\n" +
-                "\"Category\":\"Dns query (rule: DnsQuery)\",\n" +
-                "\"Opcode\":\"blahblah\",\n" +
-                "\"UtcTime\":\"2020-02-04 14:59:38.349\",\n" +
-                "\"ProcessGuid\":\"{b3c285a4-3cda-5dc0-0000-001077270b00}\",\n" +
-                "\"ProcessId\":\"1904\",\"QueryName\":\"EC2AMAZ-EPO7HKA\",\"QueryStatus\":\"0\",\n" +
-                "\"QueryResults\":\"172.31.46.38;\",\n" +
-                "\"Image\":\"C:\\\\Program Files\\\\nxlog\\\\regsvr32.exe\",\n" +
-                "\"EventReceivedTime\":\"2020-02-04T14:59:40.780905+00:00\",\n" +
-                "\"SourceModuleName\":\"in\",\n" +
-                "\"SourceModuleType\":\"im_msvistalog\",\n" +
-                "\"CommandLine\": \"eachtest\",\n" +
-                "\"Initiated\": \"true\"\n" +
-                "}";
+        String doc =
+                "{\n"
+                        + "\"EventTime\":\"2020-02-04T14:59:39.343541+00:00\",\n"
+                        + "\"HostName\":\"%s\",\n"
+                        + "\"Keywords\":\"9223372036854775808\",\n"
+                        + "\"SeverityValue\":%s,\n"
+                        + "\"Severity\":\"INFO\",\n"
+                        + "\"EventID\":22,\n"
+                        + "\"SourceName\":\"Microsoft-Windows-Sysmon\",\n"
+                        + "\"ProviderGuid\":\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\",\n"
+                        + "\"Version\":%s,\n"
+                        + "\"TaskValue\":22,\n"
+                        + "\"OpcodeValue\":0,\n"
+                        + "\"RecordNumber\":9532,\n"
+                        + "\"ExecutionProcessID\":1996,\n"
+                        + "\"ExecutionThreadID\":2616,\n"
+                        + "\"Channel\":\"Microsoft-Windows-Sysmon/Operational\",\n"
+                        + "\"Domain\":\"NT AUTHORITY\",\n"
+                        + "\"AccountName\":\"SYSTEM\",\n"
+                        + "\"UserID\":\"S-1-5-18\",\n"
+                        + "\"AccountType\":\"User\",\n"
+                        + "\"Message\":\"Dns query:\\r\\nRuleName: \\r\\nUtcTime: 2020-02-04 14:59:38.349\\r\\nProcessGuid: {b3c285a4-3cda-5dc0-0000-001077270b00}\\r\\nProcessId: 1904\\r\\nQueryName: EC2AMAZ-EPO7HKA\\r\\nQueryStatus: 0\\r\\nQueryResults: 172.31.46.38;\\r\\nImage: C:\\\\Program Files\\\\nxlog\\\\nxlog.exe\",\n"
+                        + "\"Category\":\"Dns query (rule: DnsQuery)\",\n"
+                        + "\"Opcode\":\"blahblah\",\n"
+                        + "\"UtcTime\":\"2020-02-04 14:59:38.349\",\n"
+                        + "\"ProcessGuid\":\"{b3c285a4-3cda-5dc0-0000-001077270b00}\",\n"
+                        + "\"ProcessId\":\"1904\",\"QueryName\":\"EC2AMAZ-EPO7HKA\",\"QueryStatus\":\"0\",\n"
+                        + "\"QueryResults\":\"172.31.46.38;\",\n"
+                        + "\"Image\":\"C:\\\\Program Files\\\\nxlog\\\\regsvr32.exe\",\n"
+                        + "\"EventReceivedTime\":\"2020-02-04T14:59:40.780905+00:00\",\n"
+                        + "\"SourceModuleName\":\"in\",\n"
+                        + "\"SourceModuleType\":\"im_msvistalog\",\n"
+                        + "\"CommandLine\": \"eachtest\",\n"
+                        + "\"Initiated\": \"true\"\n"
+                        + "}";
         return String.format(Locale.ROOT, doc, ioc, severity, version);
-
     }
 
     public static String randomDocWithNullField() {
-        return "{\n" +
-                "\"@timestamp\":\"2020-02-04T14:59:39.343541+00:00\",\n" +
-                "\"EventTime\":\"2020-02-04T14:59:39.343541+00:00\",\n" +
-                "\"HostName\":\"EC2AMAZ-EPO7HKA\",\n" +
-                "\"Keywords\":\"9223372036854775808\",\n" +
-                "\"SeverityValue\":2,\n" +
-                "\"Severity\":\"INFO\",\n" +
-                "\"EventID\":22,\n" +
-                "\"SourceName\":\"Microsoft-Windows-Sysmon\",\n" +
-                "\"ProviderGuid\":\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\",\n" +
-                "\"Version\":5,\n" +
-                "\"TaskValue\":22,\n" +
-                "\"OpcodeValue\":0,\n" +
-                "\"RecordNumber\":null,\n" +
-                "\"ExecutionProcessID\":1996,\n" +
-                "\"ExecutionThreadID\":2616,\n" +
-                "\"Channel\":\"Microsoft-Windows-Sysmon/Operational\",\n" +
-                "\"Domain\":\"NTAUTHORITY\",\n" +
-                "\"AccountName\":\"SYSTEM\",\n" +
-                "\"UserID\":\"S-1-5-18\",\n" +
-                "\"AccountType\":\"User\",\n" +
-                "\"Message\":\"Dns query:\\r\\nRuleName: \\r\\nUtcTime: 2020-02-04 14:59:38.349\\r\\nProcessGuid: {b3c285a4-3cda-5dc0-0000-001077270b00}\\r\\nProcessId: 1904\\r\\nQueryName: EC2AMAZ-EPO7HKA\\r\\nQueryStatus: 0\\r\\nQueryResults: 172.31.46.38;\\r\\nImage: C:\\\\Program Files\\\\nxlog\\\\nxlog.exe\",\n" +
-                "\"Category\":\"Dns query (rule: DnsQuery)\",\n" +
-                "\"Opcode\":\"Info\",\n" +
-                "\"UtcTime\":\"2020-02-04 14:59:38.349\",\n" +
-                "\"ProcessGuid\":\"{b3c285a4-3cda-5dc0-0000-001077270b00}\",\n" +
-                "\"ProcessId\":\"1904\",\"QueryName\":\"EC2AMAZ-EPO7HKA\",\"QueryStatus\":\"0\",\n" +
-                "\"QueryResults\":\"172.31.46.38;\",\n" +
-                "\"Image\":\"C:\\\\Program Files\\\\nxlog\\\\regsvr32.exe\",\n" +
-                "\"EventReceivedTime\":\"2020-02-04T14:59:40.780905+00:00\",\n" +
-                "\"SourceModuleName\":\"in\",\n" +
-                "\"SourceModuleType\":\"im_msvistalog\",\n" +
-                "\"CommandLine\": \"eachtest\",\n" +
-                "\"Initiated\": \"true\"\n" +
-                "}";
+        return "{\n"
+                + "\"@timestamp\":\"2020-02-04T14:59:39.343541+00:00\",\n"
+                + "\"EventTime\":\"2020-02-04T14:59:39.343541+00:00\",\n"
+                + "\"HostName\":\"EC2AMAZ-EPO7HKA\",\n"
+                + "\"Keywords\":\"9223372036854775808\",\n"
+                + "\"SeverityValue\":2,\n"
+                + "\"Severity\":\"INFO\",\n"
+                + "\"EventID\":22,\n"
+                + "\"SourceName\":\"Microsoft-Windows-Sysmon\",\n"
+                + "\"ProviderGuid\":\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\",\n"
+                + "\"Version\":5,\n"
+                + "\"TaskValue\":22,\n"
+                + "\"OpcodeValue\":0,\n"
+                + "\"RecordNumber\":null,\n"
+                + "\"ExecutionProcessID\":1996,\n"
+                + "\"ExecutionThreadID\":2616,\n"
+                + "\"Channel\":\"Microsoft-Windows-Sysmon/Operational\",\n"
+                + "\"Domain\":\"NTAUTHORITY\",\n"
+                + "\"AccountName\":\"SYSTEM\",\n"
+                + "\"UserID\":\"S-1-5-18\",\n"
+                + "\"AccountType\":\"User\",\n"
+                + "\"Message\":\"Dns query:\\r\\nRuleName: \\r\\nUtcTime: 2020-02-04 14:59:38.349\\r\\nProcessGuid: {b3c285a4-3cda-5dc0-0000-001077270b00}\\r\\nProcessId: 1904\\r\\nQueryName: EC2AMAZ-EPO7HKA\\r\\nQueryStatus: 0\\r\\nQueryResults: 172.31.46.38;\\r\\nImage: C:\\\\Program Files\\\\nxlog\\\\nxlog.exe\",\n"
+                + "\"Category\":\"Dns query (rule: DnsQuery)\",\n"
+                + "\"Opcode\":\"Info\",\n"
+                + "\"UtcTime\":\"2020-02-04 14:59:38.349\",\n"
+                + "\"ProcessGuid\":\"{b3c285a4-3cda-5dc0-0000-001077270b00}\",\n"
+                + "\"ProcessId\":\"1904\",\"QueryName\":\"EC2AMAZ-EPO7HKA\",\"QueryStatus\":\"0\",\n"
+                + "\"QueryResults\":\"172.31.46.38;\",\n"
+                + "\"Image\":\"C:\\\\Program Files\\\\nxlog\\\\regsvr32.exe\",\n"
+                + "\"EventReceivedTime\":\"2020-02-04T14:59:40.780905+00:00\",\n"
+                + "\"SourceModuleName\":\"in\",\n"
+                + "\"SourceModuleType\":\"im_msvistalog\",\n"
+                + "\"CommandLine\": \"eachtest\",\n"
+                + "\"Initiated\": \"true\"\n"
+                + "}";
     }
 
     public static String randomDoc() {
-        return "{\n" +
-                "\"@timestamp\":\"2020-02-04T14:59:39.343541+00:00\",\n" +
-                "\"EventTime\":\"2020-02-04T14:59:39.343541+00:00\",\n" +
-                "\"HostName\":\"EC2AMAZ-EPO7HKA\",\n" +
-                "\"Keywords\":\"9223372036854775808\",\n" +
-                "\"SeverityValue\":2,\n" +
-                "\"Severity\":\"INFO\",\n" +
-                "\"EventID\":22,\n" +
-                "\"SourceName\":\"Microsoft-Windows-Sysmon\",\n" +
-                "\"SourceIp\":\"1.2.3.4\",\n" +
-                "\"ProviderGuid\":\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\",\n" +
-                "\"Version\":5,\n" +
-                "\"TaskValue\":22,\n" +
-                "\"OpcodeValue\":0,\n" +
-                "\"RecordNumber\":9532,\n" +
-                "\"ExecutionProcessID\":1996,\n" +
-                "\"ExecutionThreadID\":2616,\n" +
-                "\"Channel\":\"Microsoft-Windows-Sysmon/Operational\",\n" +
-                "\"Domain\":\"NTAUTHORITY\",\n" +
-                "\"AccountName\":\"SYSTEM\",\n" +
-                "\"UserID\":\"S-1-5-18\",\n" +
-                "\"AccountType\":\"User\",\n" +
-                "\"Message\":\"Dns query:\\r\\nRuleName: \\r\\nUtcTime: 2020-02-04 14:59:38.349\\r\\nProcessGuid: {b3c285a4-3cda-5dc0-0000-001077270b00}\\r\\nProcessId: 1904\\r\\nQueryName: EC2AMAZ-EPO7HKA\\r\\nQueryStatus: 0\\r\\nQueryResults: 172.31.46.38;\\r\\nImage: C:\\\\Program Files\\\\nxlog\\\\nxlog.exe\",\n" +
-                "\"Category\":\"Dns query (rule: DnsQuery)\",\n" +
-                "\"Opcode\":\"Info\",\n" +
-                "\"UtcTime\":\"2020-02-04 14:59:38.349\",\n" +
-                "\"ProcessGuid\":\"{b3c285a4-3cda-5dc0-0000-001077270b00}\",\n" +
-                "\"ProcessId\":\"1904\",\"QueryName\":\"EC2AMAZ-EPO7HKA\",\"QueryStatus\":\"0\",\n" +
-                "\"QueryResults\":\"172.31.46.38;\",\n" +
-                "\"Image\":\"C:\\\\Program Files\\\\nxlog\\\\regsvr32.exe\",\n" +
-                "\"EventReceivedTime\":\"2020-02-04T14:59:40.780905+00:00\",\n" +
-                "\"SourceModuleName\":\"in\",\n" +
-                "\"SourceModuleType\":\"im_msvistalog\",\n" +
-                "\"CommandLine\": \"eachtest\",\n" +
-                "\"Initiated\": \"true\"\n" +
-                "}";
+        return "{\n"
+                + "\"@timestamp\":\"2020-02-04T14:59:39.343541+00:00\",\n"
+                + "\"EventTime\":\"2020-02-04T14:59:39.343541+00:00\",\n"
+                + "\"HostName\":\"EC2AMAZ-EPO7HKA\",\n"
+                + "\"Keywords\":\"9223372036854775808\",\n"
+                + "\"SeverityValue\":2,\n"
+                + "\"Severity\":\"INFO\",\n"
+                + "\"EventID\":22,\n"
+                + "\"SourceName\":\"Microsoft-Windows-Sysmon\",\n"
+                + "\"SourceIp\":\"1.2.3.4\",\n"
+                + "\"ProviderGuid\":\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\",\n"
+                + "\"Version\":5,\n"
+                + "\"TaskValue\":22,\n"
+                + "\"OpcodeValue\":0,\n"
+                + "\"RecordNumber\":9532,\n"
+                + "\"ExecutionProcessID\":1996,\n"
+                + "\"ExecutionThreadID\":2616,\n"
+                + "\"Channel\":\"Microsoft-Windows-Sysmon/Operational\",\n"
+                + "\"Domain\":\"NTAUTHORITY\",\n"
+                + "\"AccountName\":\"SYSTEM\",\n"
+                + "\"UserID\":\"S-1-5-18\",\n"
+                + "\"AccountType\":\"User\",\n"
+                + "\"Message\":\"Dns query:\\r\\nRuleName: \\r\\nUtcTime: 2020-02-04 14:59:38.349\\r\\nProcessGuid: {b3c285a4-3cda-5dc0-0000-001077270b00}\\r\\nProcessId: 1904\\r\\nQueryName: EC2AMAZ-EPO7HKA\\r\\nQueryStatus: 0\\r\\nQueryResults: 172.31.46.38;\\r\\nImage: C:\\\\Program Files\\\\nxlog\\\\nxlog.exe\",\n"
+                + "\"Category\":\"Dns query (rule: DnsQuery)\",\n"
+                + "\"Opcode\":\"Info\",\n"
+                + "\"UtcTime\":\"2020-02-04 14:59:38.349\",\n"
+                + "\"ProcessGuid\":\"{b3c285a4-3cda-5dc0-0000-001077270b00}\",\n"
+                + "\"ProcessId\":\"1904\",\"QueryName\":\"EC2AMAZ-EPO7HKA\",\"QueryStatus\":\"0\",\n"
+                + "\"QueryResults\":\"172.31.46.38;\",\n"
+                + "\"Image\":\"C:\\\\Program Files\\\\nxlog\\\\regsvr32.exe\",\n"
+                + "\"EventReceivedTime\":\"2020-02-04T14:59:40.780905+00:00\",\n"
+                + "\"SourceModuleName\":\"in\",\n"
+                + "\"SourceModuleType\":\"im_msvistalog\",\n"
+                + "\"CommandLine\": \"eachtest\",\n"
+                + "\"Initiated\": \"true\"\n"
+                + "}";
     }
 
     public static String randomNetworkDoc() {
-        return "{\n" +
-                "\"@timestamp\":\"2020-02-04T14:59:39.343541+00:00\",\n" +
-                "\"EventTime\":\"2020-02-04T14:59:39.343541+00:00\",\n" +
-                "\"HostName\":\"EC2AMAZ-EPO7HKA\",\n" +
-                "\"Keywords\":\"9223372036854775808\",\n" +
-                "\"SeverityValue\":2,\n" +
-                "\"Severity\":\"INFO\",\n" +
-                "\"EventID\":22,\n" +
-                "\"SourceName\":\"Microsoft-Windows-Sysmon\",\n" +
-                "\"SourceIp\":\"1.2.3.4\",\n" +
-                "\"ProviderGuid\":\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\",\n" +
-                "\"Version\":5,\n" +
-                "\"TaskValue\":22,\n" +
-                "\"OpcodeValue\":0,\n" +
-                "\"RecordNumber\":9532,\n" +
-                "\"ExecutionProcessID\":1996,\n" +
-                "\"ExecutionThreadID\":2616,\n" +
-                "\"Channel\":\"Microsoft-Windows-Sysmon/Operational\",\n" +
-                "\"Domain\":\"NTAUTHORITY\",\n" +
-                "\"AccountName\":\"SYSTEM\",\n" +
-                "\"UserID\":\"S-1-5-18\",\n" +
-                "\"AccountType\":\"User\",\n" +
-                "\"Message\":\"Dns query:\\r\\nRuleName: \\r\\nUtcTime: 2020-02-04 14:59:38.349\\r\\nProcessGuid: {b3c285a4-3cda-5dc0-0000-001077270b00}\\r\\nProcessId: 1904\\r\\nQueryName: EC2AMAZ-EPO7HKA\\r\\nQueryStatus: 0\\r\\nQueryResults: 172.31.46.38;\\r\\nImage: C:\\\\Program Files\\\\nxlog\\\\nxlog.exe\",\n" +
-                "\"Category\":\"Dns query (rule: DnsQuery)\",\n" +
-                "\"Opcode\":\"Info\",\n" +
-                "\"UtcTime\":\"2020-02-04 14:59:38.349\",\n" +
-                "\"ProcessGuid\":\"{b3c285a4-3cda-5dc0-0000-001077270b00}\",\n" +
-                "\"ProcessId\":\"1904\",\"QueryName\":\"EC2AMAZ-EPO7HKA\",\"QueryStatus\":\"0\",\n" +
-                "\"QueryResults\":\"172.31.46.38;\",\n" +
-                "\"Image\":\"C:\\\\Program Files\\\\nxlog\\\\regsvr32.exe\",\n" +
-                "\"EventReceivedTime\":\"2020-02-04T14:59:40.780905+00:00\",\n" +
-                "\"SourceModuleName\":\"in\",\n" +
-                "\"SourceModuleType\":\"im_msvistalog\",\n" +
-                "\"CommandLine\": \"eachtest\",\n" +
-                "\"id.orig_h\": \"123.12.123.12\",\n" +
-                "\"Initiated\": \"true\"\n" +
-                "}";
+        return "{\n"
+                + "\"@timestamp\":\"2020-02-04T14:59:39.343541+00:00\",\n"
+                + "\"EventTime\":\"2020-02-04T14:59:39.343541+00:00\",\n"
+                + "\"HostName\":\"EC2AMAZ-EPO7HKA\",\n"
+                + "\"Keywords\":\"9223372036854775808\",\n"
+                + "\"SeverityValue\":2,\n"
+                + "\"Severity\":\"INFO\",\n"
+                + "\"EventID\":22,\n"
+                + "\"SourceName\":\"Microsoft-Windows-Sysmon\",\n"
+                + "\"SourceIp\":\"1.2.3.4\",\n"
+                + "\"ProviderGuid\":\"{5770385F-C22A-43E0-BF4C-06F5698FFBD9}\",\n"
+                + "\"Version\":5,\n"
+                + "\"TaskValue\":22,\n"
+                + "\"OpcodeValue\":0,\n"
+                + "\"RecordNumber\":9532,\n"
+                + "\"ExecutionProcessID\":1996,\n"
+                + "\"ExecutionThreadID\":2616,\n"
+                + "\"Channel\":\"Microsoft-Windows-Sysmon/Operational\",\n"
+                + "\"Domain\":\"NTAUTHORITY\",\n"
+                + "\"AccountName\":\"SYSTEM\",\n"
+                + "\"UserID\":\"S-1-5-18\",\n"
+                + "\"AccountType\":\"User\",\n"
+                + "\"Message\":\"Dns query:\\r\\nRuleName: \\r\\nUtcTime: 2020-02-04 14:59:38.349\\r\\nProcessGuid: {b3c285a4-3cda-5dc0-0000-001077270b00}\\r\\nProcessId: 1904\\r\\nQueryName: EC2AMAZ-EPO7HKA\\r\\nQueryStatus: 0\\r\\nQueryResults: 172.31.46.38;\\r\\nImage: C:\\\\Program Files\\\\nxlog\\\\nxlog.exe\",\n"
+                + "\"Category\":\"Dns query (rule: DnsQuery)\",\n"
+                + "\"Opcode\":\"Info\",\n"
+                + "\"UtcTime\":\"2020-02-04 14:59:38.349\",\n"
+                + "\"ProcessGuid\":\"{b3c285a4-3cda-5dc0-0000-001077270b00}\",\n"
+                + "\"ProcessId\":\"1904\",\"QueryName\":\"EC2AMAZ-EPO7HKA\",\"QueryStatus\":\"0\",\n"
+                + "\"QueryResults\":\"172.31.46.38;\",\n"
+                + "\"Image\":\"C:\\\\Program Files\\\\nxlog\\\\regsvr32.exe\",\n"
+                + "\"EventReceivedTime\":\"2020-02-04T14:59:40.780905+00:00\",\n"
+                + "\"SourceModuleName\":\"in\",\n"
+                + "\"SourceModuleType\":\"im_msvistalog\",\n"
+                + "\"CommandLine\": \"eachtest\",\n"
+                + "\"id.orig_h\": \"123.12.123.12\",\n"
+                + "\"Initiated\": \"true\"\n"
+                + "}";
     }
 
     public static String randomCloudtrailAggrDoc(String eventType, String accountId) {
-        return "{\n" +
-                "  \"AccountName\": \"" + accountId + "\",\n" +
-                "  \"EventType\": \"" + eventType + "\"\n" +
-                "}";
+        return "{\n"
+                + "  \"AccountName\": \""
+                + accountId
+                + "\",\n"
+                + "  \"EventType\": \""
+                + eventType
+                + "\"\n"
+                + "}";
     }
 
     public static String randomVpcFlowDoc() {
-        return "{\n" +
-                "  \"version\": 1,\n" +
-                "  \"account-id\": \"A12345\",\n" +
-                "  \"interface-id\": \"I12345\",\n" +
-                "  \"srcaddr\": \"1.2.3.4\",\n" +
-                "  \"dstaddr\": \"4.5.6.7\",\n" +
-                "  \"srcport\": 9000,\n" +
-                "  \"dstport\": 8000,\n" +
-                "  \"severity_id\": \"-1\",\n" +
-                "  \"id.orig_h\": \"1.2.3.4\",\n" +
-                "  \"class_name\": \"Network Activity\"\n" +
-                "}";
+        return "{\n"
+                + "  \"version\": 1,\n"
+                + "  \"account-id\": \"A12345\",\n"
+                + "  \"interface-id\": \"I12345\",\n"
+                + "  \"srcaddr\": \"1.2.3.4\",\n"
+                + "  \"dstaddr\": \"4.5.6.7\",\n"
+                + "  \"srcport\": 9000,\n"
+                + "  \"dstport\": 8000,\n"
+                + "  \"severity_id\": \"-1\",\n"
+                + "  \"id.orig_h\": \"1.2.3.4\",\n"
+                + "  \"class_name\": \"Network Activity\"\n"
+                + "}";
     }
 
     public static String randomAdLdapDoc() {
-        return "{\n" +
-                "  \"azure.platformlogs.result_type\": 50126,\n" +
-                "  \"azure.signinlogs.result_description\": \"Invalid username or password or Invalid on-premises username or password.\",\n" +
-                "  \"azure.signinlogs.props.user_id\": \"DEYSUBHO\"\n" +
-                "}";
+        return "{\n"
+                + "  \"azure.platformlogs.result_type\": 50126,\n"
+                + "  \"azure.signinlogs.result_description\": \"Invalid username or password or Invalid on-premises username or password.\",\n"
+                + "  \"azure.signinlogs.props.user_id\": \"DEYSUBHO\"\n"
+                + "}";
     }
 
     public static String randomCloudtrailOcsfDoc() {
-        return "{\n" +
-                "  \"activity_id\": 8,\n" +
-                "  \"activity_name\": \"Detach Policy\",\n" +
-                "  \"actor\": {\n" +
-                "    \"idp\": {\n" +
-                "      \"name\": null\n" +
-                "    },\n" +
-                "    \"invoked_by\": null,\n" +
-                "    \"session\": {\n" +
-                "      \"created_time\": 1702510696000,\n" +
-                "      \"issuer\": \"arn\",\n" +
-                "      \"mfa\": false\n" +
-                "    },\n" +
-                "    \"user\": {\n" +
-                "      \"account_uid\": \"\",\n" +
-                "      \"credential_uid\": \"\",\n" +
-                "      \"name\": null,\n" +
-                "      \"type\": \"AssumedRole\",\n" +
-                "      \"uid\": \"\",\n" +
-                "      \"uuid\": \"\"\n" +
-                "    }\n" +
-                "  },\n" +
-                "  \"api\": {\n" +
-                "    \"operation\": \"CreateFunction\",\n" +
-                "    \"request\": {\n" +
-                "      \"uid\": \"0966237c-6279-43f4-a9d7-1eb416fca17d\"\n" +
-                "    },\n" +
-                "    \"response\": {\n" +
-                "      \"error\": null,\n" +
-                "      \"message\": null\n" +
-                "    },\n" +
-                "    \"service\": {\n" +
-                "      \"name\": \"lambda.amazonaws.com\"\n" +
-                "    },\n" +
-                "    \"version\": null\n" +
-                "  },\n" +
-                "  \"category_name\": \"Audit Activity\",\n" +
-                "  \"category_uid\": 3,\n" +
-                "  \"class_name\": \"account_change\",\n" +
-                "  \"class_uid\": 3001,\n" +
-                "  \"cloud\": {\n" +
-                "    \"provider\": \"AWS\",\n" +
-                "    \"region\": \"us-east-1\"\n" +
-                "  },\n" +
-                "  \"dst_endpoint\": null,\n" +
-                "  \"http_request\": {\n" +
-                "    \"user_agent\": \"Boto3/1.26.90 Python/3.7.17 Linux/test.amzn2.x86_64 exec-env/AWS_Lambda_python3.7 Botocore/1.29.90\"\n" +
-                "  },\n" +
-                "  \"metadata\": {\n" +
-                "    \"product\": {\n" +
-                "      \"feature\": {\n" +
-                "        \"name\": \"Management\"\n" +
-                "      },\n" +
-                "      \"name\": \"cloudtrail\",\n" +
-                "      \"vendor_name\": \"AWS\",\n" +
-                "      \"version\": \"1.08\"\n" +
-                "    },\n" +
-                "    \"profiles\": [\n" +
-                "      \"cloud\"\n" +
-                "    ],\n" +
-                "    \"uid\": \"\",\n" +
-                "    \"version\": \"1.0.0-rc.2\"\n" +
-                "  },\n" +
-                "  \"mfa\": null,\n" +
-                "  \"resources\": null,\n" +
-                "  \"severity\": \"Informational\",\n" +
-                "  \"severity_id\": 1,\n" +
-                "  \"src_endpoint\": {\n" +
-                "    \"domain\": null,\n" +
-                "    \"ip\": \"\",\n" +
-                "    \"uid\": null\n" +
-                "  },\n" +
-                "  \"status\": \"Success\",\n" +
-                "  \"status_id\": 1,\n" +
-                "  \"time\": " + System.currentTimeMillis() + ",\n" +
-                "  \"type_name\": \"Account Change: Detach Policy\",\n" +
-                "  \"type_uid\": 300108,\n" +
-                "  \"unmapped\": {\n" +
-                "    \"eventType\": \"AwsApiCall\",\n" +
-                "    \"managementEvent\": \"true\",\n" +
-                "    \"readOnly\": \"false\",\n" +
-                "    \"recipientAccountId\": \"\",\n" +
-                "    \"requestParameters.instanceProfileName\": \"\",\n" +
-                "    \"tlsDetails.cipherSuite\": \"\",\n" +
-                "    \"tlsDetails.clientProvidedHostHeader\": \"iam.amazonaws.com\",\n" +
-                "    \"tlsDetails.tlsVersion\": \"TLSv1.2\",\n" +
-                "    \"userIdentity.sessionContext.sessionIssuer.accountId\": \"\",\n" +
-                "    \"userIdentity.sessionContext.sessionIssuer.principalId\": \"\",\n" +
-                "    \"userIdentity.sessionContext.sessionIssuer.type\": \"Role\",\n" +
-                "    \"userIdentity.sessionContext.sessionIssuer.userName\": \"\"\n" +
-                "  },\n" +
-                "  \"user\": {\n" +
-                "    \"name\": \"\",\n" +
-                "    \"uid\": null,\n" +
-                "    \"uuid\": null\n" +
-                "  }\n" +
-                "}";
+        return "{\n"
+                + "  \"activity_id\": 8,\n"
+                + "  \"activity_name\": \"Detach Policy\",\n"
+                + "  \"actor\": {\n"
+                + "    \"idp\": {\n"
+                + "      \"name\": null\n"
+                + "    },\n"
+                + "    \"invoked_by\": null,\n"
+                + "    \"session\": {\n"
+                + "      \"created_time\": 1702510696000,\n"
+                + "      \"issuer\": \"arn\",\n"
+                + "      \"mfa\": false\n"
+                + "    },\n"
+                + "    \"user\": {\n"
+                + "      \"account_uid\": \"\",\n"
+                + "      \"credential_uid\": \"\",\n"
+                + "      \"name\": null,\n"
+                + "      \"type\": \"AssumedRole\",\n"
+                + "      \"uid\": \"\",\n"
+                + "      \"uuid\": \"\"\n"
+                + "    }\n"
+                + "  },\n"
+                + "  \"api\": {\n"
+                + "    \"operation\": \"CreateFunction\",\n"
+                + "    \"request\": {\n"
+                + "      \"uid\": \"0966237c-6279-43f4-a9d7-1eb416fca17d\"\n"
+                + "    },\n"
+                + "    \"response\": {\n"
+                + "      \"error\": null,\n"
+                + "      \"message\": null\n"
+                + "    },\n"
+                + "    \"service\": {\n"
+                + "      \"name\": \"lambda.amazonaws.com\"\n"
+                + "    },\n"
+                + "    \"version\": null\n"
+                + "  },\n"
+                + "  \"category_name\": \"Audit Activity\",\n"
+                + "  \"category_uid\": 3,\n"
+                + "  \"class_name\": \"account_change\",\n"
+                + "  \"class_uid\": 3001,\n"
+                + "  \"cloud\": {\n"
+                + "    \"provider\": \"AWS\",\n"
+                + "    \"region\": \"us-east-1\"\n"
+                + "  },\n"
+                + "  \"dst_endpoint\": null,\n"
+                + "  \"http_request\": {\n"
+                + "    \"user_agent\": \"Boto3/1.26.90 Python/3.7.17 Linux/test.amzn2.x86_64 exec-env/AWS_Lambda_python3.7 Botocore/1.29.90\"\n"
+                + "  },\n"
+                + "  \"metadata\": {\n"
+                + "    \"product\": {\n"
+                + "      \"feature\": {\n"
+                + "        \"name\": \"Management\"\n"
+                + "      },\n"
+                + "      \"name\": \"cloudtrail\",\n"
+                + "      \"vendor_name\": \"AWS\",\n"
+                + "      \"version\": \"1.08\"\n"
+                + "    },\n"
+                + "    \"profiles\": [\n"
+                + "      \"cloud\"\n"
+                + "    ],\n"
+                + "    \"uid\": \"\",\n"
+                + "    \"version\": \"1.0.0-rc.2\"\n"
+                + "  },\n"
+                + "  \"mfa\": null,\n"
+                + "  \"resources\": null,\n"
+                + "  \"severity\": \"Informational\",\n"
+                + "  \"severity_id\": 1,\n"
+                + "  \"src_endpoint\": {\n"
+                + "    \"domain\": null,\n"
+                + "    \"ip\": \"\",\n"
+                + "    \"uid\": null\n"
+                + "  },\n"
+                + "  \"status\": \"Success\",\n"
+                + "  \"status_id\": 1,\n"
+                + "  \"time\": "
+                + System.currentTimeMillis()
+                + ",\n"
+                + "  \"type_name\": \"Account Change: Detach Policy\",\n"
+                + "  \"type_uid\": 300108,\n"
+                + "  \"unmapped\": {\n"
+                + "    \"eventType\": \"AwsApiCall\",\n"
+                + "    \"managementEvent\": \"true\",\n"
+                + "    \"readOnly\": \"false\",\n"
+                + "    \"recipientAccountId\": \"\",\n"
+                + "    \"requestParameters.instanceProfileName\": \"\",\n"
+                + "    \"tlsDetails.cipherSuite\": \"\",\n"
+                + "    \"tlsDetails.clientProvidedHostHeader\": \"iam.amazonaws.com\",\n"
+                + "    \"tlsDetails.tlsVersion\": \"TLSv1.2\",\n"
+                + "    \"userIdentity.sessionContext.sessionIssuer.accountId\": \"\",\n"
+                + "    \"userIdentity.sessionContext.sessionIssuer.principalId\": \"\",\n"
+                + "    \"userIdentity.sessionContext.sessionIssuer.type\": \"Role\",\n"
+                + "    \"userIdentity.sessionContext.sessionIssuer.userName\": \"\"\n"
+                + "  },\n"
+                + "  \"user\": {\n"
+                + "    \"name\": \"\",\n"
+                + "    \"uid\": null,\n"
+                + "    \"uuid\": null\n"
+                + "  }\n"
+                + "}";
     }
 
     public static String randomCloudtrailDoc(String user, String event) {
-        return "{\n" +
-                "    \"eventVersion\": \"1.08\",\n" +
-                "    \"userIdentity\": {\n" +
-                "        \"type\": \"IAMUser\",\n" +
-                "        \"principalId\": \"AIDA6ON6E4XEGITEXAMPLE\",\n" +
-                "        \"arn\": \"arn:aws:iam::888888888888:user/Mary\",\n" +
-                "        \"accountId\": \"888888888888\",\n" +
-                "        \"accessKeyId\": \"AKIAIOSFODNN7EXAMPLE\",\n" +
-                "        \"userName\": \"Mary\",\n" +
-                "        \"sessionContext\": {\n" +
-                "            \"sessionIssuer\": {},\n" +
-                "            \"webIdFederationData\": {},\n" +
-                "            \"attributes\": {\n" +
-                "                \"creationDate\": \"2023-07-19T21:11:57Z\",\n" +
-                "                \"mfaAuthenticated\": \"false\"\n" +
-                "            }\n" +
-                "        }\n" +
-                "    },\n" +
-                "    \"eventTime\": \"2023-07-19T21:25:09Z\",\n" +
-                "    \"eventSource\": \"iam.amazonaws.com\",\n" +
-                "    \"EventName\": \"" + event + "\",\n" +
-                "    \"awsRegion\": \"us-east-1\",\n" +
-                "    \"sourceIPAddress\": \"192.0.2.0\",\n" +
-                "    \"AccountName\": \"" + user + "\",\n" +
-                "    \"userAgent\": \"aws-cli/2.13.5 Python/3.11.4 Linux/4.14.255-314-253.539.amzn2.x86_64 exec-env/CloudShell exe/x86_64.amzn.2 prompt/off command/iam.create-user\",\n" +
-                "    \"requestParameters\": {\n" +
-                "        \"userName\": \"" + user + "\"\n" +
-                "    },\n" +
-                "    \"responseElements\": {\n" +
-                "        \"user\": {\n" +
-                "            \"path\": \"/\",\n" +
-                "            \"arn\": \"arn:aws:iam::888888888888:user/Richard\",\n" +
-                "            \"userId\": \"AIDA6ON6E4XEP7EXAMPLE\",\n" +
-                "            \"createDate\": \"Jul 19, 2023 9:25:09 PM\",\n" +
-                "            \"userName\": \"Richard\"\n" +
-                "        }\n" +
-                "    },\n" +
-                "    \"requestID\": \"2d528c76-329e-410b-9516-EXAMPLE565dc\",\n" +
-                "    \"eventID\": \"ba0801a1-87ec-4d26-be87-EXAMPLE75bbb\",\n" +
-                "    \"readOnly\": false,\n" +
-                "    \"eventType\": \"AwsApiCall\",\n" +
-                "    \"managementEvent\": true,\n" +
-                "    \"recipientAccountId\": \"888888888888\",\n" +
-                "    \"eventCategory\": \"Management\",\n" +
-                "    \"tlsDetails\": {\n" +
-                "        \"tlsVersion\": \"TLSv1.2\",\n" +
-                "        \"cipherSuite\": \"ECDHE-RSA-AES128-GCM-SHA256\",\n" +
-                "        \"clientProvidedHostHeader\": \"iam.amazonaws.com\"\n" +
-                "    },\n" +
-                "    \"sessionCredentialFromConsole\": \"true\"\n" +
-                "}";
+        return "{\n"
+                + "    \"eventVersion\": \"1.08\",\n"
+                + "    \"userIdentity\": {\n"
+                + "        \"type\": \"IAMUser\",\n"
+                + "        \"principalId\": \"AIDA6ON6E4XEGITEXAMPLE\",\n"
+                + "        \"arn\": \"arn:aws:iam::888888888888:user/Mary\",\n"
+                + "        \"accountId\": \"888888888888\",\n"
+                + "        \"accessKeyId\": \"AKIAIOSFODNN7EXAMPLE\",\n"
+                + "        \"userName\": \"Mary\",\n"
+                + "        \"sessionContext\": {\n"
+                + "            \"sessionIssuer\": {},\n"
+                + "            \"webIdFederationData\": {},\n"
+                + "            \"attributes\": {\n"
+                + "                \"creationDate\": \"2023-07-19T21:11:57Z\",\n"
+                + "                \"mfaAuthenticated\": \"false\"\n"
+                + "            }\n"
+                + "        }\n"
+                + "    },\n"
+                + "    \"eventTime\": \"2023-07-19T21:25:09Z\",\n"
+                + "    \"eventSource\": \"iam.amazonaws.com\",\n"
+                + "    \"EventName\": \""
+                + event
+                + "\",\n"
+                + "    \"awsRegion\": \"us-east-1\",\n"
+                + "    \"sourceIPAddress\": \"192.0.2.0\",\n"
+                + "    \"AccountName\": \""
+                + user
+                + "\",\n"
+                + "    \"userAgent\": \"aws-cli/2.13.5 Python/3.11.4 Linux/4.14.255-314-253.539.amzn2.x86_64 exec-env/CloudShell exe/x86_64.amzn.2 prompt/off command/iam.create-user\",\n"
+                + "    \"requestParameters\": {\n"
+                + "        \"userName\": \""
+                + user
+                + "\"\n"
+                + "    },\n"
+                + "    \"responseElements\": {\n"
+                + "        \"user\": {\n"
+                + "            \"path\": \"/\",\n"
+                + "            \"arn\": \"arn:aws:iam::888888888888:user/Richard\",\n"
+                + "            \"userId\": \"AIDA6ON6E4XEP7EXAMPLE\",\n"
+                + "            \"createDate\": \"Jul 19, 2023 9:25:09 PM\",\n"
+                + "            \"userName\": \"Richard\"\n"
+                + "        }\n"
+                + "    },\n"
+                + "    \"requestID\": \"2d528c76-329e-410b-9516-EXAMPLE565dc\",\n"
+                + "    \"eventID\": \"ba0801a1-87ec-4d26-be87-EXAMPLE75bbb\",\n"
+                + "    \"readOnly\": false,\n"
+                + "    \"eventType\": \"AwsApiCall\",\n"
+                + "    \"managementEvent\": true,\n"
+                + "    \"recipientAccountId\": \"888888888888\",\n"
+                + "    \"eventCategory\": \"Management\",\n"
+                + "    \"tlsDetails\": {\n"
+                + "        \"tlsVersion\": \"TLSv1.2\",\n"
+                + "        \"cipherSuite\": \"ECDHE-RSA-AES128-GCM-SHA256\",\n"
+                + "        \"clientProvidedHostHeader\": \"iam.amazonaws.com\"\n"
+                + "    },\n"
+                + "    \"sessionCredentialFromConsole\": \"true\"\n"
+                + "}";
     }
 
     public static String randomAppLogDoc() {
-        return "{\n" +
-                "  \"endpoint\": \"/customer_records.txt\",\n" +
-                "  \"http_method\": \"POST\",\n" +
-                "  \"keywords\": \"INVALID\"\n" +
-                "}";
+        return "{\n"
+                + "  \"endpoint\": \"/customer_records.txt\",\n"
+                + "  \"http_method\": \"POST\",\n"
+                + "  \"keywords\": \"INVALID\"\n"
+                + "}";
     }
 
     public static String randomS3AccessLogDoc() {
-        return "{\n" +
-                "  \"aws.cloudtrail.eventSource\": \"s3.amazonaws.com\",\n" +
-                "  \"aws.cloudtrail.eventName\": \"ReplicateObject\",\n" +
-                "  \"aws.cloudtrail.eventTime\": 1\n" +
-                "}";
+        return "{\n"
+                + "  \"aws.cloudtrail.eventSource\": \"s3.amazonaws.com\",\n"
+                + "  \"aws.cloudtrail.eventName\": \"ReplicateObject\",\n"
+                + "  \"aws.cloudtrail.eventTime\": 1\n"
+                + "}";
     }
 
     public static String adLdapLogMappings() {
-        return "\"properties\": {\n" +
-                "      \"ResultType\": {\n" +
-                "        \"type\": \"integer\"\n" +
-                "      },\n" +
-                "      \"ResultDescription\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      },\n" +
-                "      \"azure.signinlogs.props.user_id\": {\n" +
-                "        \"type\": \"text\"\n" +
-                "      }\n" +
-                "    }";
+        return "\"properties\": {\n"
+                + "      \"ResultType\": {\n"
+                + "        \"type\": \"integer\"\n"
+                + "      },\n"
+                + "      \"ResultDescription\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      },\n"
+                + "      \"azure.signinlogs.props.user_id\": {\n"
+                + "        \"type\": \"text\"\n"
+                + "      }\n"
+                + "    }";
     }
 
     public static String cloudtrailMappings() {
-        return "\"properties\": {\n" +
-                "        \"Records\": {\n" +
-                "          \"properties\": {\n" +
-                "            \"awsRegion\": {\n" +
-                "              \"type\": \"text\",\n" +
-                "              \"fields\": {\n" +
-                "                \"keyword\": {\n" +
-                "                  \"type\": \"keyword\",\n" +
-                "                  \"ignore_above\": 256\n" +
-                "                }\n" +
-                "              }\n" +
-                "            },\n" +
-                "            \"eventCategory\": {\n" +
-                "              \"type\": \"text\",\n" +
-                "              \"fields\": {\n" +
-                "                \"keyword\": {\n" +
-                "                  \"type\": \"keyword\",\n" +
-                "                  \"ignore_above\": 256\n" +
-                "                }\n" +
-                "              }\n" +
-                "            },\n" +
-                "            \"eventID\": {\n" +
-                "              \"type\": \"text\",\n" +
-                "              \"fields\": {\n" +
-                "                \"keyword\": {\n" +
-                "                  \"type\": \"keyword\",\n" +
-                "                  \"ignore_above\": 256\n" +
-                "                }\n" +
-                "              }\n" +
-                "            },\n" +
-                "            \"eventName\": {\n" +
-                "              \"type\": \"text\",\n" +
-                "              \"fields\": {\n" +
-                "                \"keyword\": {\n" +
-                "                  \"type\": \"keyword\",\n" +
-                "                  \"ignore_above\": 256\n" +
-                "                }\n" +
-                "              }\n" +
-                "            },\n" +
-                "            \"eventSource\": {\n" +
-                "              \"type\": \"text\",\n" +
-                "              \"fields\": {\n" +
-                "                \"keyword\": {\n" +
-                "                  \"type\": \"keyword\",\n" +
-                "                  \"ignore_above\": 256\n" +
-                "                }\n" +
-                "              }\n" +
-                "            },\n" +
-                "            \"eventTime\": {\n" +
-                "              \"type\": \"date\"\n" +
-                "            },\n" +
-                "            \"eventType\": {\n" +
-                "              \"type\": \"text\",\n" +
-                "              \"fields\": {\n" +
-                "                \"keyword\": {\n" +
-                "                  \"type\": \"keyword\",\n" +
-                "                  \"ignore_above\": 256\n" +
-                "                }\n" +
-                "              }\n" +
-                "            },\n" +
-                "            \"eventVersion\": {\n" +
-                "              \"type\": \"text\",\n" +
-                "              \"fields\": {\n" +
-                "                \"keyword\": {\n" +
-                "                  \"type\": \"keyword\",\n" +
-                "                  \"ignore_above\": 256\n" +
-                "                }\n" +
-                "              }\n" +
-                "            },\n" +
-                "            \"managementEvent\": {\n" +
-                "              \"type\": \"boolean\"\n" +
-                "            },\n" +
-                "            \"readOnly\": {\n" +
-                "              \"type\": \"boolean\"\n" +
-                "            },\n" +
-                "            \"recipientAccountId\": {\n" +
-                "              \"type\": \"text\",\n" +
-                "              \"fields\": {\n" +
-                "                \"keyword\": {\n" +
-                "                  \"type\": \"keyword\",\n" +
-                "                  \"ignore_above\": 256\n" +
-                "                }\n" +
-                "              }\n" +
-                "            },\n" +
-                "            \"requestID\": {\n" +
-                "              \"type\": \"text\",\n" +
-                "              \"fields\": {\n" +
-                "                \"keyword\": {\n" +
-                "                  \"type\": \"keyword\",\n" +
-                "                  \"ignore_above\": 256\n" +
-                "                }\n" +
-                "              }\n" +
-                "            },\n" +
-                "            \"requestParameters\": {\n" +
-                "              \"properties\": {\n" +
-                "                \"userName\": {\n" +
-                "                  \"type\": \"text\",\n" +
-                "                  \"fields\": {\n" +
-                "                    \"keyword\": {\n" +
-                "                      \"type\": \"keyword\",\n" +
-                "                      \"ignore_above\": 256\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                }\n" +
-                "              }\n" +
-                "            },\n" +
-                "            \"responseElements\": {\n" +
-                "              \"properties\": {\n" +
-                "                \"user\": {\n" +
-                "                  \"properties\": {\n" +
-                "                    \"arn\": {\n" +
-                "                      \"type\": \"text\",\n" +
-                "                      \"fields\": {\n" +
-                "                        \"keyword\": {\n" +
-                "                          \"type\": \"keyword\",\n" +
-                "                          \"ignore_above\": 256\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    },\n" +
-                "                    \"createDate\": {\n" +
-                "                      \"type\": \"text\",\n" +
-                "                      \"fields\": {\n" +
-                "                        \"keyword\": {\n" +
-                "                          \"type\": \"keyword\",\n" +
-                "                          \"ignore_above\": 256\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    },\n" +
-                "                    \"path\": {\n" +
-                "                      \"type\": \"text\",\n" +
-                "                      \"fields\": {\n" +
-                "                        \"keyword\": {\n" +
-                "                          \"type\": \"keyword\",\n" +
-                "                          \"ignore_above\": 256\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    },\n" +
-                "                    \"userId\": {\n" +
-                "                      \"type\": \"text\",\n" +
-                "                      \"fields\": {\n" +
-                "                        \"keyword\": {\n" +
-                "                          \"type\": \"keyword\",\n" +
-                "                          \"ignore_above\": 256\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    },\n" +
-                "                    \"userName\": {\n" +
-                "                      \"type\": \"text\",\n" +
-                "                      \"fields\": {\n" +
-                "                        \"keyword\": {\n" +
-                "                          \"type\": \"keyword\",\n" +
-                "                          \"ignore_above\": 256\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                }\n" +
-                "              }\n" +
-                "            },\n" +
-                "            \"sessionCredentialFromConsole\": {\n" +
-                "              \"type\": \"text\",\n" +
-                "              \"fields\": {\n" +
-                "                \"keyword\": {\n" +
-                "                  \"type\": \"keyword\",\n" +
-                "                  \"ignore_above\": 256\n" +
-                "                }\n" +
-                "              }\n" +
-                "            },\n" +
-                "            \"sourceIPAddress\": {\n" +
-                "              \"type\": \"text\",\n" +
-                "              \"fields\": {\n" +
-                "                \"keyword\": {\n" +
-                "                  \"type\": \"keyword\",\n" +
-                "                  \"ignore_above\": 256\n" +
-                "                }\n" +
-                "              }\n" +
-                "            },\n" +
-                "            \"tlsDetails\": {\n" +
-                "              \"properties\": {\n" +
-                "                \"cipherSuite\": {\n" +
-                "                  \"type\": \"text\",\n" +
-                "                  \"fields\": {\n" +
-                "                    \"keyword\": {\n" +
-                "                      \"type\": \"keyword\",\n" +
-                "                      \"ignore_above\": 256\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                },\n" +
-                "                \"clientProvidedHostHeader\": {\n" +
-                "                  \"type\": \"text\",\n" +
-                "                  \"fields\": {\n" +
-                "                    \"keyword\": {\n" +
-                "                      \"type\": \"keyword\",\n" +
-                "                      \"ignore_above\": 256\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                },\n" +
-                "                \"tlsVersion\": {\n" +
-                "                  \"type\": \"text\",\n" +
-                "                  \"fields\": {\n" +
-                "                    \"keyword\": {\n" +
-                "                      \"type\": \"keyword\",\n" +
-                "                      \"ignore_above\": 256\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                }\n" +
-                "              }\n" +
-                "            },\n" +
-                "            \"userAgent\": {\n" +
-                "              \"type\": \"text\",\n" +
-                "              \"fields\": {\n" +
-                "                \"keyword\": {\n" +
-                "                  \"type\": \"keyword\",\n" +
-                "                  \"ignore_above\": 256\n" +
-                "                }\n" +
-                "              }\n" +
-                "            },\n" +
-                "            \"userIdentity\": {\n" +
-                "              \"properties\": {\n" +
-                "                \"accessKeyId\": {\n" +
-                "                  \"type\": \"text\",\n" +
-                "                  \"fields\": {\n" +
-                "                    \"keyword\": {\n" +
-                "                      \"type\": \"keyword\",\n" +
-                "                      \"ignore_above\": 256\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                },\n" +
-                "                \"accountId\": {\n" +
-                "                  \"type\": \"text\",\n" +
-                "                  \"fields\": {\n" +
-                "                    \"keyword\": {\n" +
-                "                      \"type\": \"keyword\",\n" +
-                "                      \"ignore_above\": 256\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                },\n" +
-                "                \"arn\": {\n" +
-                "                  \"type\": \"text\",\n" +
-                "                  \"fields\": {\n" +
-                "                    \"keyword\": {\n" +
-                "                      \"type\": \"keyword\",\n" +
-                "                      \"ignore_above\": 256\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                },\n" +
-                "                \"principalId\": {\n" +
-                "                  \"type\": \"text\",\n" +
-                "                  \"fields\": {\n" +
-                "                    \"keyword\": {\n" +
-                "                      \"type\": \"keyword\",\n" +
-                "                      \"ignore_above\": 256\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                },\n" +
-                "                \"sessionContext\": {\n" +
-                "                  \"properties\": {\n" +
-                "                    \"attributes\": {\n" +
-                "                      \"properties\": {\n" +
-                "                        \"creationDate\": {\n" +
-                "                          \"type\": \"date\"\n" +
-                "                        },\n" +
-                "                        \"mfaAuthenticated\": {\n" +
-                "                          \"type\": \"text\",\n" +
-                "                          \"fields\": {\n" +
-                "                            \"keyword\": {\n" +
-                "                              \"type\": \"keyword\",\n" +
-                "                              \"ignore_above\": 256\n" +
-                "                            }\n" +
-                "                          }\n" +
-                "                        }\n" +
-                "                      }\n" +
-                "                    },\n" +
-                "                    \"sessionIssuer\": {\n" +
-                "                      \"type\": \"object\"\n" +
-                "                    },\n" +
-                "                    \"webIdFederationData\": {\n" +
-                "                      \"type\": \"object\"\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                },\n" +
-                "                \"type\": {\n" +
-                "                  \"type\": \"text\",\n" +
-                "                  \"fields\": {\n" +
-                "                    \"keyword\": {\n" +
-                "                      \"type\": \"keyword\",\n" +
-                "                      \"ignore_above\": 256\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                },\n" +
-                "                \"userName\": {\n" +
-                "                  \"type\": \"text\",\n" +
-                "                  \"fields\": {\n" +
-                "                    \"keyword\": {\n" +
-                "                      \"type\": \"keyword\",\n" +
-                "                      \"ignore_above\": 256\n" +
-                "                    }\n" +
-                "                  }\n" +
-                "                }\n" +
-                "              }\n" +
-                "            }\n" +
-                "          }\n" +
-                "        }}";
+        return "\"properties\": {\n"
+                + "        \"Records\": {\n"
+                + "          \"properties\": {\n"
+                + "            \"awsRegion\": {\n"
+                + "              \"type\": \"text\",\n"
+                + "              \"fields\": {\n"
+                + "                \"keyword\": {\n"
+                + "                  \"type\": \"keyword\",\n"
+                + "                  \"ignore_above\": 256\n"
+                + "                }\n"
+                + "              }\n"
+                + "            },\n"
+                + "            \"eventCategory\": {\n"
+                + "              \"type\": \"text\",\n"
+                + "              \"fields\": {\n"
+                + "                \"keyword\": {\n"
+                + "                  \"type\": \"keyword\",\n"
+                + "                  \"ignore_above\": 256\n"
+                + "                }\n"
+                + "              }\n"
+                + "            },\n"
+                + "            \"eventID\": {\n"
+                + "              \"type\": \"text\",\n"
+                + "              \"fields\": {\n"
+                + "                \"keyword\": {\n"
+                + "                  \"type\": \"keyword\",\n"
+                + "                  \"ignore_above\": 256\n"
+                + "                }\n"
+                + "              }\n"
+                + "            },\n"
+                + "            \"eventName\": {\n"
+                + "              \"type\": \"text\",\n"
+                + "              \"fields\": {\n"
+                + "                \"keyword\": {\n"
+                + "                  \"type\": \"keyword\",\n"
+                + "                  \"ignore_above\": 256\n"
+                + "                }\n"
+                + "              }\n"
+                + "            },\n"
+                + "            \"eventSource\": {\n"
+                + "              \"type\": \"text\",\n"
+                + "              \"fields\": {\n"
+                + "                \"keyword\": {\n"
+                + "                  \"type\": \"keyword\",\n"
+                + "                  \"ignore_above\": 256\n"
+                + "                }\n"
+                + "              }\n"
+                + "            },\n"
+                + "            \"eventTime\": {\n"
+                + "              \"type\": \"date\"\n"
+                + "            },\n"
+                + "            \"eventType\": {\n"
+                + "              \"type\": \"text\",\n"
+                + "              \"fields\": {\n"
+                + "                \"keyword\": {\n"
+                + "                  \"type\": \"keyword\",\n"
+                + "                  \"ignore_above\": 256\n"
+                + "                }\n"
+                + "              }\n"
+                + "            },\n"
+                + "            \"eventVersion\": {\n"
+                + "              \"type\": \"text\",\n"
+                + "              \"fields\": {\n"
+                + "                \"keyword\": {\n"
+                + "                  \"type\": \"keyword\",\n"
+                + "                  \"ignore_above\": 256\n"
+                + "                }\n"
+                + "              }\n"
+                + "            },\n"
+                + "            \"managementEvent\": {\n"
+                + "              \"type\": \"boolean\"\n"
+                + "            },\n"
+                + "            \"readOnly\": {\n"
+                + "              \"type\": \"boolean\"\n"
+                + "            },\n"
+                + "            \"recipientAccountId\": {\n"
+                + "              \"type\": \"text\",\n"
+                + "              \"fields\": {\n"
+                + "                \"keyword\": {\n"
+                + "                  \"type\": \"keyword\",\n"
+                + "                  \"ignore_above\": 256\n"
+                + "                }\n"
+                + "              }\n"
+                + "            },\n"
+                + "            \"requestID\": {\n"
+                + "              \"type\": \"text\",\n"
+                + "              \"fields\": {\n"
+                + "                \"keyword\": {\n"
+                + "                  \"type\": \"keyword\",\n"
+                + "                  \"ignore_above\": 256\n"
+                + "                }\n"
+                + "              }\n"
+                + "            },\n"
+                + "            \"requestParameters\": {\n"
+                + "              \"properties\": {\n"
+                + "                \"userName\": {\n"
+                + "                  \"type\": \"text\",\n"
+                + "                  \"fields\": {\n"
+                + "                    \"keyword\": {\n"
+                + "                      \"type\": \"keyword\",\n"
+                + "                      \"ignore_above\": 256\n"
+                + "                    }\n"
+                + "                  }\n"
+                + "                }\n"
+                + "              }\n"
+                + "            },\n"
+                + "            \"responseElements\": {\n"
+                + "              \"properties\": {\n"
+                + "                \"user\": {\n"
+                + "                  \"properties\": {\n"
+                + "                    \"arn\": {\n"
+                + "                      \"type\": \"text\",\n"
+                + "                      \"fields\": {\n"
+                + "                        \"keyword\": {\n"
+                + "                          \"type\": \"keyword\",\n"
+                + "                          \"ignore_above\": 256\n"
+                + "                        }\n"
+                + "                      }\n"
+                + "                    },\n"
+                + "                    \"createDate\": {\n"
+                + "                      \"type\": \"text\",\n"
+                + "                      \"fields\": {\n"
+                + "                        \"keyword\": {\n"
+                + "                          \"type\": \"keyword\",\n"
+                + "                          \"ignore_above\": 256\n"
+                + "                        }\n"
+                + "                      }\n"
+                + "                    },\n"
+                + "                    \"path\": {\n"
+                + "                      \"type\": \"text\",\n"
+                + "                      \"fields\": {\n"
+                + "                        \"keyword\": {\n"
+                + "                          \"type\": \"keyword\",\n"
+                + "                          \"ignore_above\": 256\n"
+                + "                        }\n"
+                + "                      }\n"
+                + "                    },\n"
+                + "                    \"userId\": {\n"
+                + "                      \"type\": \"text\",\n"
+                + "                      \"fields\": {\n"
+                + "                        \"keyword\": {\n"
+                + "                          \"type\": \"keyword\",\n"
+                + "                          \"ignore_above\": 256\n"
+                + "                        }\n"
+                + "                      }\n"
+                + "                    },\n"
+                + "                    \"userName\": {\n"
+                + "                      \"type\": \"text\",\n"
+                + "                      \"fields\": {\n"
+                + "                        \"keyword\": {\n"
+                + "                          \"type\": \"keyword\",\n"
+                + "                          \"ignore_above\": 256\n"
+                + "                        }\n"
+                + "                      }\n"
+                + "                    }\n"
+                + "                  }\n"
+                + "                }\n"
+                + "              }\n"
+                + "            },\n"
+                + "            \"sessionCredentialFromConsole\": {\n"
+                + "              \"type\": \"text\",\n"
+                + "              \"fields\": {\n"
+                + "                \"keyword\": {\n"
+                + "                  \"type\": \"keyword\",\n"
+                + "                  \"ignore_above\": 256\n"
+                + "                }\n"
+                + "              }\n"
+                + "            },\n"
+                + "            \"sourceIPAddress\": {\n"
+                + "              \"type\": \"text\",\n"
+                + "              \"fields\": {\n"
+                + "                \"keyword\": {\n"
+                + "                  \"type\": \"keyword\",\n"
+                + "                  \"ignore_above\": 256\n"
+                + "                }\n"
+                + "              }\n"
+                + "            },\n"
+                + "            \"tlsDetails\": {\n"
+                + "              \"properties\": {\n"
+                + "                \"cipherSuite\": {\n"
+                + "                  \"type\": \"text\",\n"
+                + "                  \"fields\": {\n"
+                + "                    \"keyword\": {\n"
+                + "                      \"type\": \"keyword\",\n"
+                + "                      \"ignore_above\": 256\n"
+                + "                    }\n"
+                + "                  }\n"
+                + "                },\n"
+                + "                \"clientProvidedHostHeader\": {\n"
+                + "                  \"type\": \"text\",\n"
+                + "                  \"fields\": {\n"
+                + "                    \"keyword\": {\n"
+                + "                      \"type\": \"keyword\",\n"
+                + "                      \"ignore_above\": 256\n"
+                + "                    }\n"
+                + "                  }\n"
+                + "                },\n"
+                + "                \"tlsVersion\": {\n"
+                + "                  \"type\": \"text\",\n"
+                + "                  \"fields\": {\n"
+                + "                    \"keyword\": {\n"
+                + "                      \"type\": \"keyword\",\n"
+                + "                      \"ignore_above\": 256\n"
+                + "                    }\n"
+                + "                  }\n"
+                + "                }\n"
+                + "              }\n"
+                + "            },\n"
+                + "            \"userAgent\": {\n"
+                + "              \"type\": \"text\",\n"
+                + "              \"fields\": {\n"
+                + "                \"keyword\": {\n"
+                + "                  \"type\": \"keyword\",\n"
+                + "                  \"ignore_above\": 256\n"
+                + "                }\n"
+                + "              }\n"
+                + "            },\n"
+                + "            \"userIdentity\": {\n"
+                + "              \"properties\": {\n"
+                + "                \"accessKeyId\": {\n"
+                + "                  \"type\": \"text\",\n"
+                + "                  \"fields\": {\n"
+                + "                    \"keyword\": {\n"
+                + "                      \"type\": \"keyword\",\n"
+                + "                      \"ignore_above\": 256\n"
+                + "                    }\n"
+                + "                  }\n"
+                + "                },\n"
+                + "                \"accountId\": {\n"
+                + "                  \"type\": \"text\",\n"
+                + "                  \"fields\": {\n"
+                + "                    \"keyword\": {\n"
+                + "                      \"type\": \"keyword\",\n"
+                + "                      \"ignore_above\": 256\n"
+                + "                    }\n"
+                + "                  }\n"
+                + "                },\n"
+                + "                \"arn\": {\n"
+                + "                  \"type\": \"text\",\n"
+                + "                  \"fields\": {\n"
+                + "                    \"keyword\": {\n"
+                + "                      \"type\": \"keyword\",\n"
+                + "                      \"ignore_above\": 256\n"
+                + "                    }\n"
+                + "                  }\n"
+                + "                },\n"
+                + "                \"principalId\": {\n"
+                + "                  \"type\": \"text\",\n"
+                + "                  \"fields\": {\n"
+                + "                    \"keyword\": {\n"
+                + "                      \"type\": \"keyword\",\n"
+                + "                      \"ignore_above\": 256\n"
+                + "                    }\n"
+                + "                  }\n"
+                + "                },\n"
+                + "                \"sessionContext\": {\n"
+                + "                  \"properties\": {\n"
+                + "                    \"attributes\": {\n"
+                + "                      \"properties\": {\n"
+                + "                        \"creationDate\": {\n"
+                + "                          \"type\": \"date\"\n"
+                + "                        },\n"
+                + "                        \"mfaAuthenticated\": {\n"
+                + "                          \"type\": \"text\",\n"
+                + "                          \"fields\": {\n"
+                + "                            \"keyword\": {\n"
+                + "                              \"type\": \"keyword\",\n"
+                + "                              \"ignore_above\": 256\n"
+                + "                            }\n"
+                + "                          }\n"
+                + "                        }\n"
+                + "                      }\n"
+                + "                    },\n"
+                + "                    \"sessionIssuer\": {\n"
+                + "                      \"type\": \"object\"\n"
+                + "                    },\n"
+                + "                    \"webIdFederationData\": {\n"
+                + "                      \"type\": \"object\"\n"
+                + "                    }\n"
+                + "                  }\n"
+                + "                },\n"
+                + "                \"type\": {\n"
+                + "                  \"type\": \"text\",\n"
+                + "                  \"fields\": {\n"
+                + "                    \"keyword\": {\n"
+                + "                      \"type\": \"keyword\",\n"
+                + "                      \"ignore_above\": 256\n"
+                + "                    }\n"
+                + "                  }\n"
+                + "                },\n"
+                + "                \"userName\": {\n"
+                + "                  \"type\": \"text\",\n"
+                + "                  \"fields\": {\n"
+                + "                    \"keyword\": {\n"
+                + "                      \"type\": \"keyword\",\n"
+                + "                      \"ignore_above\": 256\n"
+                + "                    }\n"
+                + "                  }\n"
+                + "                }\n"
+                + "              }\n"
+                + "            }\n"
+                + "          }\n"
+                + "        }}";
     }
 
     public static String s3AccessLogMappings() {
-        return "    \"properties\": {" +
-                "        \"aws.cloudtrail.eventSource\": {" +
-                "          \"type\": \"text\"" +
-                "        }," +
-                "        \"aws.cloudtrail.eventName\": {" +
-                "          \"type\": \"text\"" +
-                "        }," +
-                "        \"aws.cloudtrail.eventTime\": {" +
-                "          \"type\": \"integer\"" +
-                "        }" +
-                "    }";
+        return "    \"properties\": {"
+                + "        \"aws.cloudtrail.eventSource\": {"
+                + "          \"type\": \"text\""
+                + "        },"
+                + "        \"aws.cloudtrail.eventName\": {"
+                + "          \"type\": \"text\""
+                + "        },"
+                + "        \"aws.cloudtrail.eventTime\": {"
+                + "          \"type\": \"integer\""
+                + "        }"
+                + "    }";
     }
 
     public static String appLogMappings() {
-        return "    \"properties\": {" +
-                "        \"http_method\": {" +
-                "          \"type\": \"text\"" +
-                "        }," +
-                "        \"endpoint\": {" +
-                "          \"type\": \"text\"" +
-                "        }," +
-                "        \"keywords\": {" +
-                "          \"type\": \"text\"" +
-                "        }" +
-                "    }";
+        return "    \"properties\": {"
+                + "        \"http_method\": {"
+                + "          \"type\": \"text\""
+                + "        },"
+                + "        \"endpoint\": {"
+                + "          \"type\": \"text\""
+                + "        },"
+                + "        \"keywords\": {"
+                + "          \"type\": \"text\""
+                + "        }"
+                + "    }";
     }
 
     public static String vpcFlowMappings() {
-        return "    \"properties\": {" +
-                "        \"version\": {" +
-                "          \"type\": \"integer\"" +
-                "        }," +
-                "        \"account-id\": {" +
-                "          \"type\": \"text\"" +
-                "        }," +
-                "        \"interface-id\": {" +
-                "          \"type\": \"text\"" +
-                "        }," +
-                "        \"srcaddr\": {" +
-                "          \"type\": \"text\"" +
-                "        }," +
-                "        \"dstaddr\": {" +
-                "          \"type\": \"text\"" +
-                "        }," +
-                "        \"srcport\": {" +
-                "          \"type\": \"integer\"" +
-                "        }," +
-                "        \"dstport\": {" +
-                "          \"type\": \"integer\"" +
-                "        }," +
-                "        \"severity_id\": {" +
-                "          \"type\": \"text\"" +
-                "        }," +
-                "        \"class_name\": {" +
-                "          \"type\": \"text\"" +
-                "        }" +
-                "    }";
+        return "    \"properties\": {"
+                + "        \"version\": {"
+                + "          \"type\": \"integer\""
+                + "        },"
+                + "        \"account-id\": {"
+                + "          \"type\": \"text\""
+                + "        },"
+                + "        \"interface-id\": {"
+                + "          \"type\": \"text\""
+                + "        },"
+                + "        \"srcaddr\": {"
+                + "          \"type\": \"text\""
+                + "        },"
+                + "        \"dstaddr\": {"
+                + "          \"type\": \"text\""
+                + "        },"
+                + "        \"srcport\": {"
+                + "          \"type\": \"integer\""
+                + "        },"
+                + "        \"dstport\": {"
+                + "          \"type\": \"integer\""
+                + "        },"
+                + "        \"severity_id\": {"
+                + "          \"type\": \"text\""
+                + "        },"
+                + "        \"class_name\": {"
+                + "          \"type\": \"text\""
+                + "        }"
+                + "    }";
     }
 
     private static String randomString() {
@@ -2789,7 +2925,10 @@ public class TestHelpers {
     }
 
     public static XContentParser parser(String xc) throws IOException {
-        XContentParser parser = XContentType.JSON.xContent().createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, xc);
+        XContentParser parser =
+                XContentType.JSON
+                        .xContent()
+                        .createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, xc);
         parser.nextToken();
         return parser;
     }
@@ -2799,13 +2938,10 @@ public class TestHelpers {
                 List.of(
                         Detector.XCONTENT_REGISTRY,
                         DetectorInput.XCONTENT_REGISTRY,
-                        ThreatIntelFeedData.XCONTENT_REGISTRY
-                )
-        );
+                        ThreatIntelFeedData.XCONTENT_REGISTRY));
     }
 
     public static XContentBuilder builder() throws IOException {
         return XContentBuilder.builder(XContentType.JSON.xContent());
     }
-
 }

--- a/src/test/java/org/opensearch/securityanalytics/action/IndexDetectorResponseTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/action/IndexDetectorResponseTests.java
@@ -1,17 +1,29 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.opensearch.securityanalytics.action;
 
-import org.junit.Assert;
 import org.opensearch.common.io.stream.BytesStreamOutput;
-import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.commons.alerting.model.CronSchedule;
+import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.securityanalytics.config.monitors.DetectorMonitorConfig;
 import org.opensearch.securityanalytics.model.Detector;
 import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Assert;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -27,32 +39,34 @@ public class IndexDetectorResponseTests extends OpenSearchTestCase {
         String cronExpression = "31 * * * *";
         Instant testInstance = Instant.ofEpochSecond(1538164858L);
 
-        CronSchedule cronSchedule = new CronSchedule(cronExpression, ZoneId.of("Asia/Kolkata"), testInstance);
+        CronSchedule cronSchedule =
+                new CronSchedule(cronExpression, ZoneId.of("Asia/Kolkata"), testInstance);
 
         String detectorType = "linux";
-        Detector detector = new Detector(
-                "123",
-                0L,
-                "test-monitor",
-                true,
-                cronSchedule,
-                Instant.now(),
-                Instant.now(),
-                detectorType,
-                randomUser(),
-                List.of(),
-                List.of(),
-                List.of("1", "2", "3"),
-                DetectorMonitorConfig.getRuleIndex("others_application"),
-                null,
-                DetectorMonitorConfig.getAlertsIndex("others_application"),
-                null,
-                null,
-                DetectorMonitorConfig.getFindingsIndex("others_application"),
-                Collections.emptyMap(),
-                Collections.emptyList(),
-                false
-        );
+        Detector detector =
+                new Detector(
+                        "123",
+                        0L,
+                        "test-monitor",
+                        true,
+                        cronSchedule,
+                        Instant.now(),
+                        Instant.now(),
+                        detectorType,
+                        randomUser(),
+                        List.of(),
+                        List.of(),
+                        List.of("1", "2", "3"),
+                        DetectorMonitorConfig.getRuleIndex("others_application"),
+                        null,
+                        DetectorMonitorConfig.getAlertsIndex("others_application"),
+                        null,
+                        null,
+                        DetectorMonitorConfig.getFindingsIndex("others_application"),
+                        Collections.emptyMap(),
+                        Collections.emptyList(),
+                        false,
+                        null);
         IndexDetectorResponse response = new IndexDetectorResponse("1234", 1L, RestStatus.OK, detector);
         Assert.assertNotNull(response);
 
@@ -66,7 +80,7 @@ public class IndexDetectorResponseTests extends OpenSearchTestCase {
         Assert.assertEquals(1L, newResponse.getVersion().longValue());
         Assert.assertEquals(RestStatus.OK, newResponse.getStatus());
         Assert.assertNotNull(newResponse.getDetector());
-        Assert.assertEquals(newResponse.getDetector().getMonitorIds().size(),3);
+        Assert.assertEquals(newResponse.getDetector().getMonitorIds().size(), 3);
         Assert.assertTrue(newResponse.getDetector().getMonitorIds().contains("1"));
         Assert.assertTrue(newResponse.getDetector().getMonitorIds().contains("2"));
         Assert.assertTrue(newResponse.getDetector().getMonitorIds().contains("3"));

--- a/src/test/java/org/opensearch/securityanalytics/alerts/AlertingServiceTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/alerts/AlertingServiceTests.java
@@ -1,22 +1,28 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.opensearch.securityanalytics.alerts;
 
-import java.time.Instant;
-import java.time.ZoneId;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import org.opensearch.core.action.ActionListener;
 import org.opensearch.commons.alerting.model.Alert;
 import org.opensearch.commons.alerting.model.CronSchedule;
 import org.opensearch.commons.alerting.model.DataSources;
 import org.opensearch.commons.alerting.model.DocumentLevelTrigger;
 import org.opensearch.commons.alerting.model.Monitor;
 import org.opensearch.commons.alerting.model.Table;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.script.Script;
 import org.opensearch.securityanalytics.action.AlertDto;
@@ -30,6 +36,11 @@ import org.opensearch.securityanalytics.transport.TransportIndexDetectorAction;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.client.Client;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -45,183 +56,203 @@ public class AlertingServiceTests extends OpenSearchTestCase {
         Client client = mock(Client.class);
         alertssService.setIndicesAdminClient(client);
         // Create fake GetDetectorResponse
-        Detector detector = new Detector(
-                "detector_id123",
-                0L,
-                "test-monitor",
-                true,
-                new CronSchedule("31 * * * *", ZoneId.of("Asia/Kolkata"), Instant.ofEpochSecond(1538164858L)),
-                Instant.now(),
-                Instant.now(),
-                "others_application",
-                null,
-                List.of(),
-                List.of(),
-                List.of("monitor_id1", "monitor_id2"),
-                DetectorMonitorConfig.getRuleIndex("others_application"),
-                null,
-                DetectorMonitorConfig.getAlertsIndex("others_application"),
-                null,
-                null,
-                DetectorMonitorConfig.getFindingsIndex("others_application"),
-                Collections.emptyMap(),
-                Collections.emptyList(),
-                false
-        );
-        GetDetectorResponse getDetectorResponse = new GetDetectorResponse("detector_id123", 1L, RestStatus.OK, detector);
+        Detector detector =
+                new Detector(
+                        "detector_id123",
+                        0L,
+                        "test-monitor",
+                        true,
+                        new CronSchedule(
+                                "31 * * * *", ZoneId.of("Asia/Kolkata"), Instant.ofEpochSecond(1538164858L)),
+                        Instant.now(),
+                        Instant.now(),
+                        "others_application",
+                        null,
+                        List.of(),
+                        List.of(),
+                        List.of("monitor_id1", "monitor_id2"),
+                        DetectorMonitorConfig.getRuleIndex("others_application"),
+                        null,
+                        DetectorMonitorConfig.getAlertsIndex("others_application"),
+                        null,
+                        null,
+                        DetectorMonitorConfig.getFindingsIndex("others_application"),
+                        Collections.emptyMap(),
+                        Collections.emptyList(),
+                        false,
+                        null);
+        GetDetectorResponse getDetectorResponse =
+                new GetDetectorResponse("detector_id123", 1L, RestStatus.OK, detector);
 
-        // Setup getDetector interceptor and return fake GetDetectorResponse by calling listener.onResponse
-        doAnswer(invocation -> {
-            ActionListener l = invocation.getArgument(2);
-            l.onResponse(getDetectorResponse);
-            return null;
-        }).when(client).execute(eq(GetDetectorAction.INSTANCE), any(GetDetectorRequest.class), any(ActionListener.class));
+        // Setup getDetector interceptor and return fake GetDetectorResponse by calling
+        // listener.onResponse
+        doAnswer(
+                        invocation -> {
+                            ActionListener l = invocation.getArgument(2);
+                            l.onResponse(getDetectorResponse);
+                            return null;
+                        })
+                .when(client)
+                .execute(
+                        eq(GetDetectorAction.INSTANCE),
+                        any(GetDetectorRequest.class),
+                        any(ActionListener.class));
 
         // Alerting GetAlertsResponse mock #1
-        Alert alert1 = new Alert(
-                "alert_id_1",
-                new Monitor(
-                        "monitor_id_1",
-                        -3,
-                        "monitor_name",
-                        true,
-                        new CronSchedule("31 * * * *", ZoneId.of("Asia/Kolkata"), Instant.ofEpochSecond(1538164858L)),
+        Alert alert1 =
+                new Alert(
+                        "alert_id_1",
+                        new Monitor(
+                                "monitor_id_1",
+                                -3,
+                                "monitor_name",
+                                true,
+                                new CronSchedule(
+                                        "31 * * * *", ZoneId.of("Asia/Kolkata"), Instant.ofEpochSecond(1538164858L)),
+                                Instant.now(),
+                                Instant.now(),
+                                Monitor.MonitorType.DOC_LEVEL_MONITOR.getValue(),
+                                null,
+                                1,
+                                List.of(),
+                                List.of(),
+                                Map.of(),
+                                new DataSources(),
+                                true,
+                                null,
+                                TransportIndexDetectorAction.PLUGIN_OWNER_FIELD),
+                        new DocumentLevelTrigger(
+                                "trigger_id_1", "my_trigger", "severity_low", List.of(), new Script("")),
+                        List.of("finding_id_1"),
+                        List.of("docId1"),
                         Instant.now(),
                         Instant.now(),
-                        Monitor.MonitorType.DOC_LEVEL_MONITOR.getValue(),
+                        Alert.State.COMPLETED,
                         null,
-                        1,
                         List.of(),
                         List.of(),
-                        Map.of(),
-                        new DataSources(),
-                        true,
+                        3,
                         null,
-                        TransportIndexDetectorAction.PLUGIN_OWNER_FIELD
-                ),
-                new DocumentLevelTrigger("trigger_id_1", "my_trigger", "severity_low", List.of(), new Script("")),
-                List.of("finding_id_1"),
-                List.of("docId1"),
-                Instant.now(),
-                Instant.now(),
-                Alert.State.COMPLETED,
-                null,
-                List.of(),
-                List.of(),
-                3,
-                null,
-                null,
-                null
-        );
+                        null,
+                        null);
 
-        Alert alert2 = new Alert(
-                "alert_id_1",
-                new Monitor(
-                        "monitor_id_1",
-                        -3,
-                        "monitor_name",
-                        true,
-                        new CronSchedule("31 * * * *", ZoneId.of("Asia/Kolkata"), Instant.ofEpochSecond(1538164858L)),
+        Alert alert2 =
+                new Alert(
+                        "alert_id_1",
+                        new Monitor(
+                                "monitor_id_1",
+                                -3,
+                                "monitor_name",
+                                true,
+                                new CronSchedule(
+                                        "31 * * * *", ZoneId.of("Asia/Kolkata"), Instant.ofEpochSecond(1538164858L)),
+                                Instant.now(),
+                                Instant.now(),
+                                Monitor.MonitorType.DOC_LEVEL_MONITOR.getValue(),
+                                null,
+                                1,
+                                List.of(),
+                                List.of(),
+                                Map.of(),
+                                new DataSources(),
+                                true,
+                                null,
+                                TransportIndexDetectorAction.PLUGIN_OWNER_FIELD),
+                        new DocumentLevelTrigger(
+                                "trigger_id_1", "my_trigger", "severity_low", List.of(), new Script("")),
+                        List.of("finding_id_1"),
+                        List.of("docId1"),
                         Instant.now(),
                         Instant.now(),
-                        Monitor.MonitorType.DOC_LEVEL_MONITOR.getValue(),
+                        Alert.State.COMPLETED,
                         null,
-                        1,
                         List.of(),
                         List.of(),
-                        Map.of(),
-                        new DataSources(),
-                        true,
+                        3,
                         null,
-                        TransportIndexDetectorAction.PLUGIN_OWNER_FIELD
-                ),
-                new DocumentLevelTrigger("trigger_id_1", "my_trigger", "severity_low", List.of(), new Script("")),
-                List.of("finding_id_1"),
-                List.of("docId1"),
-                Instant.now(),
-                Instant.now(),
-                Alert.State.COMPLETED,
-                null,
-                List.of(),
-                List.of(),
-                3,
-                null,
-                null,
-                null
-        );
+                        null,
+                        null);
 
-        GetAlertsResponse getAlertsResponse = new GetAlertsResponse(
-                List.of(new AlertDto(
-                                detector.getId(),
-                                alert1.getId(),
-                                alert1.getVersion(),
-                                alert1.getSchemaVersion(),
-                                alert1.getTriggerId(),
-                                alert1.getTriggerName(),
-                                alert1.getFindingIds(),
-                                alert1.getRelatedDocIds(),
-                                alert1.getState(),
-                                alert1.getStartTime(),
-                                alert1.getEndTime(),
-                                alert1.getLastNotificationTime(),
-                                alert1.getAcknowledgedTime(),
-                                alert1.getErrorMessage(),
-                                alert1.getErrorHistory(),
-                                alert1.getSeverity(),
-                                alert1.getActionExecutionResults(),
-                                alert1.getAggregationResultBucket()
-                        ),
-                        new AlertDto(
-                                detector.getId(),
-                                alert2.getId(),
-                                alert2.getVersion(),
-                                alert2.getSchemaVersion(),
-                                alert2.getTriggerId(),
-                                alert2.getTriggerName(),
-                                alert2.getFindingIds(),
-                                alert2.getRelatedDocIds(),
-                                alert2.getState(),
-                                alert2.getStartTime(),
-                                alert2.getEndTime(),
-                                alert2.getLastNotificationTime(),
-                                alert2.getAcknowledgedTime(),
-                                alert2.getErrorMessage(),
-                                alert2.getErrorHistory(),
-                                alert2.getSeverity(),
-                                alert2.getActionExecutionResults(),
-                                alert2.getAggregationResultBucket()
-                        )
-                ), 2
-        );
+        GetAlertsResponse getAlertsResponse =
+                new GetAlertsResponse(
+                        List.of(
+                                new AlertDto(
+                                        detector.getId(),
+                                        alert1.getId(),
+                                        alert1.getVersion(),
+                                        alert1.getSchemaVersion(),
+                                        alert1.getTriggerId(),
+                                        alert1.getTriggerName(),
+                                        alert1.getFindingIds(),
+                                        alert1.getRelatedDocIds(),
+                                        alert1.getState(),
+                                        alert1.getStartTime(),
+                                        alert1.getEndTime(),
+                                        alert1.getLastNotificationTime(),
+                                        alert1.getAcknowledgedTime(),
+                                        alert1.getErrorMessage(),
+                                        alert1.getErrorHistory(),
+                                        alert1.getSeverity(),
+                                        alert1.getActionExecutionResults(),
+                                        alert1.getAggregationResultBucket()),
+                                new AlertDto(
+                                        detector.getId(),
+                                        alert2.getId(),
+                                        alert2.getVersion(),
+                                        alert2.getSchemaVersion(),
+                                        alert2.getTriggerId(),
+                                        alert2.getTriggerName(),
+                                        alert2.getFindingIds(),
+                                        alert2.getRelatedDocIds(),
+                                        alert2.getState(),
+                                        alert2.getStartTime(),
+                                        alert2.getEndTime(),
+                                        alert2.getLastNotificationTime(),
+                                        alert2.getAcknowledgedTime(),
+                                        alert2.getErrorMessage(),
+                                        alert2.getErrorHistory(),
+                                        alert2.getSeverity(),
+                                        alert2.getActionExecutionResults(),
+                                        alert2.getAggregationResultBucket())),
+                        2);
 
-        doAnswer(invocation -> {
-            ActionListener l = invocation.getArgument(8);
-            l.onResponse(getAlertsResponse);
-            return null;
-        }).when(alertssService).getAlertsByMonitorIds(any(), any(), anyString(), any(Table.class), anyString(), anyString(), any(), any(), any(ActionListener.class));
+        doAnswer(
+                        invocation -> {
+                            ActionListener l = invocation.getArgument(8);
+                            l.onResponse(getAlertsResponse);
+                            return null;
+                        })
+                .when(alertssService)
+                .getAlertsByMonitorIds(
+                        any(),
+                        any(),
+                        anyString(),
+                        any(Table.class),
+                        anyString(),
+                        anyString(),
+                        any(),
+                        any(),
+                        any(ActionListener.class));
 
         // Call getFindingsByDetectorId
-        Table table = new Table(
-                "asc",
-                "id",
+        Table table = new Table("asc", "id", null, 100, 0, null);
+        alertssService.getAlertsByDetectorId(
+                "detector_id123",
+                table,
+                "severity_low",
+                Alert.State.COMPLETED.toString(),
                 null,
-                100,
-                0,
-                null
-        );
-        alertssService.getAlertsByDetectorId("detector_id123", table, "severity_low", Alert.State.COMPLETED.toString(), null, null,
-          new ActionListener<>() {
-            @Override
-            public void onResponse(GetAlertsResponse getAlertsResponse) {
-                assertEquals(2, (int)getAlertsResponse.getTotalAlerts());
-                assertEquals(2, getAlertsResponse.getAlerts().size());
-            }
+                null,
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(GetAlertsResponse getAlertsResponse) {
+                        assertEquals(2, (int) getAlertsResponse.getTotalAlerts());
+                        assertEquals(2, getAlertsResponse.getAlerts().size());
+                    }
 
-            @Override
-            public void onFailure(Exception e) {
-
-            }
-        });
+                    @Override
+                    public void onFailure(Exception e) {}
+                });
     }
 
     public void testGetFindings_getFindingsByMonitorIdFailures() {
@@ -230,65 +261,86 @@ public class AlertingServiceTests extends OpenSearchTestCase {
         Client client = mock(Client.class);
         alertssService.setIndicesAdminClient(client);
         // Create fake GetDetectorResponse
-        Detector detector = new Detector(
-                "detector_id123",
-                0L,
-                "test-monitor",
-                true,
-                new CronSchedule("31 * * * *", ZoneId.of("Asia/Kolkata"), Instant.ofEpochSecond(1538164858L)),
-                Instant.now(),
-                Instant.now(),
-                "others_application",
-                null,
-                List.of(),
-                List.of(),
-                List.of("monitor_id1", "monitor_id2"),
-                DetectorMonitorConfig.getRuleIndex("others_application"),
-                null,
-                DetectorMonitorConfig.getAlertsIndex("others_application"),
-                null,
-                null,
-                DetectorMonitorConfig.getFindingsIndex("others_application"),
-                Collections.emptyMap(),
-                Collections.emptyList(),
-                false
-        );
-        GetDetectorResponse getDetectorResponse = new GetDetectorResponse("detector_id123", 1L, RestStatus.OK, detector);
+        Detector detector =
+                new Detector(
+                        "detector_id123",
+                        0L,
+                        "test-monitor",
+                        true,
+                        new CronSchedule(
+                                "31 * * * *", ZoneId.of("Asia/Kolkata"), Instant.ofEpochSecond(1538164858L)),
+                        Instant.now(),
+                        Instant.now(),
+                        "others_application",
+                        null,
+                        List.of(),
+                        List.of(),
+                        List.of("monitor_id1", "monitor_id2"),
+                        DetectorMonitorConfig.getRuleIndex("others_application"),
+                        null,
+                        DetectorMonitorConfig.getAlertsIndex("others_application"),
+                        null,
+                        null,
+                        DetectorMonitorConfig.getFindingsIndex("others_application"),
+                        Collections.emptyMap(),
+                        Collections.emptyList(),
+                        false,
+                        null);
+        GetDetectorResponse getDetectorResponse =
+                new GetDetectorResponse("detector_id123", 1L, RestStatus.OK, detector);
 
-        // Setup getDetector interceptor and return fake GetDetectorResponse by calling listener.onResponse
-        doAnswer(invocation -> {
-            ActionListener l = invocation.getArgument(2);
-            l.onResponse(getDetectorResponse);
-            return null;
-        }).when(client).execute(eq(GetDetectorAction.INSTANCE), any(GetDetectorRequest.class), any(ActionListener.class));
+        // Setup getDetector interceptor and return fake GetDetectorResponse by calling
+        // listener.onResponse
+        doAnswer(
+                        invocation -> {
+                            ActionListener l = invocation.getArgument(2);
+                            l.onResponse(getDetectorResponse);
+                            return null;
+                        })
+                .when(client)
+                .execute(
+                        eq(GetDetectorAction.INSTANCE),
+                        any(GetDetectorRequest.class),
+                        any(ActionListener.class));
 
-        doAnswer(invocation -> {
-            ActionListener l = invocation.getArgument(8);
-            l.onFailure(new IllegalArgumentException("Error getting findings"));
-            return null;
-        }).when(alertssService).getAlertsByMonitorIds(any(), any(), anyString(), any(Table.class), anyString(), anyString(), any(), any(), any(ActionListener.class));
+        doAnswer(
+                        invocation -> {
+                            ActionListener l = invocation.getArgument(8);
+                            l.onFailure(new IllegalArgumentException("Error getting findings"));
+                            return null;
+                        })
+                .when(alertssService)
+                .getAlertsByMonitorIds(
+                        any(),
+                        any(),
+                        anyString(),
+                        any(Table.class),
+                        anyString(),
+                        anyString(),
+                        any(),
+                        any(),
+                        any(ActionListener.class));
 
         // Call getFindingsByDetectorId
-        Table table = new Table(
-                "asc",
-                "id",
+        Table table = new Table("asc", "id", null, 100, 0, null);
+        alertssService.getAlertsByDetectorId(
+                "detector_id123",
+                table,
+                "severity_low",
+                Alert.State.COMPLETED.toString(),
                 null,
-                100,
-                0,
-                null
-        );
-        alertssService.getAlertsByDetectorId("detector_id123", table, "severity_low", Alert.State.COMPLETED.toString(), null, null,
-          new ActionListener<>() {
-            @Override
-            public void onResponse(GetAlertsResponse getAlertsResponse) {
-                fail("this test should've failed");
-            }
+                null,
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(GetAlertsResponse getAlertsResponse) {
+                        fail("this test should've failed");
+                    }
 
-            @Override
-            public void onFailure(Exception e) {
-                assertTrue(e.getMessage().contains("Error getting findings"));
-            }
-        });
+                    @Override
+                    public void onFailure(Exception e) {
+                        assertTrue(e.getMessage().contains("Error getting findings"));
+                    }
+                });
     }
 
     public void testGetFindings_getDetectorFailure() {
@@ -298,32 +350,37 @@ public class AlertingServiceTests extends OpenSearchTestCase {
         alertssService.setIndicesAdminClient(client);
 
         // Setup getDetector interceptor and return fake expcetion by calling onFailure
-        doAnswer(invocation -> {
-            ActionListener l = invocation.getArgument(2);
-            l.onFailure(new IllegalArgumentException("GetDetector failed"));
-            return null;
-        }).when(client).execute(eq(GetDetectorAction.INSTANCE), any(GetDetectorRequest.class), any(ActionListener.class));
+        doAnswer(
+                        invocation -> {
+                            ActionListener l = invocation.getArgument(2);
+                            l.onFailure(new IllegalArgumentException("GetDetector failed"));
+                            return null;
+                        })
+                .when(client)
+                .execute(
+                        eq(GetDetectorAction.INSTANCE),
+                        any(GetDetectorRequest.class),
+                        any(ActionListener.class));
 
         // Call getFindingsByDetectorId
-        Table table = new Table(
-                "asc",
-                "id",
+        Table table = new Table("asc", "id", null, 100, 0, null);
+        alertssService.getAlertsByDetectorId(
+                "detector_id123",
+                table,
+                "severity_low",
+                Alert.State.COMPLETED.toString(),
                 null,
-                100,
-                0,
-                null
-        );
-        alertssService.getAlertsByDetectorId("detector_id123", table, "severity_low", Alert.State.COMPLETED.toString(), null, null,
-          new ActionListener<>() {
-            @Override
-            public void onResponse(GetAlertsResponse getAlertsResponse) {
-                fail("this test should've failed");
-            }
+                null,
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(GetAlertsResponse getAlertsResponse) {
+                        fail("this test should've failed");
+                    }
 
-            @Override
-            public void onFailure(Exception e) {
-                assertTrue(e.getMessage().contains("GetDetector failed"));
-            }
-        });
+                    @Override
+                    public void onFailure(Exception e) {
+                        assertTrue(e.getMessage().contains("GetDetector failed"));
+                    }
+                });
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/findings/FindingServiceTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/findings/FindingServiceTests.java
@@ -1,22 +1,27 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 package org.opensearch.securityanalytics.findings;
 
-
-import java.time.Instant;
-import java.time.ZoneId;
-import java.util.Collections;
-import java.util.List;
-
-import org.opensearch.core.action.ActionListener;
 import org.opensearch.commons.alerting.model.CronSchedule;
 import org.opensearch.commons.alerting.model.DocLevelQuery;
 import org.opensearch.commons.alerting.model.Finding;
 import org.opensearch.commons.alerting.model.FindingDocument;
 import org.opensearch.commons.alerting.model.Table;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.securityanalytics.action.FindingDto;
 import org.opensearch.securityanalytics.action.GetDetectorAction;
@@ -29,6 +34,10 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.client.Client;
 import org.opensearch.transport.client.node.NodeClient;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -36,7 +45,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 public class FindingServiceTests extends OpenSearchTestCase {
 
@@ -46,120 +54,147 @@ public class FindingServiceTests extends OpenSearchTestCase {
         NodeClient nodeClient = mock(NodeClient.class);
         findingsService.setIndicesAdminClient(client);
         // Create fake GetDetectorResponse
-        Detector detector = new Detector(
-                "detector_id123",
-                0L,
-                "test-monitor",
-                true,
-                new CronSchedule("31 * * * *", ZoneId.of("Asia/Kolkata"), Instant.ofEpochSecond(1538164858L)),
-                Instant.now(),
-                Instant.now(),
-                "others_application",
-                null,
-                List.of(),
-                List.of(),
-                List.of("monitor_id1", "monitor_id2"),
-                DetectorMonitorConfig.getRuleIndex("others_application"),
-                null,
-                DetectorMonitorConfig.getAlertsIndex("others_application"),
-                null,
-                null,
-                DetectorMonitorConfig.getFindingsIndex("others_application"),
-                Collections.emptyMap(),
-                Collections.emptyList(),
-                false
-        );
-        GetDetectorResponse getDetectorResponse = new GetDetectorResponse("detector_id123", 1L, RestStatus.OK, detector);
+        Detector detector =
+                new Detector(
+                        "detector_id123",
+                        0L,
+                        "test-monitor",
+                        true,
+                        new CronSchedule(
+                                "31 * * * *", ZoneId.of("Asia/Kolkata"), Instant.ofEpochSecond(1538164858L)),
+                        Instant.now(),
+                        Instant.now(),
+                        "others_application",
+                        null,
+                        List.of(),
+                        List.of(),
+                        List.of("monitor_id1", "monitor_id2"),
+                        DetectorMonitorConfig.getRuleIndex("others_application"),
+                        null,
+                        DetectorMonitorConfig.getAlertsIndex("others_application"),
+                        null,
+                        null,
+                        DetectorMonitorConfig.getFindingsIndex("others_application"),
+                        Collections.emptyMap(),
+                        Collections.emptyList(),
+                        false,
+                        null);
+        GetDetectorResponse getDetectorResponse =
+                new GetDetectorResponse("detector_id123", 1L, RestStatus.OK, detector);
 
-        // Setup getDetector interceptor and return fake GetDetectorResponse by calling listener.onResponse
-        doAnswer(invocation -> {
-            ActionListener l = invocation.getArgument(2);
-            l.onResponse(getDetectorResponse);
-            return null;
-        }).when(nodeClient).execute(eq(GetDetectorAction.INSTANCE), any(GetDetectorRequest.class), any(ActionListener.class));
+        // Setup getDetector interceptor and return fake GetDetectorResponse by calling
+        // listener.onResponse
+        doAnswer(
+                        invocation -> {
+                            ActionListener l = invocation.getArgument(2);
+                            l.onResponse(getDetectorResponse);
+                            return null;
+                        })
+                .when(nodeClient)
+                .execute(
+                        eq(GetDetectorAction.INSTANCE),
+                        any(GetDetectorRequest.class),
+                        any(ActionListener.class));
 
         // Alerting GetFindingsResponse mock #1
-        Finding finding1 = new Finding(
-                "1",
-                List.of("doc1", "doc2", "doc3"),
-                List.of("doc1", "doc2", "doc3"),
-                "monitor_id1",
-                "monitor_name1",
-                "test_index1",
-                List.of(new DocLevelQuery("1", "myQuery", Collections.emptyList(), "fieldA:valABC", List.of())),
-                Instant.now(),
-                "1234"
-        );
-        FindingDocument findingDocument1 = new FindingDocument("test_index1", "doc1", true, "document 1 payload");
-        FindingDocument findingDocument2 = new FindingDocument("test_index1", "doc2", true, "document 2 payload");
-        FindingDocument findingDocument3 = new FindingDocument("test_index1", "doc3", true, "document 3 payload");
+        Finding finding1 =
+                new Finding(
+                        "1",
+                        List.of("doc1", "doc2", "doc3"),
+                        List.of("doc1", "doc2", "doc3"),
+                        "monitor_id1",
+                        "monitor_name1",
+                        "test_index1",
+                        List.of(
+                                new DocLevelQuery(
+                                        "1", "myQuery", Collections.emptyList(), "fieldA:valABC", List.of())),
+                        Instant.now(),
+                        "1234");
+        FindingDocument findingDocument1 =
+                new FindingDocument("test_index1", "doc1", true, "document 1 payload");
+        FindingDocument findingDocument2 =
+                new FindingDocument("test_index1", "doc2", true, "document 2 payload");
+        FindingDocument findingDocument3 =
+                new FindingDocument("test_index1", "doc3", true, "document 3 payload");
 
         // Alerting GetFindingsResponse mock #2
-        Finding finding2 = new Finding(
-                "1",
-                List.of("doc21", "doc22"),
-                List.of("doc21", "doc22"),
-                "monitor_id2",
-                "monitor_name2",
-                "test_index2",
-                List.of(new DocLevelQuery("1", "myQuery", Collections.emptyList(), "fieldA:valABC", List.of())),
-                Instant.now(),
-                "1234"
-        );
-        FindingDocument findingDocument21 = new FindingDocument("test_index2", "doc21", true, "document 21 payload");
-        FindingDocument findingDocument22 = new FindingDocument("test_index2", "doc22", true, "document 22 payload");
+        Finding finding2 =
+                new Finding(
+                        "1",
+                        List.of("doc21", "doc22"),
+                        List.of("doc21", "doc22"),
+                        "monitor_id2",
+                        "monitor_name2",
+                        "test_index2",
+                        List.of(
+                                new DocLevelQuery(
+                                        "1", "myQuery", Collections.emptyList(), "fieldA:valABC", List.of())),
+                        Instant.now(),
+                        "1234");
+        FindingDocument findingDocument21 =
+                new FindingDocument("test_index2", "doc21", true, "document 21 payload");
+        FindingDocument findingDocument22 =
+                new FindingDocument("test_index2", "doc22", true, "document 22 payload");
 
         GetFindingsResponse getFindingsResponse =
                 new GetFindingsResponse(
                         2,
                         List.of(
-                            new FindingDto(
-                                detector.getId(),
-                                finding1.getId(),
-                                finding1.getRelatedDocIds(),
-                                finding1.getIndex(),
-                                finding1.getDocLevelQueries(),
-                                finding1.getTimestamp(),
-                                List.of(findingDocument1, findingDocument2, findingDocument3)
-                            ),
-                            new FindingDto(
-                                    detector.getId(),
-                                    finding2.getId(),
-                                    finding2.getRelatedDocIds(),
-                                    finding2.getIndex(),
-                                    finding2.getDocLevelQueries(),
-                                    finding2.getTimestamp(),
-                                    List.of(findingDocument1, findingDocument2, findingDocument3)
-                            )
-                        )
-                );
-        doAnswer(invocation -> {
-            ActionListener l = invocation.getArgument(4);
-            l.onResponse(getFindingsResponse);
-            return null;
-        }).when(findingsService).getFindingsByMonitorIds(any(), any(), anyString(), any(Table.class), anyString(), anyString(), any(), any(), any(), any(ActionListener.class));
+                                new FindingDto(
+                                        detector.getId(),
+                                        finding1.getId(),
+                                        finding1.getRelatedDocIds(),
+                                        finding1.getIndex(),
+                                        finding1.getDocLevelQueries(),
+                                        finding1.getTimestamp(),
+                                        List.of(findingDocument1, findingDocument2, findingDocument3)),
+                                new FindingDto(
+                                        detector.getId(),
+                                        finding2.getId(),
+                                        finding2.getRelatedDocIds(),
+                                        finding2.getIndex(),
+                                        finding2.getDocLevelQueries(),
+                                        finding2.getTimestamp(),
+                                        List.of(findingDocument1, findingDocument2, findingDocument3))));
+        doAnswer(
+                        invocation -> {
+                            ActionListener l = invocation.getArgument(4);
+                            l.onResponse(getFindingsResponse);
+                            return null;
+                        })
+                .when(findingsService)
+                .getFindingsByMonitorIds(
+                        any(),
+                        any(),
+                        anyString(),
+                        any(Table.class),
+                        anyString(),
+                        anyString(),
+                        any(),
+                        any(),
+                        any(),
+                        any(ActionListener.class));
 
         // Call getFindingsByDetectorId
-        Table table = new Table(
-            "asc",
-            "id",
-            null,
-            100,
-            0,
-            null
-        );
-        findingsService.getFindingsByDetectorId("detector_id123", table, null, null, null, null, null, new ActionListener<>() {
-            @Override
-            public void onResponse(GetFindingsResponse getFindingsResponse) {
-                assertEquals(2, (int)getFindingsResponse.getTotalFindings());
-                assertEquals(2, getFindingsResponse.getFindings().size());
-            }
+        Table table = new Table("asc", "id", null, 100, 0, null);
+        findingsService.getFindingsByDetectorId(
+                "detector_id123",
+                table,
+                null,
+                null,
+                null,
+                null,
+                null,
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(GetFindingsResponse getFindingsResponse) {
+                        assertEquals(2, (int) getFindingsResponse.getTotalFindings());
+                        assertEquals(2, getFindingsResponse.getFindings().size());
+                    }
 
-            @Override
-            public void onFailure(Exception e) {
-
-            }
-        });
+                    @Override
+                    public void onFailure(Exception e) {}
+                });
     }
 
     public void testGetFindings_getFindingsByMonitorIdFailure() {
@@ -170,64 +205,88 @@ public class FindingServiceTests extends OpenSearchTestCase {
         // Mocking a NodeClient instance
         NodeClient nodeClient = mock(NodeClient.class);
         // Create fake GetDetectorResponse
-        Detector detector = new Detector(
-                "detector_id123",
-                0L,
-                "test-monitor",
-                true,
-                new CronSchedule("31 * * * *", ZoneId.of("Asia/Kolkata"), Instant.ofEpochSecond(1538164858L)),
-                Instant.now(),
-                Instant.now(),
-                "others_application",
-                null,
-                List.of(),
-                List.of(),
-                List.of("monitor_id1", "monitor_id2"),
-                DetectorMonitorConfig.getRuleIndex("others_application"),
-                null,
-                DetectorMonitorConfig.getAlertsIndex("others_application"),
-                null,
-                null,
-                DetectorMonitorConfig.getFindingsIndex("others_application"),
-                Collections.emptyMap(),
-                Collections.emptyList(),
-                false
-        );
-        GetDetectorResponse getDetectorResponse = new GetDetectorResponse("detector_id123", 1L, RestStatus.OK, detector);
+        Detector detector =
+                new Detector(
+                        "detector_id123",
+                        0L,
+                        "test-monitor",
+                        true,
+                        new CronSchedule(
+                                "31 * * * *", ZoneId.of("Asia/Kolkata"), Instant.ofEpochSecond(1538164858L)),
+                        Instant.now(),
+                        Instant.now(),
+                        "others_application",
+                        null,
+                        List.of(),
+                        List.of(),
+                        List.of("monitor_id1", "monitor_id2"),
+                        DetectorMonitorConfig.getRuleIndex("others_application"),
+                        null,
+                        DetectorMonitorConfig.getAlertsIndex("others_application"),
+                        null,
+                        null,
+                        DetectorMonitorConfig.getFindingsIndex("others_application"),
+                        Collections.emptyMap(),
+                        Collections.emptyList(),
+                        false,
+                        null);
+        GetDetectorResponse getDetectorResponse =
+                new GetDetectorResponse("detector_id123", 1L, RestStatus.OK, detector);
 
-        // Setup getDetector interceptor and return fake GetDetectorResponse by calling listener.onResponse
-        doAnswer(invocation -> {
-            ActionListener l = invocation.getArgument(2);
-            l.onResponse(getDetectorResponse);
-            return null;
-        }).when(nodeClient).execute(eq(GetDetectorAction.INSTANCE), any(GetDetectorRequest.class), any(ActionListener.class));
+        // Setup getDetector interceptor and return fake GetDetectorResponse by calling
+        // listener.onResponse
+        doAnswer(
+                        invocation -> {
+                            ActionListener l = invocation.getArgument(2);
+                            l.onResponse(getDetectorResponse);
+                            return null;
+                        })
+                .when(nodeClient)
+                .execute(
+                        eq(GetDetectorAction.INSTANCE),
+                        any(GetDetectorRequest.class),
+                        any(ActionListener.class));
 
-        doAnswer(invocation -> {
-            ActionListener l = invocation.getArgument(4);
-            l.onFailure(new IllegalArgumentException("Error getting findings"));
-            return null;
-        }).when(findingsService).getFindingsByMonitorIds(any(), any(), anyString(), any(Table.class), anyString(), anyString(), any(), any(), any(), any(ActionListener.class));
+        doAnswer(
+                        invocation -> {
+                            ActionListener l = invocation.getArgument(4);
+                            l.onFailure(new IllegalArgumentException("Error getting findings"));
+                            return null;
+                        })
+                .when(findingsService)
+                .getFindingsByMonitorIds(
+                        any(),
+                        any(),
+                        anyString(),
+                        any(Table.class),
+                        anyString(),
+                        anyString(),
+                        any(),
+                        any(),
+                        any(),
+                        any(ActionListener.class));
 
         // Call getFindingsByDetectorId
-        Table table = new Table(
-                "asc",
-                "id",
+        Table table = new Table("asc", "id", null, 100, 0, null);
+        findingsService.getFindingsByDetectorId(
+                "detector_id123",
+                table,
                 null,
-                100,
-                0,
-                null
-        );
-        findingsService.getFindingsByDetectorId("detector_id123", table, null, null, null, null, null, new ActionListener<>() {
-            @Override
-            public void onResponse(GetFindingsResponse getFindingsResponse) {
-                fail("this test should've failed");
-            }
+                null,
+                null,
+                null,
+                null,
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(GetFindingsResponse getFindingsResponse) {
+                        fail("this test should've failed");
+                    }
 
-            @Override
-            public void onFailure(Exception e) {
-                assertTrue(e.getMessage().contains("Error getting findings"));
-            }
-        });
+                    @Override
+                    public void onFailure(Exception e) {
+                        assertTrue(e.getMessage().contains("Error getting findings"));
+                    }
+                });
     }
 
     public void testGetFindings_getDetectorFailure() {
@@ -237,31 +296,38 @@ public class FindingServiceTests extends OpenSearchTestCase {
         findingsService.setIndicesAdminClient(client);
 
         // Setup getDetector interceptor and return fake expcetion by calling onFailure
-        doAnswer(invocation -> {
-            ActionListener l = invocation.getArgument(2);
-            l.onFailure(new IllegalArgumentException("GetDetector failed"));
-            return null;
-        }).when(client).execute(eq(GetDetectorAction.INSTANCE), any(GetDetectorRequest.class), any(ActionListener.class));
+        doAnswer(
+                        invocation -> {
+                            ActionListener l = invocation.getArgument(2);
+                            l.onFailure(new IllegalArgumentException("GetDetector failed"));
+                            return null;
+                        })
+                .when(client)
+                .execute(
+                        eq(GetDetectorAction.INSTANCE),
+                        any(GetDetectorRequest.class),
+                        any(ActionListener.class));
 
         // Call getFindingsByDetectorId
-        Table table = new Table(
-                "asc",
-                "id",
+        Table table = new Table("asc", "id", null, 100, 0, null);
+        findingsService.getFindingsByDetectorId(
+                "detector_id123",
+                table,
                 null,
-                100,
-                0,
-                null
-        );
-        findingsService.getFindingsByDetectorId("detector_id123", table, null, null, null, null, null, new ActionListener<>() {
-            @Override
-            public void onResponse(GetFindingsResponse getFindingsResponse) {
-                fail("this test should've failed");
-            }
+                null,
+                null,
+                null,
+                null,
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(GetFindingsResponse getFindingsResponse) {
+                        fail("this test should've failed");
+                    }
 
-            @Override
-            public void onFailure(Exception e) {
-                assertTrue(e.getMessage().contains("GetDetector failed"));
-            }
-        });
+                    @Override
+                    public void onFailure(Exception e) {
+                        assertTrue(e.getMessage().contains("GetDetector failed"));
+                    }
+                });
     }
 }


### PR DESCRIPTION
### Description
This PR disables the modification of standard space threat detectors, just allowing to enable and disable them

In order to do this I have:
- Add a new header: `_wazuh_internal_caller: "content-manager"` so we can distinguish detectors created by content manager (Standard space) from user created detectors
- Now the detectors are created with a field `"source"` that is either `"Sigma"` or `"Custom"` so we can differentiate how to modify them

## Validation
https://github.com/wazuh/wazuh-indexer-security-analytics/issues/112#issuecomment-4250804989

### Related Issues
Resolves #112 
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
