### PR TITLE
Validate single rule space per detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Create new Rule Testing action [(#96)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/96)
 - Add --set-as-main flag support to repository bumper [(#90)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/90)
 - Add Wazuh Alerting plugin to the build process [(#114)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/114)
+- Validate single rule space per detector [(#130)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/130)
 
 ### Dependencies
 - Update to JDK 25 [(#49)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/49)

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -147,6 +147,19 @@ public class TransportIndexDetectorAction
     public static final String TIMESTAMP_FIELD_ALIAS = "timestamp";
     public static final String CHAINED_FINDINGS_MONITOR_STRING = "chained_findings_monitor";
 
+    static String validateSingleRuleSpace(Detector detector) {
+        if (detector.getInputs().isEmpty()) {
+            return null;
+        }
+        DetectorInput input = detector.getInputs().get(0);
+        List<DetectorRule> prePackaged = input.getPrePackagedRules();
+        List<DetectorRule> custom = input.getCustomRules();
+        if (prePackaged != null && !prePackaged.isEmpty() && custom != null && !custom.isEmpty()) {
+            return "Detector cannot have both prepackaged and custom rules. Use only one type.";
+        }
+        return null;
+    }
+
     private final Client client;
 
     private final NamedXContentRegistry xContentRegistry;
@@ -1645,6 +1658,11 @@ public class TransportIndexDetectorAction
 
             if (!detector.getInputs().isEmpty()) {
                 try {
+                    String spaceError = validateSingleRuleSpace(detector);
+                    if (spaceError != null) {
+                        onFailures(new OpenSearchStatusException(spaceError, RestStatus.BAD_REQUEST));
+                        return;
+                    }
                     log.debug("init rule index template");
                     ruleTopicIndices.initRuleTopicIndexTemplate(
                             new ActionListener<>() {
@@ -1785,6 +1803,11 @@ public class TransportIndexDetectorAction
 
             if (!detector.getInputs().isEmpty()) {
                 try {
+                    String spaceError = validateSingleRuleSpace(detector);
+                    if (spaceError != null) {
+                        onFailures(new OpenSearchStatusException(spaceError, RestStatus.BAD_REQUEST));
+                        return;
+                    }
                     ruleTopicIndices.initRuleTopicIndexTemplate(
                             new ActionListener<>() {
                                 @Override
@@ -1967,6 +1990,12 @@ public class TransportIndexDetectorAction
             final String ruleTopic = detector.getDetectorType();
             final DetectorInput detectorInput = detector.getInputs().get(0);
             final String logIndex = detectorInput.getIndices().get(0);
+
+            String spaceError = validateSingleRuleSpace(detector);
+            if (spaceError != null) {
+                onFailures(new OpenSearchStatusException(spaceError, RestStatus.BAD_REQUEST));
+                return;
+            }
 
             List<String> ruleIds =
                     detectorInput.getPrePackagedRules().stream()

--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorAction.java
@@ -42,6 +42,7 @@ import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -210,6 +211,7 @@ public class WTransportIndexDetectorAction
                     public void onResponse(SearchResponse response) {
                         List<String> invalidSpaceRules = new ArrayList<>();
                         Set<String> foundRuleIds = new HashSet<>();
+                        Map<String, String> ruleWorldMap = new HashMap<>();
 
                         for (var hit : response.getHits().getHits()) {
                             Map<String, Object> sourceMap = hit.getSourceAsMap();
@@ -232,6 +234,8 @@ public class WTransportIndexDetectorAction
                             if ("draft".equalsIgnoreCase(spaceSource) || "test".equalsIgnoreCase(spaceSource)) {
                                 invalidSpaceRules.add(docId);
                             }
+
+                            ruleWorldMap.put(docId, classifyRuleWorld(spaceSource));
                         }
 
                         List<String> missingRules = new ArrayList<>();
@@ -253,6 +257,14 @@ public class WTransportIndexDetectorAction
                                             request.getLogTypeName(), invalidSpaceRules);
                             log.warn(errorMsg);
                             listener.onFailure(new OpenSearchStatusException(errorMsg, RestStatus.BAD_REQUEST));
+                            return;
+                        }
+
+                        String worldError =
+                                validateRuleWorlds(ruleWorldMap, validRulesToKeep, request.getLogTypeName());
+                        if (worldError != null) {
+                            log.warn(worldError);
+                            listener.onFailure(new OpenSearchStatusException(worldError, RestStatus.BAD_REQUEST));
                             return;
                         }
 
@@ -331,5 +343,42 @@ public class WTransportIndexDetectorAction
                         listener.onFailure(e);
                     }
                 });
+    }
+
+    /**
+     * Classifies a rule's space into a "world": either "Standard" (Sigma/CTI upstream) or "User"
+     * (Draft, Test, Custom — user-managed content).
+     *
+     * @param space the rule's space value (may be null)
+     * @return "Standard" if space is null or "Sigma", otherwise "User"
+     */
+    static String classifyRuleWorld(String space) {
+        return (space == null || "Sigma".equalsIgnoreCase(space)) ? "Standard" : "User";
+    }
+
+    /**
+     * Validates that all rules in the given list belong to the same world.
+     *
+     * @param ruleWorldMap mapping from rule document.id to its world ("Standard" or "User")
+     * @param ruleIds the list of rule IDs to validate
+     * @param logTypeName the log type name, used in the error message
+     * @return an error message if rules span multiple worlds, or null if valid
+     */
+    static String validateRuleWorlds(
+            Map<String, String> ruleWorldMap, List<String> ruleIds, String logTypeName) {
+        Set<String> detectedWorlds = new HashSet<>();
+        for (String ruleId : ruleIds) {
+            String world = ruleWorldMap.get(ruleId);
+            if (world != null) {
+                detectedWorlds.add(world);
+            }
+        }
+        if (detectedWorlds.size() > 1) {
+            return String.format(
+                    "Cannot create [%s] detector. Rules must belong to a single space type "
+                            + "(standard or custom), but found both.",
+                    logTypeName);
+        }
+        return null;
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorAction.java
@@ -42,7 +42,6 @@ import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -211,64 +210,48 @@ public class WTransportIndexDetectorAction
                 searchRequest,
                 new ActionListener<SearchResponse>() {
                     @Override
+                    @SuppressWarnings("unchecked")
                     public void onResponse(SearchResponse response) {
-                        List<String> invalidSpaceRules = new ArrayList<>();
-                        Set<String> foundRuleIds = new HashSet<>();
-                        Map<String, String> ruleWorldMap = new HashMap<>();
-
+                        // Extract hit metadata into RuleHit objects
+                        List<RuleHit> ruleHits = new ArrayList<>();
                         for (var hit : response.getHits().getHits()) {
                             Map<String, Object> sourceMap = hit.getSourceAsMap();
                             Map<String, Object> ruleMap = (Map<String, Object>) sourceMap.get("rule");
 
                             String docId = null;
-                            String spaceSource = null;
+                            String space = null;
 
                             if (ruleMap != null) {
                                 docId = (String) ruleMap.get("document.id");
-                                spaceSource = (String) ruleMap.get("space");
+                                space = (String) ruleMap.get("space");
                             }
 
                             if (docId == null) {
                                 docId = hit.getId();
                             }
 
-                            foundRuleIds.add(docId);
+                            ruleHits.add(new RuleHit(hit.getIndex(), docId, space));
+                        }
 
-                            if ("draft".equalsIgnoreCase(spaceSource) || "test".equalsIgnoreCase(spaceSource)) {
-                                invalidSpaceRules.add(docId);
-                            }
-
-                            ruleWorldMap.put(docId, classifyRuleWorld(spaceSource));
+                        // Classify and validate
+                        RuleClassificationResult result = classifyRuleHits(ruleHits);
+                        String validationError = validateClassificationResult(result, request.getLogTypeName());
+                        if (validationError != null) {
+                            log.warn(validationError);
+                            listener.onFailure(
+                                    new OpenSearchStatusException(validationError, RestStatus.BAD_REQUEST));
+                            return;
                         }
 
                         List<String> missingRules = new ArrayList<>();
                         List<String> validRulesToKeep = new ArrayList<>();
 
-                        // Filter rules: track missing, and collect only the valid ones
                         for (String expectedId : expectedRuleIds) {
-                            if (!foundRuleIds.contains(expectedId)) {
+                            if (!result.foundRuleIds.contains(expectedId)) {
                                 missingRules.add(expectedId);
-                            } else if (!invalidSpaceRules.contains(expectedId)) {
+                            } else {
                                 validRulesToKeep.add(expectedId);
                             }
-                        }
-
-                        if (!invalidSpaceRules.isEmpty()) {
-                            String errorMsg =
-                                    String.format(
-                                            "Cannot create [%s] detector. Rules %s are in draft/test space.",
-                                            request.getLogTypeName(), invalidSpaceRules);
-                            log.warn(errorMsg);
-                            listener.onFailure(new OpenSearchStatusException(errorMsg, RestStatus.BAD_REQUEST));
-                            return;
-                        }
-
-                        String worldError =
-                                validateRuleWorlds(ruleWorldMap, validRulesToKeep, request.getLogTypeName());
-                        if (worldError != null) {
-                            log.warn(worldError);
-                            listener.onFailure(new OpenSearchStatusException(worldError, RestStatus.BAD_REQUEST));
-                            return;
                         }
 
                         if (!missingRules.isEmpty()) {
@@ -279,15 +262,16 @@ public class WTransportIndexDetectorAction
                         }
 
                         log.debug(
-                                "Rule validation for [{}]: expected={}, found={}, valid={}, missing={}, invalidSpace={}",
+                                "Rule validation for [{}]: expected={}, found={}, valid={}, missing={}, "
+                                        + "prePackaged={}, custom={}",
                                 request.getLogTypeName(),
                                 expectedRuleIds.size(),
-                                foundRuleIds.size(),
+                                result.foundRuleIds.size(),
                                 validRulesToKeep.size(),
                                 missingRules.size(),
-                                invalidSpaceRules.size());
+                                result.prePackagedRuleIds.size(),
+                                result.customRuleIds.size());
 
-                        // Proceed to creation with ONLY the valid, existing rules
                         WTransportIndexDetectorAction.this.executeDetectorCreation(
                                 request, listener, validRulesToKeep);
                     }
@@ -314,6 +298,93 @@ public class WTransportIndexDetectorAction
      *     completion
      * @param validRuleIds the sanitized list of valid rule IDs to associate with the detector
      */
+    /** Result of classifying a set of rule search hits by index origin and space. */
+    static class RuleClassificationResult {
+        final Set<String> prePackagedRuleIds;
+        final Set<String> customRuleIds;
+        final List<String> invalidCustomRules;
+        final Set<String> foundRuleIds;
+
+        RuleClassificationResult(
+                Set<String> prePackagedRuleIds,
+                Set<String> customRuleIds,
+                List<String> invalidCustomRules,
+                Set<String> foundRuleIds) {
+            this.prePackagedRuleIds = prePackagedRuleIds;
+            this.customRuleIds = customRuleIds;
+            this.invalidCustomRules = invalidCustomRules;
+            this.foundRuleIds = foundRuleIds;
+        }
+    }
+
+    /**
+     * Classifies rule hits by their source index and space field.
+     *
+     * <p>Rules from the pre-packaged index are accepted as-is. Rules from the custom index must have
+     * {@code space} equal to "Custom" (case-insensitive); otherwise they are flagged as invalid.
+     *
+     * @param hits list of (index, docId, space) tuples representing search hits
+     * @return classification result with sets of pre-packaged, custom, invalid, and found rule IDs
+     */
+    static RuleClassificationResult classifyRuleHits(List<RuleHit> hits) {
+        Set<String> prePackagedRuleIds = new HashSet<>();
+        Set<String> customRuleIds = new HashSet<>();
+        List<String> invalidCustomRules = new ArrayList<>();
+        Set<String> foundRuleIds = new HashSet<>();
+
+        for (RuleHit hit : hits) {
+            foundRuleIds.add(hit.docId);
+
+            if (Rule.PRE_PACKAGED_RULES_INDEX.equals(hit.index)) {
+                prePackagedRuleIds.add(hit.docId);
+            } else {
+                if ("Custom".equalsIgnoreCase(hit.space)) {
+                    customRuleIds.add(hit.docId);
+                } else {
+                    invalidCustomRules.add(hit.docId);
+                }
+            }
+        }
+
+        return new RuleClassificationResult(
+                prePackagedRuleIds, customRuleIds, invalidCustomRules, foundRuleIds);
+    }
+
+    /**
+     * Validates the classification result, returning an error message or null if valid.
+     *
+     * @param result the classification result
+     * @param logTypeName the log type name, used in the error message
+     * @return an error message string if validation fails, or null if valid
+     */
+    static String validateClassificationResult(RuleClassificationResult result, String logTypeName) {
+        if (!result.invalidCustomRules.isEmpty()) {
+            return String.format(
+                    "Cannot create [%s] detector. Custom rules %s are not in \"Custom\" space.",
+                    logTypeName, result.invalidCustomRules);
+        }
+        if (!result.prePackagedRuleIds.isEmpty() && !result.customRuleIds.isEmpty()) {
+            return String.format(
+                    "Cannot create [%s] detector. Rules must be either all "
+                            + "pre-packaged or all custom, but found both.",
+                    logTypeName);
+        }
+        return null;
+    }
+
+    /** Simple holder for the fields extracted from a rule search hit. */
+    static class RuleHit {
+        final String index;
+        final String docId;
+        final String space;
+
+        RuleHit(String index, String docId, String space) {
+            this.index = index;
+            this.docId = docId;
+            this.space = space;
+        }
+    }
+
     private void executeDetectorCreation(
             WIndexDetectorRequest request,
             ActionListener<WIndexDetectorResponse> listener,
@@ -356,42 +427,5 @@ public class WTransportIndexDetectorAction
                         listener.onFailure(e);
                     }
                 });
-    }
-
-    /**
-     * Classifies a rule's space into a "world": either "Standard" (Sigma/CTI upstream) or "User"
-     * (Draft, Test, Custom — user-managed content).
-     *
-     * @param space the rule's space value (may be null)
-     * @return "Standard" if space is null or "Sigma", otherwise "User"
-     */
-    static String classifyRuleWorld(String space) {
-        return (space == null || "Sigma".equalsIgnoreCase(space)) ? "Standard" : "User";
-    }
-
-    /**
-     * Validates that all rules in the given list belong to the same world.
-     *
-     * @param ruleWorldMap mapping from rule document.id to its world ("Standard" or "User")
-     * @param ruleIds the list of rule IDs to validate
-     * @param logTypeName the log type name, used in the error message
-     * @return an error message if rules span multiple worlds, or null if valid
-     */
-    static String validateRuleWorlds(
-            Map<String, String> ruleWorldMap, List<String> ruleIds, String logTypeName) {
-        Set<String> detectedWorlds = new HashSet<>();
-        for (String ruleId : ruleIds) {
-            String world = ruleWorldMap.get(ruleId);
-            if (world != null) {
-                detectedWorlds.add(world);
-            }
-        }
-        if (detectedWorlds.size() > 1) {
-            return String.format(
-                    "Cannot create [%s] detector. Rules must belong to a single space type "
-                            + "(standard or custom), but found both.",
-                    logTypeName);
-        }
-        return null;
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorActionTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorActionTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opensearch.securityanalytics.transport;
+
+import org.opensearch.securityanalytics.model.Detector;
+import org.opensearch.securityanalytics.model.DetectorInput;
+import org.opensearch.securityanalytics.model.DetectorRule;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.opensearch.securityanalytics.TestHelpers.randomDetectorWithInputs;
+
+public class TransportIndexDetectorActionTests extends OpenSearchTestCase {
+
+    public void testValidateSingleRuleSpace_onlyPrePackaged_returnsNull() {
+        List<DetectorRule> prePackaged =
+                List.of(new DetectorRule("rule-1"), new DetectorRule("rule-2"));
+        DetectorInput input =
+                new DetectorInput("test", List.of("index-1"), Collections.emptyList(), prePackaged);
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        assertNull(TransportIndexDetectorAction.validateSingleRuleSpace(detector));
+    }
+
+    public void testValidateSingleRuleSpace_onlyCustom_returnsNull() {
+        List<DetectorRule> custom = List.of(new DetectorRule("rule-1"), new DetectorRule("rule-2"));
+        DetectorInput input =
+                new DetectorInput("test", List.of("index-1"), custom, Collections.emptyList());
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        assertNull(TransportIndexDetectorAction.validateSingleRuleSpace(detector));
+    }
+
+    public void testValidateSingleRuleSpace_bothTypes_returnsError() {
+        List<DetectorRule> prePackaged = List.of(new DetectorRule("std-rule-1"));
+        List<DetectorRule> custom = List.of(new DetectorRule("custom-rule-1"));
+        DetectorInput input = new DetectorInput("test", List.of("index-1"), custom, prePackaged);
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        String error = TransportIndexDetectorAction.validateSingleRuleSpace(detector);
+        assertNotNull(error);
+        assertTrue(error.contains("both prepackaged and custom rules"));
+    }
+
+    public void testValidateSingleRuleSpace_emptyRules_returnsNull() {
+        DetectorInput input =
+                new DetectorInput(
+                        "test", List.of("index-1"), Collections.emptyList(), Collections.emptyList());
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        assertNull(TransportIndexDetectorAction.validateSingleRuleSpace(detector));
+    }
+
+    public void testValidateSingleRuleSpace_nullRuleLists_returnsNull() {
+        DetectorInput input = new DetectorInput("test", List.of("index-1"), null, null);
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        assertNull(TransportIndexDetectorAction.validateSingleRuleSpace(detector));
+    }
+}

--- a/src/test/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorActionTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorActionTests.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opensearch.securityanalytics.transport;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class WTransportIndexDetectorActionTests extends OpenSearchTestCase {
+
+    public void testClassifyRuleWorld_nullSpace_returnsStandard() {
+        assertEquals("Standard", WTransportIndexDetectorAction.classifyRuleWorld(null));
+    }
+
+    public void testClassifyRuleWorld_sigmaSpace_returnsStandard() {
+        assertEquals("Standard", WTransportIndexDetectorAction.classifyRuleWorld("Sigma"));
+    }
+
+    public void testClassifyRuleWorld_sigmaCaseInsensitive_returnsStandard() {
+        assertEquals("Standard", WTransportIndexDetectorAction.classifyRuleWorld("sigma"));
+        assertEquals("Standard", WTransportIndexDetectorAction.classifyRuleWorld("SIGMA"));
+    }
+
+    public void testClassifyRuleWorld_draftSpace_returnsUser() {
+        assertEquals("User", WTransportIndexDetectorAction.classifyRuleWorld("Draft"));
+    }
+
+    public void testClassifyRuleWorld_testSpace_returnsUser() {
+        assertEquals("User", WTransportIndexDetectorAction.classifyRuleWorld("Test"));
+    }
+
+    public void testClassifyRuleWorld_customSpace_returnsUser() {
+        assertEquals("User", WTransportIndexDetectorAction.classifyRuleWorld("Custom"));
+    }
+
+    public void testClassifyRuleWorld_unknownSpace_returnsUser() {
+        assertEquals("User", WTransportIndexDetectorAction.classifyRuleWorld("SomeOtherSpace"));
+    }
+
+    public void testClassifyRuleWorld_emptyString_returnsUser() {
+        assertEquals("User", WTransportIndexDetectorAction.classifyRuleWorld(""));
+    }
+
+    public void testValidateRuleWorlds_allStandard_returnsNull() {
+        Map<String, String> worldMap = new HashMap<>();
+        worldMap.put("rule-1", "Standard");
+        worldMap.put("rule-2", "Standard");
+
+        assertNull(
+                WTransportIndexDetectorAction.validateRuleWorlds(
+                        worldMap, List.of("rule-1", "rule-2"), "test-log-type"));
+    }
+
+    public void testValidateRuleWorlds_allUser_returnsNull() {
+        Map<String, String> worldMap = new HashMap<>();
+        worldMap.put("rule-1", "User");
+        worldMap.put("rule-2", "User");
+
+        assertNull(
+                WTransportIndexDetectorAction.validateRuleWorlds(
+                        worldMap, List.of("rule-1", "rule-2"), "test-log-type"));
+    }
+
+    public void testValidateRuleWorlds_mixedWorlds_returnsError() {
+        Map<String, String> worldMap = new HashMap<>();
+        worldMap.put("rule-standard", "Standard");
+        worldMap.put("rule-user", "User");
+
+        String error =
+                WTransportIndexDetectorAction.validateRuleWorlds(
+                        worldMap, List.of("rule-standard", "rule-user"), "my-integration");
+
+        assertNotNull(error);
+        assertTrue(error.contains("my-integration"));
+        assertTrue(error.contains("standard or custom"));
+    }
+
+    public void testValidateRuleWorlds_singleRule_standard_returnsNull() {
+        Map<String, String> worldMap = new HashMap<>();
+        worldMap.put("only-rule", "Standard");
+
+        assertNull(
+                WTransportIndexDetectorAction.validateRuleWorlds(
+                        worldMap, List.of("only-rule"), "test-log-type"));
+    }
+
+    public void testValidateRuleWorlds_singleRule_user_returnsNull() {
+        Map<String, String> worldMap = new HashMap<>();
+        worldMap.put("only-rule", "User");
+
+        assertNull(
+                WTransportIndexDetectorAction.validateRuleWorlds(
+                        worldMap, List.of("only-rule"), "test-log-type"));
+    }
+
+    public void testValidateRuleWorlds_emptyRuleList_returnsNull() {
+        Map<String, String> worldMap = new HashMap<>();
+        worldMap.put("rule-1", "Standard");
+
+        assertNull(
+                WTransportIndexDetectorAction.validateRuleWorlds(worldMap, List.of(), "test-log-type"));
+    }
+
+    public void testValidateRuleWorlds_ruleNotInMap_ignored() {
+        Map<String, String> worldMap = new HashMap<>();
+        worldMap.put("rule-1", "Standard");
+
+        assertNull(
+                WTransportIndexDetectorAction.validateRuleWorlds(
+                        worldMap, List.of("rule-1", "rule-2"), "test-log-type"));
+    }
+
+    public void testValidateRuleWorlds_multipleStandardWithMissingRules_returnsNull() {
+        Map<String, String> worldMap = new HashMap<>();
+        worldMap.put("rule-a", "Standard");
+        worldMap.put("rule-b", "Standard");
+
+        assertNull(
+                WTransportIndexDetectorAction.validateRuleWorlds(
+                        worldMap, List.of("rule-a", "rule-b", "rule-missing"), "test-log-type"));
+    }
+
+    public void testValidateRuleWorlds_mixedWithMissing_returnsError() {
+        Map<String, String> worldMap = new HashMap<>();
+        worldMap.put("rule-std", "Standard");
+        worldMap.put("rule-usr", "User");
+
+        String error =
+                WTransportIndexDetectorAction.validateRuleWorlds(
+                        worldMap, List.of("rule-std", "rule-usr", "rule-missing"), "mixed-int");
+
+        assertNotNull(error);
+        assertTrue(error.contains("mixed-int"));
+    }
+
+    public void testValidateRuleWorlds_noRulesFoundInMap_returnsNull() {
+        Map<String, String> worldMap = new HashMap<>();
+        worldMap.put("other-rule", "Standard");
+
+        assertNull(
+                WTransportIndexDetectorAction.validateRuleWorlds(
+                        worldMap, List.of("missing-1", "missing-2"), "test-log-type"));
+    }
+
+    public void testClassifyAndValidate_sigmaAndNull_bothStandard() {
+        Map<String, String> worldMap = new HashMap<>();
+        worldMap.put("rule-sigma", WTransportIndexDetectorAction.classifyRuleWorld("Sigma"));
+        worldMap.put("rule-null", WTransportIndexDetectorAction.classifyRuleWorld(null));
+
+        assertNull(
+                WTransportIndexDetectorAction.validateRuleWorlds(
+                        worldMap, List.of("rule-sigma", "rule-null"), "test"));
+    }
+
+    public void testClassifyAndValidate_draftTestCustom_allUser() {
+        Map<String, String> worldMap = new HashMap<>();
+        worldMap.put("r1", WTransportIndexDetectorAction.classifyRuleWorld("Draft"));
+        worldMap.put("r2", WTransportIndexDetectorAction.classifyRuleWorld("Test"));
+        worldMap.put("r3", WTransportIndexDetectorAction.classifyRuleWorld("Custom"));
+
+        assertNull(
+                WTransportIndexDetectorAction.validateRuleWorlds(
+                        worldMap, List.of("r1", "r2", "r3"), "test"));
+    }
+
+    public void testClassifyAndValidate_sigmaAndCustom_rejected() {
+        Map<String, String> worldMap = new HashMap<>();
+        worldMap.put("std", WTransportIndexDetectorAction.classifyRuleWorld("Sigma"));
+        worldMap.put("cust", WTransportIndexDetectorAction.classifyRuleWorld("Custom"));
+
+        String error =
+                WTransportIndexDetectorAction.validateRuleWorlds(
+                        worldMap, List.of("std", "cust"), "wazuh-rootcheck");
+
+        assertNotNull(error);
+        assertTrue(error.contains("wazuh-rootcheck"));
+    }
+
+    public void testClassifyAndValidate_nullAndDraft_rejected() {
+        Map<String, String> worldMap = new HashMap<>();
+        worldMap.put("std", WTransportIndexDetectorAction.classifyRuleWorld(null));
+        worldMap.put("draft", WTransportIndexDetectorAction.classifyRuleWorld("Draft"));
+
+        String error =
+                WTransportIndexDetectorAction.validateRuleWorlds(
+                        worldMap, List.of("std", "draft"), "my-type");
+
+        assertNotNull(error);
+    }
+
+    public void testClassifyAndValidate_emptyStringAndSigma_rejected() {
+        Map<String, String> worldMap = new HashMap<>();
+        worldMap.put("rule-empty", WTransportIndexDetectorAction.classifyRuleWorld(""));
+        worldMap.put("rule-sigma", WTransportIndexDetectorAction.classifyRuleWorld("Sigma"));
+
+        String error =
+                WTransportIndexDetectorAction.validateRuleWorlds(
+                        worldMap, List.of("rule-empty", "rule-sigma"), "mixed-edge-case");
+
+        assertNotNull(error);
+        assertTrue(error.contains("mixed-edge-case"));
+    }
+}

--- a/src/test/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorActionTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorActionTests.java
@@ -16,204 +16,237 @@
  */
 package org.opensearch.securityanalytics.transport;
 
+import org.opensearch.securityanalytics.model.Rule;
+import org.opensearch.securityanalytics.transport.WTransportIndexDetectorAction.RuleClassificationResult;
+import org.opensearch.securityanalytics.transport.WTransportIndexDetectorAction.RuleHit;
 import org.opensearch.test.OpenSearchTestCase;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public class WTransportIndexDetectorActionTests extends OpenSearchTestCase {
 
-    public void testClassifyRuleWorld_nullSpace_returnsStandard() {
-        assertEquals("Standard", WTransportIndexDetectorAction.classifyRuleWorld(null));
+    // -----------------------------------------------------------------------
+    // classifyRuleHits tests
+    // -----------------------------------------------------------------------
+
+    public void testClassifyRuleHits_allPrePackaged() {
+        List<RuleHit> hits =
+                List.of(
+                        new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "rule-1", "Sigma"),
+                        new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "rule-2", "Sigma"));
+
+        RuleClassificationResult result = WTransportIndexDetectorAction.classifyRuleHits(hits);
+
+        assertEquals(2, result.prePackagedRuleIds.size());
+        assertTrue(result.prePackagedRuleIds.contains("rule-1"));
+        assertTrue(result.prePackagedRuleIds.contains("rule-2"));
+        assertTrue(result.customRuleIds.isEmpty());
+        assertTrue(result.invalidCustomRules.isEmpty());
+        assertEquals(2, result.foundRuleIds.size());
     }
 
-    public void testClassifyRuleWorld_sigmaSpace_returnsStandard() {
-        assertEquals("Standard", WTransportIndexDetectorAction.classifyRuleWorld("Sigma"));
+    public void testClassifyRuleHits_allCustomWithCustomSpace() {
+        List<RuleHit> hits =
+                List.of(
+                        new RuleHit(Rule.CUSTOM_RULES_INDEX, "rule-1", "Custom"),
+                        new RuleHit(Rule.CUSTOM_RULES_INDEX, "rule-2", "custom"));
+
+        RuleClassificationResult result = WTransportIndexDetectorAction.classifyRuleHits(hits);
+
+        assertTrue(result.prePackagedRuleIds.isEmpty());
+        assertEquals(2, result.customRuleIds.size());
+        assertTrue(result.invalidCustomRules.isEmpty());
     }
 
-    public void testClassifyRuleWorld_sigmaCaseInsensitive_returnsStandard() {
-        assertEquals("Standard", WTransportIndexDetectorAction.classifyRuleWorld("sigma"));
-        assertEquals("Standard", WTransportIndexDetectorAction.classifyRuleWorld("SIGMA"));
+    public void testClassifyRuleHits_customRuleWithDraftSpace_invalid() {
+        List<RuleHit> hits = List.of(new RuleHit(Rule.CUSTOM_RULES_INDEX, "rule-1", "Draft"));
+
+        RuleClassificationResult result = WTransportIndexDetectorAction.classifyRuleHits(hits);
+
+        assertTrue(result.prePackagedRuleIds.isEmpty());
+        assertTrue(result.customRuleIds.isEmpty());
+        assertEquals(1, result.invalidCustomRules.size());
+        assertEquals("rule-1", result.invalidCustomRules.get(0));
     }
 
-    public void testClassifyRuleWorld_draftSpace_returnsUser() {
-        assertEquals("User", WTransportIndexDetectorAction.classifyRuleWorld("Draft"));
+    public void testClassifyRuleHits_customRuleWithTestSpace_invalid() {
+        List<RuleHit> hits = List.of(new RuleHit(Rule.CUSTOM_RULES_INDEX, "rule-1", "Test"));
+
+        RuleClassificationResult result = WTransportIndexDetectorAction.classifyRuleHits(hits);
+
+        assertTrue(result.customRuleIds.isEmpty());
+        assertEquals(1, result.invalidCustomRules.size());
     }
 
-    public void testClassifyRuleWorld_testSpace_returnsUser() {
-        assertEquals("User", WTransportIndexDetectorAction.classifyRuleWorld("Test"));
+    public void testClassifyRuleHits_customRuleWithNullSpace_invalid() {
+        List<RuleHit> hits = List.of(new RuleHit(Rule.CUSTOM_RULES_INDEX, "rule-1", null));
+
+        RuleClassificationResult result = WTransportIndexDetectorAction.classifyRuleHits(hits);
+
+        assertTrue(result.customRuleIds.isEmpty());
+        assertEquals(1, result.invalidCustomRules.size());
     }
 
-    public void testClassifyRuleWorld_customSpace_returnsUser() {
-        assertEquals("User", WTransportIndexDetectorAction.classifyRuleWorld("Custom"));
+    public void testClassifyRuleHits_mixedPrePackagedAndCustom() {
+        List<RuleHit> hits =
+                List.of(
+                        new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "rule-std", "Sigma"),
+                        new RuleHit(Rule.CUSTOM_RULES_INDEX, "rule-cust", "Custom"));
+
+        RuleClassificationResult result = WTransportIndexDetectorAction.classifyRuleHits(hits);
+
+        assertEquals(1, result.prePackagedRuleIds.size());
+        assertEquals(1, result.customRuleIds.size());
+        assertTrue(result.invalidCustomRules.isEmpty());
+        assertEquals(2, result.foundRuleIds.size());
     }
 
-    public void testClassifyRuleWorld_unknownSpace_returnsUser() {
-        assertEquals("User", WTransportIndexDetectorAction.classifyRuleWorld("SomeOtherSpace"));
+    public void testClassifyRuleHits_emptyHits() {
+        RuleClassificationResult result =
+                WTransportIndexDetectorAction.classifyRuleHits(new ArrayList<>());
+
+        assertTrue(result.prePackagedRuleIds.isEmpty());
+        assertTrue(result.customRuleIds.isEmpty());
+        assertTrue(result.invalidCustomRules.isEmpty());
+        assertTrue(result.foundRuleIds.isEmpty());
     }
 
-    public void testClassifyRuleWorld_emptyString_returnsUser() {
-        assertEquals("User", WTransportIndexDetectorAction.classifyRuleWorld(""));
+    public void testClassifyRuleHits_prePackagedWithAnySpace_accepted() {
+        // Pre-packaged rules are accepted regardless of their space value
+        List<RuleHit> hits =
+                List.of(
+                        new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "rule-1", "Sigma"),
+                        new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "rule-2", null),
+                        new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "rule-3", "SomeOther"));
+
+        RuleClassificationResult result = WTransportIndexDetectorAction.classifyRuleHits(hits);
+
+        assertEquals(3, result.prePackagedRuleIds.size());
+        assertTrue(result.customRuleIds.isEmpty());
+        assertTrue(result.invalidCustomRules.isEmpty());
     }
 
-    public void testValidateRuleWorlds_allStandard_returnsNull() {
-        Map<String, String> worldMap = new HashMap<>();
-        worldMap.put("rule-1", "Standard");
-        worldMap.put("rule-2", "Standard");
+    public void testClassifyRuleHits_customRuleWithEmptySpace_invalid() {
+        List<RuleHit> hits = List.of(new RuleHit(Rule.CUSTOM_RULES_INDEX, "rule-1", ""));
 
-        assertNull(
-                WTransportIndexDetectorAction.validateRuleWorlds(
-                        worldMap, List.of("rule-1", "rule-2"), "test-log-type"));
+        RuleClassificationResult result = WTransportIndexDetectorAction.classifyRuleHits(hits);
+
+        assertTrue(result.customRuleIds.isEmpty());
+        assertEquals(1, result.invalidCustomRules.size());
     }
 
-    public void testValidateRuleWorlds_allUser_returnsNull() {
-        Map<String, String> worldMap = new HashMap<>();
-        worldMap.put("rule-1", "User");
-        worldMap.put("rule-2", "User");
+    // -----------------------------------------------------------------------
+    // validateClassificationResult tests
+    // -----------------------------------------------------------------------
 
-        assertNull(
-                WTransportIndexDetectorAction.validateRuleWorlds(
-                        worldMap, List.of("rule-1", "rule-2"), "test-log-type"));
+    public void testValidate_allPrePackaged_returnsNull() {
+        RuleClassificationResult result =
+                WTransportIndexDetectorAction.classifyRuleHits(
+                        List.of(
+                                new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "r1", "Sigma"),
+                                new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "r2", "Sigma")));
+
+        assertNull(WTransportIndexDetectorAction.validateClassificationResult(result, "test-type"));
     }
 
-    public void testValidateRuleWorlds_mixedWorlds_returnsError() {
-        Map<String, String> worldMap = new HashMap<>();
-        worldMap.put("rule-standard", "Standard");
-        worldMap.put("rule-user", "User");
+    public void testValidate_allCustom_returnsNull() {
+        RuleClassificationResult result =
+                WTransportIndexDetectorAction.classifyRuleHits(
+                        List.of(
+                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r1", "Custom"),
+                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r2", "Custom")));
+
+        assertNull(WTransportIndexDetectorAction.validateClassificationResult(result, "test-type"));
+    }
+
+    public void testValidate_mixed_returnsError() {
+        RuleClassificationResult result =
+                WTransportIndexDetectorAction.classifyRuleHits(
+                        List.of(
+                                new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "r-std", "Sigma"),
+                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r-cust", "Custom")));
 
         String error =
-                WTransportIndexDetectorAction.validateRuleWorlds(
-                        worldMap, List.of("rule-standard", "rule-user"), "my-integration");
+                WTransportIndexDetectorAction.validateClassificationResult(result, "my-integration");
 
         assertNotNull(error);
         assertTrue(error.contains("my-integration"));
-        assertTrue(error.contains("standard or custom"));
+        assertTrue(error.contains("pre-packaged or all custom"));
     }
 
-    public void testValidateRuleWorlds_singleRule_standard_returnsNull() {
-        Map<String, String> worldMap = new HashMap<>();
-        worldMap.put("only-rule", "Standard");
+    public void testValidate_invalidCustomSpace_returnsError() {
+        RuleClassificationResult result =
+                WTransportIndexDetectorAction.classifyRuleHits(
+                        List.of(new RuleHit(Rule.CUSTOM_RULES_INDEX, "r-draft", "Draft")));
 
-        assertNull(
-                WTransportIndexDetectorAction.validateRuleWorlds(
-                        worldMap, List.of("only-rule"), "test-log-type"));
-    }
-
-    public void testValidateRuleWorlds_singleRule_user_returnsNull() {
-        Map<String, String> worldMap = new HashMap<>();
-        worldMap.put("only-rule", "User");
-
-        assertNull(
-                WTransportIndexDetectorAction.validateRuleWorlds(
-                        worldMap, List.of("only-rule"), "test-log-type"));
-    }
-
-    public void testValidateRuleWorlds_emptyRuleList_returnsNull() {
-        Map<String, String> worldMap = new HashMap<>();
-        worldMap.put("rule-1", "Standard");
-
-        assertNull(
-                WTransportIndexDetectorAction.validateRuleWorlds(worldMap, List.of(), "test-log-type"));
-    }
-
-    public void testValidateRuleWorlds_ruleNotInMap_ignored() {
-        Map<String, String> worldMap = new HashMap<>();
-        worldMap.put("rule-1", "Standard");
-
-        assertNull(
-                WTransportIndexDetectorAction.validateRuleWorlds(
-                        worldMap, List.of("rule-1", "rule-2"), "test-log-type"));
-    }
-
-    public void testValidateRuleWorlds_multipleStandardWithMissingRules_returnsNull() {
-        Map<String, String> worldMap = new HashMap<>();
-        worldMap.put("rule-a", "Standard");
-        worldMap.put("rule-b", "Standard");
-
-        assertNull(
-                WTransportIndexDetectorAction.validateRuleWorlds(
-                        worldMap, List.of("rule-a", "rule-b", "rule-missing"), "test-log-type"));
-    }
-
-    public void testValidateRuleWorlds_mixedWithMissing_returnsError() {
-        Map<String, String> worldMap = new HashMap<>();
-        worldMap.put("rule-std", "Standard");
-        worldMap.put("rule-usr", "User");
-
-        String error =
-                WTransportIndexDetectorAction.validateRuleWorlds(
-                        worldMap, List.of("rule-std", "rule-usr", "rule-missing"), "mixed-int");
+        String error = WTransportIndexDetectorAction.validateClassificationResult(result, "my-type");
 
         assertNotNull(error);
-        assertTrue(error.contains("mixed-int"));
+        assertTrue(error.contains("my-type"));
+        assertTrue(error.contains("not in \"Custom\" space"));
+        assertTrue(error.contains("r-draft"));
     }
 
-    public void testValidateRuleWorlds_noRulesFoundInMap_returnsNull() {
-        Map<String, String> worldMap = new HashMap<>();
-        worldMap.put("other-rule", "Standard");
+    public void testValidate_invalidCustomSpace_takePrecedenceOverMixedCheck() {
+        // If there are invalid custom rules AND pre-packaged rules, the invalid space
+        // error should be reported (it's checked first)
+        RuleClassificationResult result =
+                WTransportIndexDetectorAction.classifyRuleHits(
+                        List.of(
+                                new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "r-std", "Sigma"),
+                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r-draft", "Draft")));
 
-        assertNull(
-                WTransportIndexDetectorAction.validateRuleWorlds(
-                        worldMap, List.of("missing-1", "missing-2"), "test-log-type"));
-    }
-
-    public void testClassifyAndValidate_sigmaAndNull_bothStandard() {
-        Map<String, String> worldMap = new HashMap<>();
-        worldMap.put("rule-sigma", WTransportIndexDetectorAction.classifyRuleWorld("Sigma"));
-        worldMap.put("rule-null", WTransportIndexDetectorAction.classifyRuleWorld(null));
-
-        assertNull(
-                WTransportIndexDetectorAction.validateRuleWorlds(
-                        worldMap, List.of("rule-sigma", "rule-null"), "test"));
-    }
-
-    public void testClassifyAndValidate_draftTestCustom_allUser() {
-        Map<String, String> worldMap = new HashMap<>();
-        worldMap.put("r1", WTransportIndexDetectorAction.classifyRuleWorld("Draft"));
-        worldMap.put("r2", WTransportIndexDetectorAction.classifyRuleWorld("Test"));
-        worldMap.put("r3", WTransportIndexDetectorAction.classifyRuleWorld("Custom"));
-
-        assertNull(
-                WTransportIndexDetectorAction.validateRuleWorlds(
-                        worldMap, List.of("r1", "r2", "r3"), "test"));
-    }
-
-    public void testClassifyAndValidate_sigmaAndCustom_rejected() {
-        Map<String, String> worldMap = new HashMap<>();
-        worldMap.put("std", WTransportIndexDetectorAction.classifyRuleWorld("Sigma"));
-        worldMap.put("cust", WTransportIndexDetectorAction.classifyRuleWorld("Custom"));
-
-        String error =
-                WTransportIndexDetectorAction.validateRuleWorlds(
-                        worldMap, List.of("std", "cust"), "wazuh-rootcheck");
+        String error = WTransportIndexDetectorAction.validateClassificationResult(result, "test");
 
         assertNotNull(error);
-        assertTrue(error.contains("wazuh-rootcheck"));
+        assertTrue(error.contains("not in \"Custom\" space"));
     }
 
-    public void testClassifyAndValidate_nullAndDraft_rejected() {
-        Map<String, String> worldMap = new HashMap<>();
-        worldMap.put("std", WTransportIndexDetectorAction.classifyRuleWorld(null));
-        worldMap.put("draft", WTransportIndexDetectorAction.classifyRuleWorld("Draft"));
+    public void testValidate_empty_returnsNull() {
+        RuleClassificationResult result =
+                WTransportIndexDetectorAction.classifyRuleHits(new ArrayList<>());
 
-        String error =
-                WTransportIndexDetectorAction.validateRuleWorlds(
-                        worldMap, List.of("std", "draft"), "my-type");
-
-        assertNotNull(error);
+        assertNull(WTransportIndexDetectorAction.validateClassificationResult(result, "test"));
     }
 
-    public void testClassifyAndValidate_emptyStringAndSigma_rejected() {
-        Map<String, String> worldMap = new HashMap<>();
-        worldMap.put("rule-empty", WTransportIndexDetectorAction.classifyRuleWorld(""));
-        worldMap.put("rule-sigma", WTransportIndexDetectorAction.classifyRuleWorld("Sigma"));
+    public void testValidate_singlePrePackaged_returnsNull() {
+        RuleClassificationResult result =
+                WTransportIndexDetectorAction.classifyRuleHits(
+                        List.of(new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "only-rule", "Sigma")));
 
-        String error =
-                WTransportIndexDetectorAction.validateRuleWorlds(
-                        worldMap, List.of("rule-empty", "rule-sigma"), "mixed-edge-case");
+        assertNull(WTransportIndexDetectorAction.validateClassificationResult(result, "test"));
+    }
+
+    public void testValidate_singleCustom_returnsNull() {
+        RuleClassificationResult result =
+                WTransportIndexDetectorAction.classifyRuleHits(
+                        List.of(new RuleHit(Rule.CUSTOM_RULES_INDEX, "only-rule", "Custom")));
+
+        assertNull(WTransportIndexDetectorAction.validateClassificationResult(result, "test"));
+    }
+
+    public void testValidate_multipleInvalidCustomSpaces_allReported() {
+        RuleClassificationResult result =
+                WTransportIndexDetectorAction.classifyRuleHits(
+                        List.of(
+                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r-draft", "Draft"),
+                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r-test", "Test")));
+
+        String error = WTransportIndexDetectorAction.validateClassificationResult(result, "my-type");
 
         assertNotNull(error);
-        assertTrue(error.contains("mixed-edge-case"));
+        assertTrue(error.contains("r-draft"));
+        assertTrue(error.contains("r-test"));
+    }
+
+    public void testValidate_customCaseInsensitive_accepted() {
+        RuleClassificationResult result =
+                WTransportIndexDetectorAction.classifyRuleHits(
+                        List.of(
+                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r1", "CUSTOM"),
+                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r2", "custom")));
+
+        assertNull(WTransportIndexDetectorAction.validateClassificationResult(result, "test"));
     }
 }


### PR DESCRIPTION

## Description

Enforces that a threat detector's input contains rules from a **single source only**: either `pre_packaged_rules` OR `custom_rules`, never both simultaneously. Mixed inputs are now rejected with a clear `400` error on both **create** and **update** operations.

## Related Issues

Resolves #117

## Validation

### Test 1 — CREATE: mixed rules (pre_packaged + custom)

**Request:**
```http
POST _plugins/_security_analytics/detectors
{
  "detector_type": "wazuh-core",
  "name": "test-117-create-mixed",
  "enabled": true,
  "schedule": { "period": { "interval": 2, "unit": "MINUTES" } },
  "inputs": [{ "detector_input": {
    "description": "test",
    "indices": ["wazuh-events-v5-security"],
    "pre_packaged_rules": [{"id": "f8ffeaf5-e736-48a9-a178-e08b1f9d741c"}],
    "custom_rules": [{"id": "eb50fa15-c0d9-4565-9150-435a00ecf1ef"}]
  }}],
  "triggers": []
}
```

**Response:** 
```json
{
  "error": {
    "root_cause": [{
      "type": "status_exception",
      "reason": "Detector cannot have both prepackaged and custom rules. Use only one type."
    }],
    "type": "status_exception",
    "reason": "Detector cannot have both prepackaged and custom rules. Use only one type."
  },
  "status": 400
}
```

---

### Test 2 — UPDATE: add custom rules to a standard-only detector

**Request:**
```http
PUT _plugins/_security_analytics/detectors/lOHymp0BUlCVMHAZesGq
{
  "detector_type": "wazuh-core",
  "name": "test-117-create-standard-only",
  "enabled": true,
  "schedule": { "period": { "interval": 2, "unit": "MINUTES" } },
  "inputs": [{ "detector_input": {
    "description": "test",
    "indices": ["wazuh-events-v5-security"],
    "pre_packaged_rules": [{"id": "f8ffeaf5-e736-48a9-a178-e08b1f9d741c"}],
    "custom_rules": [{"id": "dde16d65-c9e8-4aba-8894-11abf28150f2"}]
  }}],
  "triggers": []
}
```

**Response:** 
```json
{
  "error": {
    "root_cause": [{
      "type": "status_exception",
      "reason": "Detector cannot have both prepackaged and custom rules. Use only one type."
    }],
    "type": "status_exception",
    "reason": "Detector cannot have both prepackaged and custom rules. Use only one type."
  },
  "status": 400
}
```
