### PR TITLE
Add support for case-insensitive Sigma operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add Wazuh Alerting plugin to the build process [(#114)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/114)
 - Validate single rule space per detector [(#130)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/130)
 - Add revert bump functionality to repository bumper workflow [(#154)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/154)
+- Add support for case-insensitive Sigma operators [(#183)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/183)
 
 ### Dependencies
 - Update to JDK 25 [(#49)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/49)

--- a/src/main/java/org/opensearch/securityanalytics/rules/objects/SigmaCondition.java
+++ b/src/main/java/org/opensearch/securityanalytics/rules/objects/SigmaCondition.java
@@ -1,11 +1,24 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.opensearch.securityanalytics.rules.objects;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.opensearch.securityanalytics.rules.aggregation.AggregationItem;
 import org.opensearch.securityanalytics.rules.aggregation.AggregationTraverseVisitor;
@@ -23,11 +36,12 @@ import org.opensearch.securityanalytics.rules.exceptions.SigmaConditionError;
 import org.opensearch.securityanalytics.rules.utils.AnyOneOf;
 import org.opensearch.securityanalytics.rules.utils.Either;
 
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class SigmaCondition {
 
@@ -37,7 +51,11 @@ public class SigmaCondition {
 
     private final String identifierPattern = "[a-zA-Z0-9*_]+";
 
-    private final List<Either<List<String>, String>> selector = List.of(Either.left(quantifier), Either.right("of"), Either.right(identifierPattern));
+    private final List<Either<List<String>, String>> selector =
+            List.of(Either.left(quantifier), Either.right("of"), Either.right(identifierPattern));
+
+    private static final Pattern OPERATOR_PATTERN =
+            Pattern.compile("\\b(and|or|not)\\b", Pattern.CASE_INSENSITIVE);
 
     private final List<String> operators = List.of("not ", " and ", " or ");
 
@@ -55,7 +73,27 @@ public class SigmaCondition {
 
     private AggregationTraverseVisitor aggVisitor;
 
+    /**
+     * Normalize operators in the condition string to lowercase to ensure they are correctly
+     * recognized by the ANTLR lexer, which defines them as lowercase literals. This allows users to
+     * write conditions using uppercase operators (e.g., "AND", "OR", "NOT") without causing parsing
+     * errors, while still preserving the case of detection identifiers.
+     *
+     * @param condition the condition string to normalize
+     * @return the normalized condition string with operators in lowercase
+     */
+    private static String normalizeOperators(String condition) {
+        Matcher m = OPERATOR_PATTERN.matcher(condition);
+        StringBuilder sb = new StringBuilder();
+        while (m.find()) {
+            m.appendReplacement(sb, m.group().toLowerCase());
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
     public SigmaCondition(String condition, SigmaDetections detections) {
+        condition = SigmaCondition.normalizeOperators(condition);
         if (condition.contains(" | ")) {
             this.condition = condition.split(" \\| ")[0];
             this.aggregation = condition.split(" \\| ")[1];
@@ -81,9 +119,12 @@ public class SigmaCondition {
         if (itemOrCondition.isLeft()) {
             parsedConditionItem = itemOrCondition.getLeft();
         } else {
-            parsedConditionItem = Objects.requireNonNull(parsed(condition)).isLeft()? Objects.requireNonNull(parsed(condition)).getLeft():
-                    ((Objects.requireNonNull(parsed(condition))).isMiddle()? Objects.requireNonNull(parsed(condition)).getMiddle():
-                            Objects.requireNonNull(parsed(condition)).get());
+            parsedConditionItem =
+                    Objects.requireNonNull(parsed(condition)).isLeft()
+                            ? Objects.requireNonNull(parsed(condition)).getLeft()
+                            : ((Objects.requireNonNull(parsed(condition))).isMiddle()
+                                    ? Objects.requireNonNull(parsed(condition)).getMiddle()
+                                    : Objects.requireNonNull(parsed(condition)).get());
         }
 
         AggregationItem parsedAggItem = null;
@@ -94,13 +135,35 @@ public class SigmaCondition {
         return Pair.of(parsedConditionItem, parsedAggItem);
     }
 
-    public List<Either<AnyOneOf<ConditionItem, ConditionFieldEqualsValueExpression, ConditionValueExpression>, String>> convertArgs(
-            List<Either<AnyOneOf<ConditionItem, ConditionFieldEqualsValueExpression, ConditionValueExpression>, String>> parsedArgs) throws SigmaConditionError {
-        List<Either<AnyOneOf<ConditionItem, ConditionFieldEqualsValueExpression, ConditionValueExpression>, String>> newArgs = new ArrayList<>();
+    public List<
+                    Either<
+                            AnyOneOf<
+                                    ConditionItem, ConditionFieldEqualsValueExpression, ConditionValueExpression>,
+                            String>>
+            convertArgs(
+                    List<
+                                    Either<
+                                            AnyOneOf<
+                                                    ConditionItem,
+                                                    ConditionFieldEqualsValueExpression,
+                                                    ConditionValueExpression>,
+                                            String>>
+                            parsedArgs)
+                    throws SigmaConditionError {
+        List<
+                        Either<
+                                AnyOneOf<
+                                        ConditionItem, ConditionFieldEqualsValueExpression, ConditionValueExpression>,
+                                String>>
+                newArgs = new ArrayList<>();
 
-        for (Either<AnyOneOf<ConditionItem, ConditionFieldEqualsValueExpression, ConditionValueExpression>, String> parsedArg: parsedArgs) {
+        for (Either<
+                        AnyOneOf<ConditionItem, ConditionFieldEqualsValueExpression, ConditionValueExpression>,
+                        String>
+                parsedArg : parsedArgs) {
             if (parsedArg.isRight()) {
-                AnyOneOf<ConditionItem, ConditionFieldEqualsValueExpression, ConditionValueExpression> newItem = parsed(parsedArg.get());
+                AnyOneOf<ConditionItem, ConditionFieldEqualsValueExpression, ConditionValueExpression>
+                        newItem = parsed(parsedArg.get());
                 newArgs.add(Either.left(newItem));
             } else {
                 newArgs.add(parsedArg);
@@ -109,21 +172,30 @@ public class SigmaCondition {
         return newArgs;
     }
 
-    private AnyOneOf<ConditionItem, ConditionFieldEqualsValueExpression, ConditionValueExpression> parsed(String token) throws SigmaConditionError {
+    private AnyOneOf<ConditionItem, ConditionFieldEqualsValueExpression, ConditionValueExpression>
+            parsed(String token) throws SigmaConditionError {
         List<String> subTokens = List.of(token.split(" "));
         if (subTokens.size() < 3 && token.matches(identifier)) {
             ConditionIdentifier conditionIdentifier =
                     new ConditionIdentifier(Collections.singletonList(Either.right(token)));
             ConditionItem item = conditionIdentifier.postProcess(detections, null);
-            return item instanceof ConditionFieldEqualsValueExpression? AnyOneOf.middleVal((ConditionFieldEqualsValueExpression) item):
-                    (item instanceof ConditionValueExpression ? AnyOneOf.rightVal((ConditionValueExpression) item): AnyOneOf.leftVal(item));
-        } else if (subTokens.size() == 3 && quantifier.contains(subTokens.get(0)) && selector.get(1).get().equals(subTokens.get(1)) &&
-                subTokens.get(2).matches(identifierPattern)) {
+            return item instanceof ConditionFieldEqualsValueExpression
+                    ? AnyOneOf.middleVal((ConditionFieldEqualsValueExpression) item)
+                    : (item instanceof ConditionValueExpression
+                            ? AnyOneOf.rightVal((ConditionValueExpression) item)
+                            : AnyOneOf.leftVal(item));
+        } else if (subTokens.size() == 3
+                && quantifier.contains(subTokens.get(0))
+                && selector.get(1).get().equals(subTokens.get(1))
+                && subTokens.get(2).matches(identifierPattern)) {
             ConditionSelector conditionSelector =
                     new ConditionSelector(subTokens.get(0), subTokens.get(2));
             ConditionItem item = conditionSelector.postProcess(detections, null);
-            return item instanceof ConditionFieldEqualsValueExpression? AnyOneOf.middleVal((ConditionFieldEqualsValueExpression) item):
-                    (item instanceof ConditionValueExpression ? AnyOneOf.rightVal((ConditionValueExpression) item): AnyOneOf.leftVal(item));
+            return item instanceof ConditionFieldEqualsValueExpression
+                    ? AnyOneOf.middleVal((ConditionFieldEqualsValueExpression) item)
+                    : (item instanceof ConditionValueExpression
+                            ? AnyOneOf.rightVal((ConditionValueExpression) item)
+                            : AnyOneOf.leftVal(item));
         }
         return null;
     }

--- a/src/test/java/org/opensearch/securityanalytics/rules/objects/SigmaConditionTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/rules/objects/SigmaConditionTests.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opensearch.securityanalytics.rules.objects;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.opensearch.securityanalytics.rules.condition.ConditionAND;
+import org.opensearch.securityanalytics.rules.condition.ConditionItem;
+import org.opensearch.securityanalytics.rules.condition.ConditionNOT;
+import org.opensearch.securityanalytics.rules.condition.ConditionOR;
+import org.opensearch.securityanalytics.rules.exceptions.SigmaConditionError;
+import org.opensearch.securityanalytics.rules.exceptions.SigmaDetectionError;
+import org.opensearch.securityanalytics.rules.exceptions.SigmaModifierError;
+import org.opensearch.securityanalytics.rules.exceptions.SigmaRegularExpressionError;
+import org.opensearch.securityanalytics.rules.exceptions.SigmaValueError;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Map;
+
+public class SigmaConditionTests extends OpenSearchTestCase {
+
+    private static SigmaDetections detections(String... names)
+            throws SigmaDetectionError,
+                    SigmaModifierError,
+                    SigmaValueError,
+                    SigmaRegularExpressionError,
+                    SigmaConditionError {
+        Map<String, Object> detectionMap = new java.util.LinkedHashMap<>();
+        for (String name : names) {
+            detectionMap.put(name, Map.of("field", "value"));
+        }
+        detectionMap.put("condition", names[0]);
+        return SigmaDetections.fromDict(detectionMap);
+    }
+
+    private static SigmaDetections detectionsWithCondition(String condition, String... names)
+            throws SigmaDetectionError,
+                    SigmaModifierError,
+                    SigmaValueError,
+                    SigmaRegularExpressionError,
+                    SigmaConditionError {
+        Map<String, Object> detectionMap = new java.util.LinkedHashMap<>();
+        for (String name : names) {
+            detectionMap.put(name, Map.of("field", "value"));
+        }
+        detectionMap.put("condition", condition);
+        return SigmaDetections.fromDict(detectionMap);
+    }
+
+    private static ConditionItem parse(String condition, String... identifiers)
+            throws SigmaDetectionError,
+                    SigmaModifierError,
+                    SigmaValueError,
+                    SigmaRegularExpressionError,
+                    SigmaConditionError {
+        SigmaDetections dets = detectionsWithCondition(condition, identifiers);
+        SigmaCondition sigmaCondition = new SigmaCondition(condition, dets);
+        Pair<ConditionItem, ?> result = sigmaCondition.parsed();
+        return result.getLeft();
+    }
+
+    // --- AND operator ---
+
+    public void testAndLowercaseIsAccepted() throws Exception {
+        ConditionItem item = parse("sel1 and sel2", "sel1", "sel2");
+        assertNotNull(item);
+        assertSame(ConditionAND.class, item.getClass());
+    }
+
+    public void testAndUppercaseIsAccepted() throws Exception {
+        ConditionItem item = parse("sel1 AND sel2", "sel1", "sel2");
+        assertNotNull(item);
+        assertSame(ConditionAND.class, item.getClass());
+    }
+
+    public void testAndMixedCaseIsAccepted() throws Exception {
+        ConditionItem item = parse("sel1 And sel2", "sel1", "sel2");
+        assertNotNull(item);
+        assertSame(ConditionAND.class, item.getClass());
+    }
+
+    // --- OR operator ---
+
+    public void testOrLowercaseIsAccepted() throws Exception {
+        ConditionItem item = parse("sel1 or sel2", "sel1", "sel2");
+        assertNotNull(item);
+        assertSame(ConditionOR.class, item.getClass());
+    }
+
+    public void testOrUppercaseIsAccepted() throws Exception {
+        ConditionItem item = parse("sel1 OR sel2", "sel1", "sel2");
+        assertNotNull(item);
+        assertSame(ConditionOR.class, item.getClass());
+    }
+
+    public void testOrMixedCaseIsAccepted() throws Exception {
+        ConditionItem item = parse("sel1 Or sel2", "sel1", "sel2");
+        assertNotNull(item);
+        assertSame(ConditionOR.class, item.getClass());
+    }
+
+    // --- NOT operator ---
+
+    public void testNotLowercaseIsAccepted() throws Exception {
+        ConditionItem item = parse("not sel1", "sel1");
+        assertNotNull(item);
+        assertSame(ConditionNOT.class, item.getClass());
+    }
+
+    public void testNotUppercaseIsAccepted() throws Exception {
+        ConditionItem item = parse("NOT sel1", "sel1");
+        assertNotNull(item);
+        assertSame(ConditionNOT.class, item.getClass());
+    }
+
+    public void testNotMixedCaseIsAccepted() throws Exception {
+        ConditionItem item = parse("Not sel1", "sel1");
+        assertNotNull(item);
+        assertSame(ConditionNOT.class, item.getClass());
+    }
+
+    // --- Chained operators ---
+
+    public void testChainedUppercaseOperators() throws Exception {
+        ConditionItem item = parse("sel1 AND sel2 OR NOT sel3", "sel1", "sel2", "sel3");
+        assertNotNull(item);
+    }
+
+    public void testChainedMixedCaseOperators() throws Exception {
+        ConditionItem item = parse("sel1 And sel2 Or Not sel3", "sel1", "sel2", "sel3");
+        assertNotNull(item);
+    }
+
+    // --- Identifier names containing operator substrings are not mangled ---
+
+    public void testIdentifierContainingAndSubstring() throws Exception {
+        ConditionItem item = parse("android_sel AND norton_filter", "android_sel", "norton_filter");
+        assertNotNull(item);
+        assertSame(ConditionAND.class, item.getClass());
+    }
+
+    public void testIdentifierContainingOrSubstring() throws Exception {
+        ConditionItem item = parse("selector OR oracle_filter", "selector", "oracle_filter");
+        assertNotNull(item);
+        assertSame(ConditionOR.class, item.getClass());
+    }
+
+    // --- Lowercase operators remain unaffected ---
+
+    public void testLowercaseOperatorsUnchanged() throws Exception {
+        ConditionItem andItem = parse("sel1 and sel2", "sel1", "sel2");
+        ConditionItem andUpperItem = parse("sel1 AND sel2", "sel1", "sel2");
+        assertSame(andItem.getClass(), andUpperItem.getClass());
+
+        ConditionItem orItem = parse("sel1 or sel2", "sel1", "sel2");
+        ConditionItem orUpperItem = parse("sel1 OR sel2", "sel1", "sel2");
+        assertSame(orItem.getClass(), orUpperItem.getClass());
+
+        ConditionItem notItem = parse("not sel1", "sel1");
+        ConditionItem notUpperItem = parse("NOT sel1", "sel1");
+        assertSame(notItem.getClass(), notUpperItem.getClass());
+    }
+}


### PR DESCRIPTION
### Description

Lowercase Sigma operators in the condition string to ensure they are correctly recognized by the ANTLR lexer.

<details><summary>Details</summary>
<p>

Using uppercase and lowercase operator matches and generates a finding.

```log
[2026-04-29T14:01:24,838][INFO ][o.o.s.e.WazuhEnrichedFindingService] [indexer] Flushing 1 pending enriched findings
[2026-04-29T14:01:24,849][INFO ][o.o.s.e.WazuhEnrichedFindingService] [indexer] Bulk indexing of enriched findings completed successfully
```


```json
{
          "wazuh": {
            "agent": {
              "name": "test-agent-001"
            },
            "integration": {
              "name": "findings-enrichment-test",
              "category": "other"
            }
          },
          "rule": {
            "sigma_id": "144b3285-fbe8-409e-8e44-80bfaf7951f0",
            "level": "high",
            "compliance": {
              "iso_27001": [
                "A.9.4.1"
              ],
              "pci_dss": [
                "2.2.1",
                "6.3.3"
              ],
              "hipaa": [
                "164.312(a)(1)"
              ],
              "tsc": [
                "CC6.1"
              ],
              "nist_800_171": [
                "3.1.1"
              ],
              "nis2": [
                "Art. 21"
              ],
              "fedramp": [
                "AC-2"
              ],
              "nist_800_53": [
                "AC-3",
                "AU-2"
              ],
              "cmmc": [
                "AC.1.001"
              ],
              "gdpr": [
                "Art. 32",
                "Art. 25"
              ]
            },
            "mitre": {
              "technique": [
                "T1059",
                "T1562",
                "T1059.001"
              ],
              "subtechnique": [
                "T1059.001"
              ],
              "tactic": [
                "TA0002",
                "TA0005"
              ]
            },
            "id": "144b3285-fbe8-409e-8e44-80bfaf7951f0",
            "title": "KeePass (mod)",
            "tags": [
              "high",
              "findings-enrichment-test",
              "attack.credential-access",
              "attack.t1555.005"
            ],
            "status": "test"
          },
          "process": {
            "parent.command_line": "/bin/java",
            "executable": "KeePass.exe"
          },
          "@timestamp": "2026-04-29T14:01:20.026131463Z",
          "event": {
            "ingested": "2026-04-29T14:00:24Z",
            "index": ".ds-wazuh-events-v5-other-000001",
            "doc_id": "htSK2Z0BmH1yhkIacbDb"
          }
        }
```

</p>
</details> 


### Related Issues
Resolves #182 

### Validation

<details><summary>session.md</summary>
<p>

```json
POST /_plugins/_content_manager/integrations
{
  "resource": {
    "metadata": {
      "description": "This is a test integration.",
      "documentation": "test1234",
      "references": [
        "https://wazuh.com"
      ],
      "title": "findings-enrichment-test",
      "author": "Wazuh Inc."
    },
    "category": "other"
  }
}
# ccd23853-c7e2-4668-9528-9690b71b0683


POST /_plugins/_content_manager/rules
{
  "integration": "ccd23853-c7e2-4668-9528-9690b71b0683",
  "resource": {
    "id": "db226338-863e-4227-bb71-a1b040ef014d",
    "logsource": {
      "product": "findings-enrichment-test"
    },
    "metadata": {
      "title": "KeePass (mod)",
      "description": "Test rule",
      "references": [],
      "author": "Wazuh"
    },
    "mitre": {
      "tactic": [
        "TA0002",
        "TA0005"
      ],
      "technique": [
        "T1059",
        "T1562"
      ],
      "subtechnique": [
        "T1059.001"
      ]
    },
    "compliance": {
      "gdpr": [
        "Art. 32",
        "Art. 25"
      ],
      "pci_dss": [
        "2.2.1",
        "6.3.3"
      ],
      "cmmc": [
        "AC.1.001"
      ],
      "nist_800_53": [
        "AC-3",
        "AU-2"
      ],
      "nist_800_171": [
        "3.1.1"
      ],
      "hipaa": [
        "164.312(a)(1)"
      ],
      "iso_27001": [
        "A.9.4.1"
      ],
      "nis2": [
        "Art. 21"
      ],
      "tsc": [
        "CC6.1"
      ],
      "fedramp": [
        "AC-2"
      ]
    },
    "tags": [
      "attack.credential-access",
      "attack.t1555.005"
    ],
    "falsepositives": [
      "Unknown"
    ],
    "level": "high",
    "status": "test",
    "detection": {
      "condition": "1 of selection AND sub_processes",
      "selection": {
        "process.executable": "KeePass.exe"
      },
      "sub_processes": {
        "process.parent.command_line": "/bin/java"
      }
    }
  }
}
# c460889e-af1e-44a7-85bb-1e737a232a77

## Root decoder
POST /_plugins/_content_manager/decoders
{
  "integration": "ccd23853-c7e2-4668-9528-9690b71b0683",
  "resource": {
    "enabled": true,
    "metadata": {
      "compatibility": "All wazuh events.",
      "description": """Base decoder to process Wazuh message format, parses location part and enriches the events that comes from a Wazuh agent with the host information.
""",
      "module": "wazuh",
      "references": [
        "https://documentation.wazuh.com/"
      ],
      "title": "Wazuh message decoder",
      "versions": [
        "Wazuh 5.*"
      ]
    },
    "name": "decoder/core-wazuh-message/0",
    "normalize": [
      {
        "map": [
          {
            "@timestamp": "get_date()"
          }
        ]
      }
    ]
  }
}
# b7752a03-b070-4611-9767-da52cc6886a1


GET wazuh-threatintel-policies/_search?size=1
{
 "query": {
   "match": {
     "space.name": "draft"
   }
 }
}
PUT _plugins/_content_manager/policy/draft
{
  "resource": {
    "id": "4a2bbfac-1235-37ba-ac04-0cefe3ecace0",
    "metadata": {
      "title": "Custom space",
      "author": "Custom",
      "date": "2026-04-29T11:12:39Z",
      "modified": "2026-04-29T11:12:39Z",
      "description": "Custom space",
      "references": [],
      "documentation": "",
      "compatibility": []
    },
    "root_decoder": "5b45ecd5-9400-4748-af11-a5c6ec8113e4",
    "integrations": [
      "ccd23853-c7e2-4668-9528-9690b71b0683"
    ],
    "filters": [],
    "enrichments": [],
    "enabled": false,
    "index_unclassified_events": false,
    "index_discarded_events": false
  }
}
GET _plugins/_content_manager/promote?space=draft
POST _plugins/_content_manager/promote
{
  "space": "test",
  "changes": {
    "kvdbs": [],
    "rules": [
      {
        "id": "01e62258-0e81-481d-adf4-676d10a75366",
        "operation": "add"
      }
    ],
    "decoders": [
      {
        "id": "5b45ecd5-9400-4748-af11-a5c6ec8113e4",
        "operation": "add"
      }
    ],
    "filters": [],
    "integrations": [
      {
        "id": "ccd23853-c7e2-4668-9528-9690b71b0683",
        "operation": "add"
      }
    ],
    "policy": [
      {
        "id": "4a2bbfac-1235-37ba-ac04-0cefe3ecace0",
        "operation": "update"
      }
    ]
  }
}


POST _plugins/_security_analytics/detectors
{
  "enabled": true,
  "schedule": {
    "period": {
      "interval": 1,
      "unit": "MINUTES"
    }
  },
  "detector_type": "findings-enrichment-test",
  "type": "detector",
  "inputs": [
    {
      "detector_input": {
        "description": "test detector for security analytics",
        "custom_rules": [
          {
            "id": "01e62258-0e81-481d-adf4-676d10a75366"
          }
        ],
        "indices": [
          "wazuh-events-v5-other"
        ],
        "pre_packaged_rules": []
      }
    }
  ],
  "triggers": [],
  "name": "test-detector"
}

POST wazuh-events-v5-other/_doc
{
  "wazuh": {
    "agent": {
      "name": "test-agent-001"
    },
    "integration": {
      "category": "other",
      "name": "findings-enrichment-test"
    }
  },
  "process": {
    "executable": "KeePass.exe",
    "parent.command_line": "/bin/java"
  },
  "@timestamp": "2026-04-29T14:00:24Z"
}
GET wazuh-findings-v5-other*/_search
```

</p>
</details> 

#### `AND`|`and` operator

1. The custom rule uses the `AND` operator.
2. Promote to test.
4. Index a test document that satisfies the condition.
5. Check that a finding is generated.

-- edit the rule --

1. The custom rule uses the `and` operator.
2. Promote to test.
4. Index a test document that satisfies the condition.
5. Check that a finding is generated.

-- /\ --

1. Index a test document that DOES NOT satisfy the condition.
2. Check that a finding is NOT generated.

#### `OR`|`or` operator

1. The custom rule uses the `OR` operator.
2. Promote to test.
4. Index a test document that satisfies the condition.
5. Check that a finding is generated.

-- edit the rule --

1. The custom rule uses the `or` operator.
2. Promote to test.
4. Index a test document that satisfies the condition.
5. Check that a finding is generated.

-- /\ --

1. Index a test document that DOES NOT satisfy the condition.
2. Check that a finding is NOT generated.

#### `NOT`|`not` operator

```yaml
detection:
  condition: 1 of selection and NOT sub_processes
  selection:
    process.executable: KeePass.exe
  sub_processes:
    process.parent.command_line: /bin/java
```

```json
POST wazuh-events-v5-other/_doc
{
  "wazuh": {
    "agent": {
      "name": "test-agent-001"
    },
    "integration": {
      "category": "other",
      "name": "findings-enrichment-test"
    }
  },
  "process": {
    "executable": "KeePass.exe",
    "parent.command_line": "/bin/python"
  },
  "@timestamp": "2026-04-29T14:24:24Z"
}
```

1. The custom rule uses the `NOT` operator.
2. Promote to test.
4. Index a test document that satisfies the condition.
5. Check that a finding is generated.

-- edit the rule --

1. The custom rule uses the `not` operator.
2. Promote to test.
4. Index a test document that satisfies the condition.
5. Check that a finding is generated.

-- /\ --

1. Index a test document that DOES NOT satisfy the condition.
2. Check that a finding is NOT generated.