### PR TITLE
Change references from old indices to new ones

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorAction.java
@@ -75,7 +75,7 @@ public class WTransportIndexDetectorAction
     private static final Logger log = LogManager.getLogger(WTransportIndexDetectorAction.class);
 
     // Constant for the CTI Integrations index
-    private static final String CTI_INTEGRATIONS_INDEX = ".cti-integrations";
+    private static final String CTI_INTEGRATIONS_INDEX = "wazuh-threatintel-integrations";
 
     /**
      * Constructs a new WTransportIndexDetectorAction.
@@ -107,7 +107,8 @@ public class WTransportIndexDetectorAction
     protected void doExecute(
             Task task, WIndexDetectorRequest request, ActionListener<WIndexDetectorResponse> listener) {
 
-        // Fetch the integration document from .cti-integrations to get the true list of rules
+        // Fetch the integration document from wazuh-threatintel-integrations to get the true list of
+        // rules
         SearchRequest integrationSearch = new SearchRequest(CTI_INTEGRATIONS_INDEX);
         integrationSearch.indicesOptions(IndicesOptions.lenientExpandOpen());
 

--- a/src/test/java/org/opensearch/securityanalytics/rules/engine/EventMatcherTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/rules/engine/EventMatcherTests.java
@@ -404,7 +404,7 @@ public class EventMatcherTests extends OpenSearchTestCase {
         """;
 
     /**
-     * Builds a rule JSON in the same format stored in the .cti-rules index
+     * Builds a rule JSON in the same format stored in the wazuh-threatintel-rules index
      * (after nestMetadataFields processing).
      */
     private static String indexedRuleJson(String id, String title, String level, String detectionField, String detectionValue) {
@@ -494,7 +494,7 @@ public class EventMatcherTests extends OpenSearchTestCase {
         Assert.assertEquals(0, parsed.get("rules_matched"));
     }
 
-    // ---- JSON-based tests (simulating .cti-rules index round-trip) ----
+    // ---- JSON-based tests (simulating wazuh-threatintel-rules index round-trip) ----
 
     /**
      * Startswith parsed from JSON (Content Manager stored format). Verifies the full round-trip: JSON


### PR DESCRIPTION
### Description
This PR changes the references from old indices to use the new names

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-plugins/issues/1041
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
