### PR TITLE
Rework caches in GH Workflows

### DIFF
--- a/.github/workflows/5_builderpackage_security-analytics.yml
+++ b/.github/workflows/5_builderpackage_security-analytics.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ~/.m2/repository
-          key: maven-common-utils-${{ github.ref_name }}
+          key: ${{ github.run_id }}-common-utils
 
   publish-alerting:
     runs-on: ubuntu-24.04
@@ -111,7 +111,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.m2/repository
-          key: maven-common-utils-${{ github.ref_name }}
+          key: ${{ github.run_id }}-common-utils
       - name: Publish alerting to Maven Local
         uses: wazuh/wazuh-indexer-alerting/.github/actions/5_local_maven_publisher@main
         with:
@@ -122,7 +122,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ~/.m2/repository
-          key: maven-alerting-${{ github.ref_name }}
+          key: ${{ github.run_id }}-alerting
 
   build:
     needs: [get-version, publish-common-utils, publish-alerting]
@@ -139,17 +139,11 @@ jobs:
       - name: Setup Gradle # Used for caching
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Restore Maven Local cache
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.m2/repository
-          key: maven-common-utils-${{ github.ref_name }}
-
       - name: Restore Maven Local cache (alerting)
         uses: actions/cache/restore@v5
         with:
           path: ~/.m2/repository
-          key: maven-alerting-${{ github.ref_name }}
+          key: ${{ github.run_id }}-alerting
 
       - name: Get version
         id: version

--- a/.github/workflows/5_testintegration_gradlecheck.yml
+++ b/.github/workflows/5_testintegration_gradlecheck.yml
@@ -4,9 +4,10 @@ name: (5.x) Run tests
 # - On any changes
 
 on:
-  push:
+  pull_request:
+    types: [synchronize]
     paths:
-      - "src/**" # Match changes in source files.
+      - "**/src/**" # Match changes in source files.
       - "*.gradle" # Match changes in Gradle configuration.
 
 concurrency:
@@ -56,7 +57,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ~/.m2/repository
-          key: maven-common-utils-${{ github.ref_name }}
+          key: ${{ github.run_id }}-common-utils
 
   publish-alerting:
     runs-on: ubuntu-24.04
@@ -66,7 +67,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.m2/repository
-          key: maven-common-utils-${{ github.ref_name }}
+          key: ${{ github.run_id }}-common-utils
       - name: Publish alerting to Maven Local
         uses: wazuh/wazuh-indexer-alerting/.github/actions/5_local_maven_publisher@main
         with:
@@ -77,11 +78,11 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: ~/.m2/repository
-          key: maven-alerting-${{ github.ref_name }}
+          key: ${{ github.run_id }}-alerting
 
   call-test-workflow:
     runs-on: ubuntu-24.04
-    needs: [publish-common-utils, publish-alerting]
+    needs: [get-version, publish-common-utils, publish-alerting]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -89,28 +90,19 @@ jobs:
           distribution: temurin
           java-version: 25
 
-      - name: Restore Maven Local cache
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.m2/repository
-          key: maven-common-utils-${{ github.ref_name }}
-
       - name: Restore Maven Local cache (alerting)
         uses: actions/cache/restore@v5
         with:
           path: ~/.m2/repository
-          key: maven-alerting-${{ github.ref_name }}
+          key: ${{ github.run_id }}-alerting
 
-      - name: Get version
-        id: version
-        run: echo "version=$(jq -r '.version' VERSION.json)" >> "$GITHUB_OUTPUT"
-
-      - name: Publish to Maven local
+      - name: Publish to Maven local # SAP commons
         uses: ./.github/actions/5_local_maven_publisher
         with:
-          version: ${{ steps.version.outputs.version }}
+          version: ${{ needs.get-version.outputs.version }}
           revision: '0'
           reference: ${{ github.ref }}
 
       - name: Run Gradle check
-        run: ./gradlew check
+        run: ./gradlew check "-Dversion=${{ needs.get-version.outputs.version }}" "-Drevision=0"
+        shell: bash


### PR DESCRIPTION
### Description
Uses .m2 cache to transport artifacts within the same workflow run.

**Validation**
- Run `./gradlew check`

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1443
