### PR TITLE
Fix race condition and missing else branch in TransportCorrelateFindingAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix race condition on findings correlation [(#106)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/106) [(#132)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/132)
 - Fix codeql issues [(#113)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/113)
 - Fix stale detector references after rule deletion [(#152)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/152)
+- Fix race condition and missing else branch on correlation metadata index creation [(#148)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/184)
 
 ### Security
 -

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
@@ -281,6 +281,8 @@ public class TransportCorrelateFindingAction
                                                 } catch (Exception ex) {
                                                     correlateFindingAction.onFailures(ex);
                                                 }
+                                            } else {
+                                                correlateFindingAction.start();
                                             }
                                             if (!correlationIndices.correlationAlertIndexExists()) {
                                                 try {
@@ -654,7 +656,17 @@ public class TransportCorrelateFindingAction
                                             onFailures(e);
                                         }
                                     },
-                                    this::onFailures));
+                                    e -> {
+                                        if (ExceptionsHelper.unwrapCause(e) instanceof ResourceAlreadyExistsException) {
+                                            log.debug(
+                                                    "Correlation metadata index already exists, proceeding with existing index");
+                                            IndexUtils.correlationMetadataIndexUpdated();
+                                            getTimestampFeature(
+                                                    detectorType, correlatedFindings, orphanFinding, correlationRules);
+                                        } else {
+                                            onFailures(e);
+                                        }
+                                    }));
                 } else {
                     long findingTimestamp = this.request.getFinding().getTimestamp().toEpochMilli();
                     SearchRequest searchMetadataIndexRequest = getSearchMetadataIndexRequest();

--- a/src/test/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingActionTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingActionTests.java
@@ -16,11 +16,55 @@
  */
 package org.opensearch.securityanalytics.transport;
 
+import org.opensearch.ResourceAlreadyExistsException;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.commons.alerting.action.PublishFindingsRequest;
+import org.opensearch.commons.alerting.action.SubscribeFindingsResponse;
+import org.opensearch.commons.alerting.model.Finding;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.securityanalytics.correlation.alert.CorrelationAlertService;
+import org.opensearch.securityanalytics.correlation.alert.notifications.NotificationService;
+import org.opensearch.securityanalytics.enrichment.WazuhEnrichedFindingService;
+import org.opensearch.securityanalytics.logtype.LogTypeService;
 import org.opensearch.securityanalytics.model.CustomLogType;
+import org.opensearch.securityanalytics.model.Detector;
+import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
+import org.opensearch.securityanalytics.util.CorrelationIndices;
+import org.opensearch.securityanalytics.util.DetectorIndices;
+import org.opensearch.tasks.Task;
+import org.opensearch.tasks.TaskManager;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
 
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+
+import org.mockito.ArgumentCaptor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TransportCorrelateFindingActionTests extends OpenSearchTestCase {
 
@@ -80,5 +124,176 @@ public class TransportCorrelateFindingActionTests extends OpenSearchTestCase {
         source.put("category", "web");
         source.put("tags", Map.of("source", "wazuh"));
         return source;
+    }
+
+    private static class TestSetup {
+        Client client;
+        CorrelationIndices correlationIndices;
+        DetectorIndices detectorIndices;
+        ThreadPool threadPool;
+        TransportCorrelateFindingAction transportAction;
+    }
+
+    private TestSetup buildTestSetup() {
+        TestSetup s = new TestSetup();
+        s.client = mock(Client.class);
+        s.correlationIndices = mock(CorrelationIndices.class);
+        s.detectorIndices = mock(DetectorIndices.class);
+        s.threadPool = mock(ThreadPool.class);
+
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterSettings clusterSettings =
+                new ClusterSettings(
+                        Settings.EMPTY,
+                        new HashSet<>(
+                                Arrays.asList(
+                                        SecurityAnalyticsSettings.INDEX_TIMEOUT,
+                                        SecurityAnalyticsSettings.CORRELATION_TIME_WINDOW,
+                                        SecurityAnalyticsSettings.ENABLE_AUTO_CORRELATIONS,
+                                        SecurityAnalyticsSettings.ENRICHED_FINDINGS_ENABLED)));
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterService.state()).thenReturn(ClusterState.builder(new ClusterName("test")).build());
+        when(s.detectorIndices.getThreadPool()).thenReturn(s.threadPool);
+        when(s.threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+
+        ExecutorService executor = mock(ExecutorService.class);
+        doAnswer(
+                        inv -> {
+                            ((Runnable) inv.getArgument(0)).run();
+                            return null;
+                        })
+                .when(executor)
+                .execute(any());
+        when(s.threadPool.executor(anyString())).thenReturn(executor);
+
+        TransportService transportService = mock(TransportService.class);
+        when(transportService.getTaskManager()).thenReturn(mock(TaskManager.class));
+
+        s.transportAction =
+                new TransportCorrelateFindingAction(
+                        transportService,
+                        s.client,
+                        mock(NamedXContentRegistry.class),
+                        s.detectorIndices,
+                        s.correlationIndices,
+                        mock(LogTypeService.class),
+                        clusterService,
+                        Settings.EMPTY,
+                        new ActionFilters(Collections.emptySet()),
+                        mock(CorrelationAlertService.class),
+                        mock(NotificationService.class),
+                        mock(WazuhEnrichedFindingService.class));
+        return s;
+    }
+
+    private TransportCorrelateFindingAction.AsyncCorrelateFindingAction buildAsyncAction(
+            TestSetup s, ActionListener<SubscribeFindingsResponse> listener) {
+        Finding finding =
+                new Finding(
+                        "finding-1",
+                        List.of("doc-1"),
+                        List.of("doc-1"),
+                        "monitor-1",
+                        "monitor-name",
+                        "test-index",
+                        Collections.emptyList(),
+                        Instant.now(),
+                        "high");
+        PublishFindingsRequest request = new PublishFindingsRequest("monitor-1", finding);
+
+        return s.transportAction
+        .new AsyncCorrelateFindingAction(mock(Task.class), request, null, listener);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGetTimestampFeature_resourceAlreadyExists_retriesAndProceeds() throws Exception {
+        TestSetup s = buildTestSetup();
+        ActionListener<SubscribeFindingsResponse> listener = mock(ActionListener.class);
+        TransportCorrelateFindingAction.AsyncCorrelateFindingAction asyncAction =
+                buildAsyncAction(s, listener);
+
+        when(s.correlationIndices.correlationMetadataIndexExists()).thenReturn(false).thenReturn(true);
+        doAnswer(
+                        inv -> {
+                            ActionListener<CreateIndexResponse> l = inv.getArgument(0);
+                            l.onFailure(
+                                    new ResourceAlreadyExistsException(
+                                            CorrelationIndices.CORRELATION_METADATA_INDEX));
+                            return null;
+                        })
+                .when(s.correlationIndices)
+                .initCorrelationMetadataIndex(any());
+
+        asyncAction.getTimestampFeature(
+                "windows", Collections.emptyMap(), null, Collections.emptyList());
+
+        ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+        verify(s.client).search(captor.capture(), any());
+        assertTrue(
+                "Expected search against metadata index",
+                Arrays.asList(captor.getValue().indices())
+                        .contains(CorrelationIndices.CORRELATION_METADATA_INDEX));
+        verify(listener, never()).onFailure(any());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGetTimestampFeature_otherException_callsOnFailures() throws Exception {
+        TestSetup s = buildTestSetup();
+        ActionListener<SubscribeFindingsResponse> listener = mock(ActionListener.class);
+        TransportCorrelateFindingAction.AsyncCorrelateFindingAction asyncAction =
+                buildAsyncAction(s, listener);
+
+        when(s.correlationIndices.correlationMetadataIndexExists()).thenReturn(false);
+        doAnswer(
+                        inv -> {
+                            ActionListener<CreateIndexResponse> l = inv.getArgument(0);
+                            l.onFailure(new RuntimeException("unexpected storage failure"));
+                            return null;
+                        })
+                .when(s.correlationIndices)
+                .initCorrelationMetadataIndex(any());
+
+        asyncAction.getTimestampFeature(
+                "windows", Collections.emptyMap(), null, Collections.emptyList());
+
+        verify(listener).onFailure(any());
+        verify(s.client, never()).search(any(), any());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testDoExecute_metadataIndexAlreadyExists_callsStart() throws Exception {
+        TestSetup s = buildTestSetup();
+        when(s.correlationIndices.correlationIndexExists()).thenReturn(false);
+        when(s.correlationIndices.correlationMetadataIndexExists()).thenReturn(true);
+        doAnswer(
+                        inv -> {
+                            ActionListener<CreateIndexResponse> l = inv.getArgument(0);
+                            l.onResponse(new CreateIndexResponse(true, true, "history-index-1"));
+                            return null;
+                        })
+                .when(s.correlationIndices)
+                .initCorrelationIndex(any());
+
+        when(s.detectorIndices.detectorIndexExists()).thenReturn(true);
+
+        Finding finding =
+                new Finding(
+                        "finding-1",
+                        List.of("doc-1"),
+                        List.of("doc-1"),
+                        "monitor-1",
+                        "monitor-name",
+                        "test-index",
+                        Collections.emptyList(),
+                        Instant.now(),
+                        "high");
+        PublishFindingsRequest findingsRequest = new PublishFindingsRequest("monitor-1", finding);
+        ActionListener<SubscribeFindingsResponse> listener = mock(ActionListener.class);
+
+        s.transportAction.execute(mock(Task.class), findingsRequest, listener);
+
+        ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+        verify(s.client).search(captor.capture(), any());
+        assertEquals(Detector.DETECTORS_INDEX, captor.getValue().indices()[0]);
     }
 }


### PR DESCRIPTION
### Description

This PR fixes a race condition in `TransportCorrelateFindingAction` that caused findings to be silently dropped when multiple findings arrived in parallel. Every thread used to read `correlationMetadataIndexCreated = false`, race to create `.opensearch-sap-correlation-metadata`, and the losers would fail with `ResourceAlreadyExistsException` straight into `onFailures()` so their finding never reached `start()`.

The fix is two small changes in the same class: a catch branch that distinguishes the benign "index already exists" case from real errors and re-enters the flow recursively, and a missing `else` in `doExecute` that left findings stranded when the metadata index already existed at startup.

### Changes

**Code**

- `transport/TransportCorrelateFindingAction.java` : `getTimestampFeature` failure callback now distinguishes the benign case from real errors:

  ```java
  e -> {
      if (ExceptionsHelper.unwrapCause(e) instanceof ResourceAlreadyExistsException) {
          log.debug("Correlation metadata index already exists, proceeding with existing index");
          IndexUtils.correlationMetadataIndexUpdated();
          getTimestampFeature(detectorType, correlatedFindings, orphanFinding, correlationRules);
      } else {
          onFailures(e);
      }
  }
  ```

  On the recursive call the flag is already `true` (set either by the winning thread or by `correlationMetadataIndexUpdated()` in this catch), so the method enters the normal `else` branch and the finding continues to `start()`. 

- `transport/TransportCorrelateFindingAction.java` : `doExecute` restores the missing `else`:

  ```java
  } else {
      correlateFindingAction.start();
  }
  ```

  Without this, when the metadata index already existed before startup (the common case after a normal restart) the flow ended without doing anything.

**Tests**

- `transport/TransportCorrelateFindingActionTests.java`: added three unit tests for the new behaviour.
  - `testGetTimestampFeature_resourceAlreadyExists_retriesAndProceeds` : reproduces the race scenario (mock returns `false` then `true` on `correlationMetadataIndexExists()`, and `initCorrelationMetadataIndex` fails with `ResourceAlreadyExistsException`). 
  - `testGetTimestampFeature_otherException_callsOnFailures` : when the failure is **not** `ResourceAlreadyExistsException`, the new `else` branch must still propagate it.
  - `testDoExecute_metadataIndexAlreadyExists_callsStart`: covers the second part of the fix. With the metadata index already present at startup (the common case after a restart), the missing `else` used to leave the flow stranded.

### Validation  

Validated on Wazuh 5.0. I forced the race by deleting `.opensearch-sap-correlation-metadata` and pushing findings, with `org.opensearch.securityanalytics.transport` raised to `DEBUG` via the cluster settings API.

One thread wins and creates the index; the other three hit the new catch branch and continue:

```
[2026-04-29T11:36:46,016][INFO ][o.o.c.m.MetadataCreateIndexService] [indexer] [.opensearch-sap-correlation-metadata] creating index, cause [api], templates [], shards [1]/[0]
[2026-04-29T11:36:46,453][INFO ][o.o.i.MergeSchedulerConfig] [indexer] Initialized index .opensearch-sap-correlation-metadata with maxMergeCount=7, maxThreadCount=2, autoThrottleEnabled=true
[2026-04-29T11:36:46,454][INFO ][o.o.p.PluginsService     ] [indexer] PluginService:onIndexModule index:[.opensearch-sap-correlation-metadata/BHZDVFh4Q6i_KUy8ysYs-g]
[2026-04-29T11:36:46,552][DEBUG][o.o.s.t.TransportCorrelateFindingAction] [indexer] Correlation metadata index already exists, proceeding with existing index
[2026-04-29T11:36:46,562][DEBUG][o.o.s.t.TransportCorrelateFindingAction] [indexer] Correlation metadata index already exists, proceeding with existing index
[2026-04-29T11:36:46,566][DEBUG][o.o.s.t.TransportCorrelateFindingAction] [indexer] Correlation metadata index already exists, proceeding with existing index
```

### Related Issues

Resolves #148