### PR TITLE
Normalize space values to lowercase across SAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Optimize findings enrichment [(#93)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/93)
 - Limit number of rules per detector [(#111)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/111)
 - Disable standard threat detectors modification [(#121)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/121)
+- Normalize space values to lowercase across SAP [(#174)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/174)
 
 ### Deprecated
 -

--- a/src/main/java/org/opensearch/securityanalytics/correlation/JoinEngine.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/JoinEngine.java
@@ -146,7 +146,7 @@ public class JoinEngine {
         Set<String> validIntrusionSets =
                 AutoCorrelationsRepo.validIntrusionSets(autoCorrelations, tags);
 
-        MatchQueryBuilder queryBuilder = QueryBuilders.matchQuery("space", "Sigma");
+        MatchQueryBuilder queryBuilder = QueryBuilders.matchQuery("space", "standard");
 
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.query(queryBuilder);

--- a/src/main/java/org/opensearch/securityanalytics/model/Detector.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/Detector.java
@@ -68,8 +68,8 @@ public class Detector implements Writeable, ToXContentObject {
     public static final String BUCKET_MONITOR_ID_RULE_ID = "bucket_monitor_id_rule_id";
 
     public static final String SOURCE_FIELD = "source";
-    public static final String DEFAULT_SOURCE = "Custom";
-    public static final String SIGMA_SOURCE = "Sigma";
+    public static final String DEFAULT_SOURCE = "custom";
+    public static final String STANDARD_SOURCE = "standard";
     private static final String RULE_TOPIC_INDEX = "rule_topic_index";
 
     private static final String ALERTS_INDEX = "alert_index";
@@ -767,11 +767,11 @@ public class Detector implements Writeable, ToXContentObject {
     }
 
     /**
-     * Returns whether this detector belongs to the standard (Sigma) space and is therefore protected
-     * from user modifications.
+     * Returns whether this detector belongs to the standard space and is therefore protected from
+     * user modifications.
      */
     public boolean isStandardDetector() {
-        return SIGMA_SOURCE.equalsIgnoreCase(source);
+        return STANDARD_SOURCE.equalsIgnoreCase(source);
     }
 
     @Override

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteCustomLogTypeAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteCustomLogTypeAction.java
@@ -209,7 +209,7 @@ public class TransportDeleteCustomLogTypeAction
             // TODO: Remove this check when we load our Integrations and Rules as pre-packaged.
             String enabledPrepackaged = System.getProperty("default_rules.enabled");
             if (enabledPrepackaged != null && enabledPrepackaged.equals("true")) {
-                if (logType.getSpace().equals("Sigma")) {
+                if (logType.getSpace().equals("standard")) {
                     onFailures(
                             new OpenSearchStatusException(
                                     String.format(

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexCustomLogTypeAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexCustomLogTypeAction.java
@@ -271,7 +271,7 @@ public class TransportIndexCustomLogTypeAction
             // TODO: Remove this check when we load our Integrations and Rules as pre-packaged.
             String enabledPrepackaged = System.getProperty("default_rules.enabled");
             if (enabledPrepackaged != null && enabledPrepackaged.equals("true")) {
-                if (space.equals("Sigma")) {
+                if (space.equals("standard")) {
                     onFailures(
                             new OpenSearchStatusException(
                                     String.format(
@@ -316,7 +316,7 @@ public class TransportIndexCustomLogTypeAction
 
                                 // TODO: Remove this check when we load our Integrations and Rules as pre-packaged.
                                 if (enabledPrepackaged != null && enabledPrepackaged.equals("true")) {
-                                    if (existingLogType.getSpace().equals("Sigma")) {
+                                    if (existingLogType.getSpace().equals("standard")) {
                                         onFailures(
                                                 new OpenSearchStatusException(
                                                         String.format(

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -281,7 +281,7 @@ public class TransportIndexDetectorAction
 
         // Prevent modification of standard detectors
         boolean isInternalCaller = isInternalCaller();
-        // For non-internal callers, force source to Custom
+        // For non-internal callers, force source to custom
         if (!isInternalCaller) {
             request.getDetector().setSource(Detector.DEFAULT_SOURCE);
         }
@@ -320,8 +320,8 @@ public class TransportIndexDetectorAction
     }
 
     /**
-     * Validates that a user update to a standard (Sigma) detector only changes the enabled field. If
-     * the detector is not standard, or the update is valid, the provided continuation is run.
+     * Validates that a user update to a standard detector only changes the enabled field. If the
+     * detector is not standard, or the update is valid, the provided continuation is run.
      */
     private void validateStandardDetectorUpdate(
             IndexDetectorRequest request,
@@ -394,7 +394,7 @@ public class TransportIndexDetectorAction
             int ruleCount = Math.max(input.getCustomRules().size(), input.getPrePackagedRules().size());
             if (ruleCount > MAX_RULES_PER_DETECTOR) {
                 return String.format(
-                        Locale.getDefault(),
+                        Locale.ROOT,
                         "Detector cannot have more than %d rules, but found %d",
                         MAX_RULES_PER_DETECTOR,
                         ruleCount);
@@ -2303,7 +2303,7 @@ public class TransportIndexDetectorAction
                             .map(DetectorRule::getId)
                             .collect(Collectors.toList());
 
-            // Rules are identified by document.id (from the content manager) + space=Custom.
+            // Rules are identified by document.id (from the content manager) + space=custom.
             // Querying by _id would fail because the IDs received here are document.id values,
             // not the internal _id of the custom rules index.
             QueryBuilder queryBuilder =
@@ -2313,7 +2313,7 @@ public class TransportIndexDetectorAction
                                     .filter(
                                             QueryBuilders.termsQuery(
                                                     "rule.document.id", ruleIds.toArray(new String[] {})))
-                                    .filter(QueryBuilders.termQuery("rule.space", "Custom")),
+                                    .filter(QueryBuilders.termQuery("rule.space", "custom")),
                             ScoreMode.None);
             SearchRequest searchRequest =
                     new SearchRequest(Rule.CUSTOM_RULES_INDEX)
@@ -2324,7 +2324,7 @@ public class TransportIndexDetectorAction
                                             .query(queryBuilder)
                                             .size(10000))
                             .preference(Preference.PRIMARY_FIRST.type());
-            logger.debug("importing custom rules by document.id with space=Custom");
+            logger.debug("importing custom rules by document.id with space=custom");
             client.search(
                     searchRequest,
                     new ActionListener<>() {
@@ -2342,7 +2342,7 @@ public class TransportIndexDetectorAction
                                 onFailures(
                                         new OpenSearchStatusException(
                                                 String.format(
-                                                        "Detector creation failed. No custom rules found for IDs: %s. Ensure these rules are promoted to the 'Custom' space first.",
+                                                        "Detector creation failed. No custom rules found for IDs: %s. Ensure these rules are promoted to the 'custom' space first.",
                                                         ruleIds),
                                                 RestStatus.BAD_REQUEST));
                                 return;

--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorAction.java
@@ -321,7 +321,7 @@ public class WTransportIndexDetectorAction
      * Classifies rule hits by their source index and space field.
      *
      * <p>Rules from the pre-packaged index are accepted as-is. Rules from the custom index must have
-     * {@code space} equal to "Custom" (case-insensitive); otherwise they are flagged as invalid.
+     * {@code space} equal to "custom" (case-insensitive); otherwise they are flagged as invalid.
      *
      * @param hits list of (index, docId, space) tuples representing search hits
      * @return classification result with sets of pre-packaged, custom, invalid, and found rule IDs
@@ -338,7 +338,7 @@ public class WTransportIndexDetectorAction
             if (Rule.PRE_PACKAGED_RULES_INDEX.equals(hit.index)) {
                 prePackagedRuleIds.add(hit.docId);
             } else {
-                if ("Custom".equalsIgnoreCase(hit.space)) {
+                if ("custom".equalsIgnoreCase(hit.space)) {
                     customRuleIds.add(hit.docId);
                 } else {
                     invalidCustomRules.add(hit.docId);
@@ -360,7 +360,7 @@ public class WTransportIndexDetectorAction
     static String validateClassificationResult(RuleClassificationResult result, String logTypeName) {
         if (!result.invalidCustomRules.isEmpty()) {
             return String.format(
-                    "Cannot create [%s] detector. Custom rules %s are not in \"Custom\" space.",
+                    "Cannot create [%s] detector. Custom rules %s are not in \"custom\" space.",
                     logTypeName, result.invalidCustomRules);
         }
         if (!result.prePackagedRuleIds.isEmpty() && !result.customRuleIds.isEmpty()) {

--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexIntegrationAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexIntegrationAction.java
@@ -103,7 +103,7 @@ public class WTransportIndexIntegrationAction
         Integration integration = request.getIntegration();
 
         // Custom integration / log type.
-        if (!Objects.equals(integration.getSpace(), "Sigma")) {
+        if (!Objects.equals(integration.getSpace(), "standard")) {
             try {
                 String integrationId = integration.getDocumentId();
                 String sapId = integrationId == null ? UUID.randomUUID().toString() : integrationId;

--- a/src/main/java/org/opensearch/securityanalytics/util/DetectorFactory.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/DetectorFactory.java
@@ -53,7 +53,7 @@ public class DetectorFactory {
      */
     public static Detector createDetector(
             String integration, String category, List<String> detectorRules) {
-        return createDetector(integration, category, detectorRules, Detector.SIGMA_SOURCE);
+        return createDetector(integration, category, detectorRules, Detector.STANDARD_SOURCE);
     }
 
     public static Detector createDetector(

--- a/src/main/resources/OSMapping/logtypes.json
+++ b/src/main/resources/OSMapping/logtypes.json
@@ -3,7 +3,7 @@
     "name": "others_application",
     "description": "Application logs",
     "category": "Other",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 0
     }
@@ -12,7 +12,7 @@
     "name": "others_apt",
     "description": "Apt logs",
     "category": "Other",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 1
     }
@@ -21,7 +21,7 @@
     "name": "others_cloud",
     "description": "Cloud logs",
     "category": "Other",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 2
     }
@@ -30,7 +30,7 @@
     "name": "others_compliance",
     "description": "Compliance logs",
     "category": "Other",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 4
     }
@@ -39,7 +39,7 @@
     "name": "linux",
     "description": "Sys logs",
     "category": "System Activity",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 5
     }
@@ -48,7 +48,7 @@
     "name": "others_macos",
     "description": "MacOS logs",
     "category": "System Activity",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 6
     }
@@ -57,7 +57,7 @@
     "name": "network",
     "description": "Network logs",
     "category": "Network Activity",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 7
     }
@@ -66,7 +66,7 @@
     "name": "others_proxy",
     "description": "Proxy logs",
     "category": "Other",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 8
     }
@@ -75,7 +75,7 @@
     "name": "others_web",
     "description": "Web logs",
     "category": "Other",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 9
     }
@@ -84,7 +84,7 @@
     "name": "windows",
     "description": "Windows logs",
     "category": "System Activity",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 10
     }
@@ -93,7 +93,7 @@
     "name": "ad_ldap",
     "description": "Ad/ldap logs",
     "category": "Access Management",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 11
     }
@@ -102,7 +102,7 @@
     "name": "apache_access",
     "description": "Apache Access logs",
     "category": "Access Management",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 12
     }
@@ -111,7 +111,7 @@
     "name": "cloudtrail",
     "description": "Cloudtrail Raw or OCSF based logs",
     "category": "Cloud Services",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 14
     }
@@ -120,7 +120,7 @@
     "name": "dns",
     "description": "DNS Raw or Route53 OCSF based logs",
     "category": "Network Activity",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 15
     }
@@ -129,7 +129,7 @@
     "name": "github",
     "description": "Github logs",
     "category": "Applications",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 16
     }
@@ -138,7 +138,7 @@
     "name": "m365",
     "description": "M365 logs",
     "category": "Applications",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 17
     }
@@ -147,7 +147,7 @@
     "name": "gworkspace",
     "description": "GWorkspace logs",
     "category": "Applications",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 18
     }
@@ -156,7 +156,7 @@
     "name": "okta",
     "description": "Okta logs",
     "category": "Access Management",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 19
     }
@@ -165,7 +165,7 @@
     "name": "azure",
     "description": "Azure logs",
     "category": "Cloud Services",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 20
     }
@@ -174,7 +174,7 @@
     "name": "s3",
     "description": "S3 logs",
     "category": "Cloud Services",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 21
     }
@@ -183,7 +183,7 @@
     "name": "test_windows",
     "description": "Test Windows Log Type for integ tests. Please do not use.",
     "category": "Other",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 22
     }
@@ -192,7 +192,7 @@
     "name": "vpcflow",
     "description": "VPC Flow Raw or OCSF based logs",
     "category": "Network Activity",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 23
     }
@@ -201,7 +201,7 @@
     "name": "waf",
     "description": "Web Application Firewall based logs",
     "category": "Security",
-    "source": "Sigma",
+    "source": "standard",
     "tags": {
       "correlation_id": 24
     }

--- a/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
+++ b/src/test/java/org/opensearch/securityanalytics/TestHelpers.java
@@ -269,7 +269,7 @@ public class TestHelpers {
             category = "Other";
         }
         if (source == null) {
-            source = "Sigma";
+            source = "standard";
         }
         return new CustomLogType(null, null, name, description, category, source, null);
     }

--- a/src/test/java/org/opensearch/securityanalytics/correlation/CorrelationEngineRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/correlation/CorrelationEngineRestApiIT.java
@@ -1168,7 +1168,7 @@ public class CorrelationEngineRestApiIT extends SecurityAnalyticsRestTestCase {
         String vpcFlowMonitorId = createVpcFlowDetector(indices.vpcFlowsIndex);
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/CustomLogTypeRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/CustomLogTypeRestApiIT.java
@@ -49,7 +49,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     public void testCreateACustomLogType() throws IOException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -152,7 +152,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     public void testCreateACustomLogTypeWithMappings() throws IOException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -255,7 +255,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     public void testEditACustomLogTypeDescription() throws IOException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -327,7 +327,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
                         toHttpEntity(detector));
         Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
 
-        customLogType = TestHelpers.randomCustomLogType(null, "updated desc", null, "Custom");
+        customLogType = TestHelpers.randomCustomLogType(null, "updated desc", null, "custom");
         Response updatedResponse =
                 makeRequest(
                         client(),
@@ -357,7 +357,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     public void testEditACustomLogTypeCategory() throws IOException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -429,7 +429,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
                         toHttpEntity(detector));
         Assert.assertEquals("Create detector failed", RestStatus.CREATED, restStatus(createResponse));
 
-        customLogType = TestHelpers.randomCustomLogType(null, null, "Access Management", "Custom");
+        customLogType = TestHelpers.randomCustomLogType(null, null, "Access Management", "custom");
         Response updatedResponse =
                 makeRequest(
                         client(),
@@ -457,7 +457,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     @AwaitsFix(bugUrl = "")
     @SuppressWarnings("unchecked")
     public void testEditACustomLogTypeWithoutDetectors() throws IOException {
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -475,7 +475,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
                 ((Map<String, Object>) responseBody.get("logType")).get("description"));
 
         CustomLogType updatedCustomLogType =
-                TestHelpers.randomCustomLogType("updated_name", null, null, "Custom");
+                TestHelpers.randomCustomLogType("updated_name", null, null, "custom");
         Response updatedResponse =
                 makeRequest(
                         client(),
@@ -498,7 +498,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     public void testEditACustomLogTypeNameFailsAsDetectorExist() throws IOException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -568,7 +568,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
                 ResponseException.class,
                 () -> {
                     CustomLogType updatedCustomLogType =
-                            TestHelpers.randomCustomLogType("updated name", null, null, "Custom");
+                            TestHelpers.randomCustomLogType("updated name", null, null, "custom");
                     makeRequest(
                             client(),
                             "PUT",
@@ -584,7 +584,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     public void testEditACustomLogTypeNameFailsAsCustomRuleExist() throws IOException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -666,7 +666,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
                 ResponseException.class,
                 () -> {
                     CustomLogType updatedCustomLogType =
-                            TestHelpers.randomCustomLogType("updated name", null, null, "Custom");
+                            TestHelpers.randomCustomLogType("updated name", null, null, "custom");
                     makeRequest(
                             client(),
                             "PUT",
@@ -682,7 +682,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     public void testEditACustomLogTypeNameWhenCustomRuleIndexMissing() throws IOException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -768,7 +768,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
                 Collections.emptyMap(),
                 new StringEntity(""));
 
-        customLogType = TestHelpers.randomCustomLogType("test", null, "Access Management", "Custom");
+        customLogType = TestHelpers.randomCustomLogType("test", null, "Access Management", "custom");
         Response updatedResponse =
                 makeRequest(
                         client(),
@@ -790,7 +790,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     public void testEditACustomLogTypeNameWhenDetectorIndexMissing() throws IOException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -848,7 +848,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
                         new StringEntity(""));
         Assert.assertEquals("Delete rule successful", RestStatus.OK, restStatus(deleteResponse));
 
-        customLogType = TestHelpers.randomCustomLogType("test", null, "Access Management", "Custom");
+        customLogType = TestHelpers.randomCustomLogType("test", null, "Access Management", "custom");
         Response updatedResponse =
                 makeRequest(
                         client(),
@@ -871,7 +871,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     public void testEditACustomLogTypeName() throws IOException, InterruptedException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -959,7 +959,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
         Assert.assertEquals("Delete rule failed", RestStatus.OK, restStatus(deleteResponse));
 
         CustomLogType updatedCustomLogType =
-                TestHelpers.randomCustomLogType("updated_name", null, null, "Custom");
+                TestHelpers.randomCustomLogType("updated_name", null, null, "custom");
         Response updatedResponse =
                 makeRequest(
                         client(),
@@ -977,7 +977,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     @AwaitsFix(bugUrl = "")
     @SuppressWarnings("unchecked")
     public void testSearchLogTypes() throws IOException, InterruptedException {
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -1075,7 +1075,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     public void testDeleteCustomLogTypeFailsAsDetectorExist() throws IOException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -1159,7 +1159,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     public void testDeleteCustomLogTypeWithDetectorIndexMissing() throws IOException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -1251,7 +1251,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     public void testDeleteCustomLogTypeWithRuleIndexMissing() throws IOException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -1354,7 +1354,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     public void testDeleteCustomLogTypeFailsAsRulesExist() throws IOException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -1448,7 +1448,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     @AwaitsFix(bugUrl = "")
     @SuppressWarnings("unchecked")
     public void testDeleteCustomLogTypeWithoutDetectors() throws IOException {
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -1481,7 +1481,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     public void testDeleteCustomLogType() throws IOException, InterruptedException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -1582,7 +1582,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     public void testCreateMultipleLogTypes() throws IOException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
 
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -1667,7 +1667,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
                                 ((Map<String, Object>) hit.getSourceAsMap().get("detector")).get("monitor_id"))
                         .get(0);
 
-        customLogType = TestHelpers.randomCustomLogType("custom-again", null, null, "Custom");
+        customLogType = TestHelpers.randomCustomLogType("custom-again", null, null, "custom");
         createResponse =
                 makeRequest(
                         client(),
@@ -1780,7 +1780,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     @AwaitsFix(bugUrl = "")
     public void testGetMappingsView() throws IOException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -1822,7 +1822,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     @AwaitsFix(bugUrl = "")
     public void testMultipleLogTypesUpdateFieldMappings() throws IOException {
         String index = createTestIndex(randomIndex(), windowsIndexMapping());
-        CustomLogType customLogType = TestHelpers.randomCustomLogType("logtype1", null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType("logtype1", null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -1845,7 +1845,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
                         new BasicHeader("Content-Type", "application/json"));
         Assert.assertEquals("Create rule failed", RestStatus.CREATED, restStatus(createResponse));
 
-        customLogType = TestHelpers.randomCustomLogType("logtype2", null, null, "Custom");
+        customLogType = TestHelpers.randomCustomLogType("logtype2", null, null, "custom");
         createResponse =
                 makeRequest(
                         client(),
@@ -1900,7 +1900,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     // TODO: Disabled due to commented-out REST endpoints. Re-enable when endpoints are restored.
     @AwaitsFix(bugUrl = "")
     public void testLogTypeNamesAlwaysLowercase() throws IOException {
-        CustomLogType customLogType = TestHelpers.randomCustomLogType("Logtype1", null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType("Logtype1", null, null, "custom");
         expectThrows(
                 ResponseException.class,
                 () -> {
@@ -1916,7 +1916,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     // TODO: Disabled due to commented-out REST endpoints. Re-enable when endpoints are restored.
     @AwaitsFix(bugUrl = "")
     public void testMultipleLogTypesCannotBeCreatedWithSameName() throws IOException {
-        CustomLogType customLogType = TestHelpers.randomCustomLogType("logtype", null, null, "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType("logtype", null, null, "custom");
         Response createResponse =
                 makeRequest(
                         client(),
@@ -1941,7 +1941,7 @@ public class CustomLogTypeRestApiIT extends SecurityAnalyticsRestTestCase {
     // TODO: Disabled due to commented-out REST endpoints. Re-enable when endpoints are restored.
     @AwaitsFix(bugUrl = "")
     public void testCreateACustomLogTypeInvalidCategory() throws IOException {
-        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, "Invalid", "Custom");
+        CustomLogType customLogType = TestHelpers.randomCustomLogType(null, null, "Invalid", "custom");
         expectThrows(
                 ResponseException.class,
                 () -> {

--- a/src/test/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorActionTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorActionTests.java
@@ -33,8 +33,8 @@ public class WTransportIndexDetectorActionTests extends OpenSearchTestCase {
     public void testClassifyRuleHits_allPrePackaged() {
         List<RuleHit> hits =
                 List.of(
-                        new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "rule-1", "Sigma"),
-                        new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "rule-2", "Sigma"));
+                        new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "rule-1", "standard"),
+                        new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "rule-2", "standard"));
 
         RuleClassificationResult result = WTransportIndexDetectorAction.classifyRuleHits(hits);
 
@@ -49,7 +49,7 @@ public class WTransportIndexDetectorActionTests extends OpenSearchTestCase {
     public void testClassifyRuleHits_allCustomWithCustomSpace() {
         List<RuleHit> hits =
                 List.of(
-                        new RuleHit(Rule.CUSTOM_RULES_INDEX, "rule-1", "Custom"),
+                        new RuleHit(Rule.CUSTOM_RULES_INDEX, "rule-1", "custom"),
                         new RuleHit(Rule.CUSTOM_RULES_INDEX, "rule-2", "custom"));
 
         RuleClassificationResult result = WTransportIndexDetectorAction.classifyRuleHits(hits);
@@ -60,7 +60,7 @@ public class WTransportIndexDetectorActionTests extends OpenSearchTestCase {
     }
 
     public void testClassifyRuleHits_customRuleWithDraftSpace_invalid() {
-        List<RuleHit> hits = List.of(new RuleHit(Rule.CUSTOM_RULES_INDEX, "rule-1", "Draft"));
+        List<RuleHit> hits = List.of(new RuleHit(Rule.CUSTOM_RULES_INDEX, "rule-1", "draft"));
 
         RuleClassificationResult result = WTransportIndexDetectorAction.classifyRuleHits(hits);
 
@@ -71,7 +71,7 @@ public class WTransportIndexDetectorActionTests extends OpenSearchTestCase {
     }
 
     public void testClassifyRuleHits_customRuleWithTestSpace_invalid() {
-        List<RuleHit> hits = List.of(new RuleHit(Rule.CUSTOM_RULES_INDEX, "rule-1", "Test"));
+        List<RuleHit> hits = List.of(new RuleHit(Rule.CUSTOM_RULES_INDEX, "rule-1", "test"));
 
         RuleClassificationResult result = WTransportIndexDetectorAction.classifyRuleHits(hits);
 
@@ -91,8 +91,8 @@ public class WTransportIndexDetectorActionTests extends OpenSearchTestCase {
     public void testClassifyRuleHits_mixedPrePackagedAndCustom() {
         List<RuleHit> hits =
                 List.of(
-                        new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "rule-std", "Sigma"),
-                        new RuleHit(Rule.CUSTOM_RULES_INDEX, "rule-cust", "Custom"));
+                        new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "rule-std", "standard"),
+                        new RuleHit(Rule.CUSTOM_RULES_INDEX, "rule-cust", "custom"));
 
         RuleClassificationResult result = WTransportIndexDetectorAction.classifyRuleHits(hits);
 
@@ -116,7 +116,7 @@ public class WTransportIndexDetectorActionTests extends OpenSearchTestCase {
         // Pre-packaged rules are accepted regardless of their space value
         List<RuleHit> hits =
                 List.of(
-                        new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "rule-1", "Sigma"),
+                        new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "rule-1", "standard"),
                         new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "rule-2", null),
                         new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "rule-3", "SomeOther"));
 
@@ -144,8 +144,8 @@ public class WTransportIndexDetectorActionTests extends OpenSearchTestCase {
         RuleClassificationResult result =
                 WTransportIndexDetectorAction.classifyRuleHits(
                         List.of(
-                                new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "r1", "Sigma"),
-                                new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "r2", "Sigma")));
+                                new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "r1", "standard"),
+                                new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "r2", "standard")));
 
         assertNull(WTransportIndexDetectorAction.validateClassificationResult(result, "test-type"));
     }
@@ -154,8 +154,8 @@ public class WTransportIndexDetectorActionTests extends OpenSearchTestCase {
         RuleClassificationResult result =
                 WTransportIndexDetectorAction.classifyRuleHits(
                         List.of(
-                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r1", "Custom"),
-                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r2", "Custom")));
+                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r1", "custom"),
+                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r2", "custom")));
 
         assertNull(WTransportIndexDetectorAction.validateClassificationResult(result, "test-type"));
     }
@@ -164,8 +164,8 @@ public class WTransportIndexDetectorActionTests extends OpenSearchTestCase {
         RuleClassificationResult result =
                 WTransportIndexDetectorAction.classifyRuleHits(
                         List.of(
-                                new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "r-std", "Sigma"),
-                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r-cust", "Custom")));
+                                new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "r-std", "standard"),
+                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r-cust", "custom")));
 
         String error =
                 WTransportIndexDetectorAction.validateClassificationResult(result, "my-integration");
@@ -178,13 +178,13 @@ public class WTransportIndexDetectorActionTests extends OpenSearchTestCase {
     public void testValidate_invalidCustomSpace_returnsError() {
         RuleClassificationResult result =
                 WTransportIndexDetectorAction.classifyRuleHits(
-                        List.of(new RuleHit(Rule.CUSTOM_RULES_INDEX, "r-draft", "Draft")));
+                        List.of(new RuleHit(Rule.CUSTOM_RULES_INDEX, "r-draft", "draft")));
 
         String error = WTransportIndexDetectorAction.validateClassificationResult(result, "my-type");
 
         assertNotNull(error);
         assertTrue(error.contains("my-type"));
-        assertTrue(error.contains("not in \"Custom\" space"));
+        assertTrue(error.contains("not in \"custom\" space"));
         assertTrue(error.contains("r-draft"));
     }
 
@@ -194,13 +194,13 @@ public class WTransportIndexDetectorActionTests extends OpenSearchTestCase {
         RuleClassificationResult result =
                 WTransportIndexDetectorAction.classifyRuleHits(
                         List.of(
-                                new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "r-std", "Sigma"),
-                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r-draft", "Draft")));
+                                new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "r-std", "standard"),
+                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r-draft", "draft")));
 
         String error = WTransportIndexDetectorAction.validateClassificationResult(result, "test");
 
         assertNotNull(error);
-        assertTrue(error.contains("not in \"Custom\" space"));
+        assertTrue(error.contains("not in \"custom\" space"));
     }
 
     public void testValidate_empty_returnsNull() {
@@ -213,7 +213,7 @@ public class WTransportIndexDetectorActionTests extends OpenSearchTestCase {
     public void testValidate_singlePrePackaged_returnsNull() {
         RuleClassificationResult result =
                 WTransportIndexDetectorAction.classifyRuleHits(
-                        List.of(new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "only-rule", "Sigma")));
+                        List.of(new RuleHit(Rule.PRE_PACKAGED_RULES_INDEX, "only-rule", "standard")));
 
         assertNull(WTransportIndexDetectorAction.validateClassificationResult(result, "test"));
     }
@@ -221,7 +221,7 @@ public class WTransportIndexDetectorActionTests extends OpenSearchTestCase {
     public void testValidate_singleCustom_returnsNull() {
         RuleClassificationResult result =
                 WTransportIndexDetectorAction.classifyRuleHits(
-                        List.of(new RuleHit(Rule.CUSTOM_RULES_INDEX, "only-rule", "Custom")));
+                        List.of(new RuleHit(Rule.CUSTOM_RULES_INDEX, "only-rule", "custom")));
 
         assertNull(WTransportIndexDetectorAction.validateClassificationResult(result, "test"));
     }
@@ -230,8 +230,8 @@ public class WTransportIndexDetectorActionTests extends OpenSearchTestCase {
         RuleClassificationResult result =
                 WTransportIndexDetectorAction.classifyRuleHits(
                         List.of(
-                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r-draft", "Draft"),
-                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r-test", "Test")));
+                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r-draft", "draft"),
+                                new RuleHit(Rule.CUSTOM_RULES_INDEX, "r-test", "test")));
 
         String error = WTransportIndexDetectorAction.validateClassificationResult(result, "my-type");
 


### PR DESCRIPTION
### Description
This PR normalizes the values stored in SAP's `space` / `source` field to the lowercase convention used by the Content Manager (`standard`, `custom`, `test`, `draft`). Two problems are fixed in one go: SAP used to store capitalized values, and it used `Sigma` as the name for what the Content Manager calls `standard`. 

### Changes

**Code**
- `model/Detector.java`: renamed constant `SIGMA_SOURCE = "Sigma"` to `STANDARD_SOURCE = "standard"`, and changed `DEFAULT_SOURCE` from `"Custom"` to `"custom"`. `isStandardDetector()` now compares against `STANDARD_SOURCE` (still case-insensitive for backward compatibility).
- `correlation/JoinEngine.java`: match query now uses `"standard"` instead of `"Sigma"`.
- `transport/TransportIndexDetectorAction.java`: custom-rules import query filters on `rule.space = "custom"`, error message and comments updated to lowercase. Also switched `Locale.getDefault()` to `Locale.ROOT` in the rule-count error message for deterministic formatting.
- `transport/TransportIndexCustomLogTypeAction.java` and `TransportDeleteCustomLogTypeAction.java`: standard-space guard now checks for `"standard"` (three call sites total).
- `transport/WTransportIndexDetectorAction.java`: rule classification expects `"custom"`; error message updated.
- `transport/WTransportIndexIntegrationAction.java`: custom vs. standard branch now compares against `"standard"`.
- `util/DetectorFactory.java`: default `createDetector` overload uses `Detector.STANDARD_SOURCE`.
- `resources/OSMapping/logtypes.json`: all 22 pre-packaged log types changed from `"source": "Sigma"` to `"source": "standard"`. This is the primary data-side change, since this file populates `.opensearch-sap-log-types-config` on bootstrap.

**Tests**
- `TestHelpers.java`, `WTransportIndexDetectorActionTests.java`, `CustomLogTypeRestApiIT.java`, `CorrelationEngineRestApiIT.java`: space literals updated to lowercase and asserted error substrings updated to match the new messages.

### Related Issues
Resolves #146