### PR TITLE
Fix enrichment dispatch coupling that dropped findings on correlation failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix stale detector references after rule deletion [(#152)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/152)
 - Fix race condition and missing else branch on correlation metadata index creation [(#148)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/184)
 - Fix contains conditions using white spaces [(#162)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/162)
+- Fix enrichment dispatch coupling that dropped findings on correlation failure [(#193)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/193)
 
 ### Security
 -

--- a/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
+++ b/src/main/java/org/opensearch/securityanalytics/SecurityAnalyticsPlugin.java
@@ -81,6 +81,9 @@ import org.opensearch.securityanalytics.action.SearchDetectorAction;
 import org.opensearch.securityanalytics.action.SearchRuleAction;
 import org.opensearch.securityanalytics.action.UpdateIndexMappingsAction;
 import org.opensearch.securityanalytics.action.ValidateRulesAction;
+import org.opensearch.securityanalytics.correlation.CorrelationRulesCache;
+import org.opensearch.securityanalytics.correlation.DetectorLookupCache;
+import org.opensearch.securityanalytics.correlation.LogTypeListCache;
 import org.opensearch.securityanalytics.correlation.alert.CorrelationAlertService;
 import org.opensearch.securityanalytics.correlation.alert.notifications.NotificationService;
 import org.opensearch.securityanalytics.correlation.index.codec.CorrelationCodecService;
@@ -314,6 +317,15 @@ public class SecurityAnalyticsPlugin extends Plugin
                         SecurityAnalyticsSettings.ENRICHED_FINDINGS_ENABLED.get(environment.settings()),
                         SecurityAnalyticsSettings.INDEX_TIMEOUT.get(environment.settings()),
                         threadPool);
+        DetectorLookupCache detectorLookupCache =
+                new DetectorLookupCache(
+                        SecurityAnalyticsSettings.CORRELATION_DETECTOR_CACHE_TTL.get(environment.settings()));
+        LogTypeListCache logTypeListCache =
+                new LogTypeListCache(
+                        SecurityAnalyticsSettings.CORRELATION_METADATA_CACHE_TTL.get(environment.settings()));
+        CorrelationRulesCache correlationRulesCache =
+                new CorrelationRulesCache(
+                        SecurityAnalyticsSettings.CORRELATION_METADATA_CACHE_TTL.get(environment.settings()));
 
         // Initialize WCS field validator from cluster index mappings
         SecurityAnalyticsPlugin.initWCSFieldValidator(clusterService);
@@ -330,7 +342,10 @@ public class SecurityAnalyticsPlugin extends Plugin
                 this.builtinLogTypeLoader,
                 correlationAlertService,
                 notificationService,
-                enrichedFindingService);
+                enrichedFindingService,
+                detectorLookupCache,
+                logTypeListCache,
+                correlationRulesCache);
     }
 
     /**
@@ -481,7 +496,10 @@ public class SecurityAnalyticsPlugin extends Plugin
                 SecurityAnalyticsSettings.IOC_MAX_INDICES_PER_INDEX_PATTERN,
                 SecurityAnalyticsSettings.IOC_SCAN_MAX_TERMS_COUNT,
                 SecurityAnalyticsSettings.ENABLE_DETECTORS_WITH_DEDICATED_QUERY_INDICES,
-                SecurityAnalyticsSettings.ENRICHED_FINDINGS_ENABLED);
+                SecurityAnalyticsSettings.ENRICHED_FINDINGS_ENABLED,
+                SecurityAnalyticsSettings.CORRELATION_DETECTOR_CACHE_TTL,
+                SecurityAnalyticsSettings.CORRELATION_MAX_IN_FLIGHT_FINDINGS,
+                SecurityAnalyticsSettings.CORRELATION_METADATA_CACHE_TTL);
     }
 
     @Override

--- a/src/main/java/org/opensearch/securityanalytics/correlation/CorrelationRulesCache.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/CorrelationRulesCache.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opensearch.securityanalytics.correlation;
+
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.securityanalytics.model.CorrelationRule;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
+
+/**
+ * TTL-bounded cache of correlation rules keyed by detector type. The {@link
+ * org.opensearch.securityanalytics.correlation.JoinEngine} performs an identical search against
+ * {@code .opensearch-correlation-rules-config} for every finding sharing the same detector type;
+ * this cache eliminates that redundancy.
+ *
+ * <p>A TTL of zero disables the cache.
+ */
+public final class CorrelationRulesCache {
+
+    private final ConcurrentHashMap<String, Entry> byDetectorType = new ConcurrentHashMap<>();
+    private final LongSupplier clock;
+    private volatile long ttlNanos;
+
+    public CorrelationRulesCache(TimeValue ttl) {
+        this(ttl, System::nanoTime);
+    }
+
+    CorrelationRulesCache(TimeValue ttl, LongSupplier clock) {
+        this.ttlNanos = ttl.nanos();
+        this.clock = clock;
+    }
+
+    public Optional<List<CorrelationRule>> get(String detectorType) {
+        if (ttlNanos <= 0) {
+            return Optional.empty();
+        }
+        Entry entry = byDetectorType.get(detectorType);
+        if (entry == null) {
+            return Optional.empty();
+        }
+        if (clock.getAsLong() > entry.expiresAtNanos) {
+            byDetectorType.remove(detectorType, entry);
+            return Optional.empty();
+        }
+        return Optional.of(entry.rules);
+    }
+
+    public void put(String detectorType, List<CorrelationRule> rules) {
+        long ttl = ttlNanos;
+        if (ttl <= 0 || rules == null) {
+            return;
+        }
+        byDetectorType.put(detectorType, new Entry(List.copyOf(rules), clock.getAsLong() + ttl));
+    }
+
+    public void invalidate(String detectorType) {
+        byDetectorType.remove(detectorType);
+    }
+
+    public void invalidateAll() {
+        byDetectorType.clear();
+    }
+
+    public void setTtl(TimeValue ttl) {
+        long newTtl = ttl.nanos();
+        this.ttlNanos = newTtl;
+        if (newTtl <= 0) {
+            byDetectorType.clear();
+        }
+    }
+
+    int size() {
+        return byDetectorType.size();
+    }
+
+    private static final class Entry {
+        final List<CorrelationRule> rules;
+        final long expiresAtNanos;
+
+        Entry(List<CorrelationRule> rules, long expiresAtNanos) {
+            this.rules = rules;
+            this.expiresAtNanos = expiresAtNanos;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/securityanalytics/correlation/DetectorLookupCache.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/DetectorLookupCache.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opensearch.securityanalytics.correlation;
+
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.securityanalytics.model.Detector;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.LongSupplier;
+
+/**
+ * In-memory cache of {@code monitorId -> Detector} with a TTL. Backed by a {@link
+ * ConcurrentHashMap}; expired entries are evicted lazily on read.
+ *
+ * <p>Sized implicitly by the number of distinct detectors in the cluster, so no LRU bound is
+ * applied. A TTL of zero disables the cache (every {@link #get(String)} returns empty and {@link
+ * #put(String, Detector)} is a no-op).
+ */
+public final class DetectorLookupCache {
+
+    private final ConcurrentHashMap<String, Entry> byMonitorId = new ConcurrentHashMap<>();
+    private final LongSupplier clock;
+    private volatile long ttlNanos;
+
+    public DetectorLookupCache(TimeValue ttl) {
+        this(ttl, System::nanoTime);
+    }
+
+    DetectorLookupCache(TimeValue ttl, LongSupplier clock) {
+        this.ttlNanos = ttl.nanos();
+        this.clock = clock;
+    }
+
+    public Optional<Detector> get(String monitorId) {
+        if (ttlNanos <= 0) {
+            return Optional.empty();
+        }
+        Entry entry = byMonitorId.get(monitorId);
+        if (entry == null) {
+            return Optional.empty();
+        }
+        if (clock.getAsLong() > entry.expiresAtNanos) {
+            byMonitorId.remove(monitorId, entry);
+            return Optional.empty();
+        }
+        return Optional.of(entry.detector);
+    }
+
+    public void put(String monitorId, Detector detector) {
+        long ttl = ttlNanos;
+        if (ttl <= 0 || detector == null) {
+            return;
+        }
+        byMonitorId.put(monitorId, new Entry(detector, clock.getAsLong() + ttl));
+    }
+
+    public void invalidate(String monitorId) {
+        byMonitorId.remove(monitorId);
+    }
+
+    public void invalidateAll() {
+        byMonitorId.clear();
+    }
+
+    public void setTtl(TimeValue ttl) {
+        long newTtl = ttl.nanos();
+        this.ttlNanos = newTtl;
+        if (newTtl <= 0) {
+            byMonitorId.clear();
+        }
+    }
+
+    int size() {
+        return byMonitorId.size();
+    }
+
+    private static final class Entry {
+        final Detector detector;
+        final long expiresAtNanos;
+
+        Entry(Detector detector, long expiresAtNanos) {
+            this.detector = detector;
+            this.expiresAtNanos = expiresAtNanos;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/securityanalytics/correlation/JoinEngine.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/JoinEngine.java
@@ -94,6 +94,8 @@ public class JoinEngine {
 
     private final User user;
 
+    private final CorrelationRulesCache correlationRulesCache;
+
     public JoinEngine(
             Client client,
             PublishFindingsRequest request,
@@ -105,7 +107,8 @@ public class JoinEngine {
             boolean enableAutoCorrelations,
             CorrelationAlertService correlationAlertService,
             NotificationService notificationService,
-            User user) {
+            User user,
+            CorrelationRulesCache correlationRulesCache) {
         this.client = client;
         this.request = request;
         this.xContentRegistry = xContentRegistry;
@@ -117,6 +120,7 @@ public class JoinEngine {
         this.correlationAlertService = correlationAlertService;
         this.notificationService = notificationService;
         this.user = user;
+        this.correlationRulesCache = correlationRulesCache;
     }
 
     public void onSearchDetectorResponse(Detector detector, Finding finding) {
@@ -272,6 +276,13 @@ public class JoinEngine {
         List<String> indices = detector.getInputs().get(0).getIndices();
         List<String> relatedDocIds = finding.getCorrelatedDocIds();
 
+        Optional<List<CorrelationRule>> cachedRules = correlationRulesCache.get(detectorType);
+        if (cachedRules.isPresent()) {
+            this.getValidDocuments(
+                    detectorType, indices, cachedRules.get(), relatedDocIds, autoCorrelations);
+            return;
+        }
+
         NestedQueryBuilder queryBuilder =
                 QueryBuilders.nestedQuery(
                         "correlate",
@@ -314,6 +325,7 @@ public class JoinEngine {
                                 CorrelationRule rule = CorrelationRule.parse(xcp, hit.getId(), hit.getVersion());
                                 correlationRules.add(rule);
                             }
+                            correlationRulesCache.put(detectorType, correlationRules);
                             this.getValidDocuments(
                                     detectorType, indices, correlationRules, relatedDocIds, autoCorrelations);
                         },

--- a/src/main/java/org/opensearch/securityanalytics/correlation/LogTypeListCache.java
+++ b/src/main/java/org/opensearch/securityanalytics/correlation/LogTypeListCache.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opensearch.securityanalytics.correlation;
+
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.securityanalytics.model.CustomLogType;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
+
+/**
+ * Single-entry TTL cache holding the parsed list of log types from {@code
+ * LogTypeService.LOG_TYPE_INDEX}. The query is parameter-less and identical for every finding, so a
+ * single in-memory snapshot can serve all callers between TTL refreshes.
+ *
+ * <p>A TTL of zero disables the cache.
+ */
+public final class LogTypeListCache {
+
+    private final AtomicReference<Entry> snapshot = new AtomicReference<>();
+    private final LongSupplier clock;
+    private volatile long ttlNanos;
+
+    public LogTypeListCache(TimeValue ttl) {
+        this(ttl, System::nanoTime);
+    }
+
+    LogTypeListCache(TimeValue ttl, LongSupplier clock) {
+        this.ttlNanos = ttl.nanos();
+        this.clock = clock;
+    }
+
+    public Optional<Map<String, CustomLogType>> get() {
+        if (ttlNanos <= 0) {
+            return Optional.empty();
+        }
+        Entry entry = snapshot.get();
+        if (entry == null) {
+            return Optional.empty();
+        }
+        if (clock.getAsLong() > entry.expiresAtNanos) {
+            snapshot.compareAndSet(entry, null);
+            return Optional.empty();
+        }
+        return Optional.of(entry.logTypes);
+    }
+
+    public void put(Map<String, CustomLogType> logTypes) {
+        long ttl = ttlNanos;
+        if (ttl <= 0 || logTypes == null) {
+            return;
+        }
+        snapshot.set(new Entry(logTypes, clock.getAsLong() + ttl));
+    }
+
+    public void invalidate() {
+        snapshot.set(null);
+    }
+
+    public void setTtl(TimeValue ttl) {
+        long newTtl = ttl.nanos();
+        this.ttlNanos = newTtl;
+        if (newTtl <= 0) {
+            snapshot.set(null);
+        }
+    }
+
+    boolean isCached() {
+        return get().isPresent();
+    }
+
+    private static final class Entry {
+        final Map<String, CustomLogType> logTypes;
+        final long expiresAtNanos;
+
+        Entry(Map<String, CustomLogType> logTypes, long expiresAtNanos) {
+            this.logTypes = logTypes;
+            this.expiresAtNanos = expiresAtNanos;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/securityanalytics/enrichment/WazuhEnrichedFindingService.java
+++ b/src/main/java/org/opensearch/securityanalytics/enrichment/WazuhEnrichedFindingService.java
@@ -276,11 +276,22 @@ public class WazuhEnrichedFindingService implements Closeable {
 
         List<DocLevelQuery> queries = finding.getDocLevelQueries();
         if (queries.isEmpty()) {
-            for (int i = 0; i < docIds.size(); i++) {
-                this.buildAndIndex(
-                        finding, categories.get(i), eventSources.get(i), docIds.get(i), null, Map.of());
+            try {
+                for (int i = 0; i < docIds.size(); i++) {
+                    try {
+                        this.buildAndIndex(
+                                finding, categories.get(i), eventSources.get(i), docIds.get(i), null, Map.of());
+                    } catch (Exception e) {
+                        log.warn(
+                                "Failed to build enriched finding for finding {} doc {} (no queries)",
+                                finding.getId(),
+                                docIds.get(i),
+                                e);
+                    }
+                }
+            } finally {
+                this.enrichmentComplete();
             }
-            this.enrichmentComplete();
             return;
         }
 
@@ -334,22 +345,46 @@ public class WazuhEnrichedFindingService implements Closeable {
                         }));
     }
 
-    /** Generates and indexes M×N enriched findings (one per doc–rule combination). */
+    /**
+     * Generates and indexes M×N enriched findings (one per doc–rule combination).
+     *
+     * <p>Wrapped in try/finally so {@link #enrichmentComplete()} always runs, even if {@link
+     * #buildAndIndex} throws synchronously. Each iteration is also guarded so a single bad event does
+     * not strand the in-flight permit and stall {@link #findingsQueue} for the rest of the process's
+     * lifetime.
+     */
     private void buildAllFindingsAndComplete(
             Finding finding,
             List<String> docIds,
             List<Map<String, Object>> eventSources,
             List<String> categories,
             List<DocLevelQuery> queries) {
-        for (int i = 0; i < docIds.size(); i++) {
-            for (DocLevelQuery query : queries) {
-                Map<String, Object> ruleMetadata =
-                        this.ruleMetadataCache.getOrDefault(query.getId(), Map.of());
-                this.buildAndIndex(
-                        finding, categories.get(i), eventSources.get(i), docIds.get(i), query, ruleMetadata);
+        try {
+            for (int i = 0; i < docIds.size(); i++) {
+                for (DocLevelQuery query : queries) {
+                    try {
+                        Map<String, Object> ruleMetadata =
+                                this.ruleMetadataCache.getOrDefault(query.getId(), Map.of());
+                        this.buildAndIndex(
+                                finding,
+                                categories.get(i),
+                                eventSources.get(i),
+                                docIds.get(i),
+                                query,
+                                ruleMetadata);
+                    } catch (Exception e) {
+                        log.warn(
+                                "Failed to build enriched finding for finding {} doc {} rule {}",
+                                finding.getId(),
+                                docIds.get(i),
+                                query.getId(),
+                                e);
+                    }
+                }
             }
+        } finally {
+            this.enrichmentComplete();
         }
-        this.enrichmentComplete();
     }
 
     // ── Step 3: assemble the enriched document ───────────────────────────────

--- a/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
+++ b/src/main/java/org/opensearch/securityanalytics/settings/SecurityAnalyticsSettings.java
@@ -1,6 +1,18 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.opensearch.securityanalytics.settings;
 
@@ -15,209 +27,235 @@ public class SecurityAnalyticsSettings {
     public static final int minSystemIndexReplicas = 0;
     public static final int maxSystemIndexReplicas = 20;
 
-    public static Setting<TimeValue> INDEX_TIMEOUT = Setting.positiveTimeSetting("plugins.security_analytics.index_timeout",
-            TimeValue.timeValueSeconds(60),
-            Setting.Property.NodeScope, Setting.Property.Dynamic);
+    public static Setting<TimeValue> INDEX_TIMEOUT =
+            Setting.positiveTimeSetting(
+                    "plugins.security_analytics.index_timeout",
+                    TimeValue.timeValueSeconds(60),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
     public static final Long DEFAULT_MAX_ACTIONABLE_ALERT_COUNT = 50L;
 
-    public static final Setting<Boolean> ALERT_HISTORY_ENABLED = Setting.boolSetting(
-            "plugins.security_analytics.alert_history_enabled",
-            true,
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<Boolean> ALERT_HISTORY_ENABLED =
+            Setting.boolSetting(
+                    "plugins.security_analytics.alert_history_enabled",
+                    true,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<Boolean> FINDING_HISTORY_ENABLED = Setting.boolSetting(
-            "plugins.security_analytics.alert_finding_enabled",
-            true,
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<Boolean> FINDING_HISTORY_ENABLED =
+            Setting.boolSetting(
+                    "plugins.security_analytics.alert_finding_enabled",
+                    true,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<Boolean> IOC_FINDING_HISTORY_ENABLED = Setting.boolSetting(
-            "plugins.security_analytics.ioc_finding_enabled",
-            true,
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<Boolean> IOC_FINDING_HISTORY_ENABLED =
+            Setting.boolSetting(
+                    "plugins.security_analytics.ioc_finding_enabled",
+                    true,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<TimeValue> ALERT_HISTORY_ROLLOVER_PERIOD = Setting.positiveTimeSetting(
-            "plugins.security_analytics.alert_history_rollover_period",
-            TimeValue.timeValueHours(12),
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> ALERT_HISTORY_ROLLOVER_PERIOD =
+            Setting.positiveTimeSetting(
+                    "plugins.security_analytics.alert_history_rollover_period",
+                    TimeValue.timeValueHours(12),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<TimeValue> FINDING_HISTORY_ROLLOVER_PERIOD = Setting.positiveTimeSetting(
-            "plugins.security_analytics.alert_finding_rollover_period",
-            TimeValue.timeValueHours(12),
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> FINDING_HISTORY_ROLLOVER_PERIOD =
+            Setting.positiveTimeSetting(
+                    "plugins.security_analytics.alert_finding_rollover_period",
+                    TimeValue.timeValueHours(12),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<TimeValue> CORRELATION_HISTORY_ROLLOVER_PERIOD = Setting.positiveTimeSetting(
-            "plugins.security_analytics.correlation_history_rollover_period",
-            TimeValue.timeValueHours(12),
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> CORRELATION_HISTORY_ROLLOVER_PERIOD =
+            Setting.positiveTimeSetting(
+                    "plugins.security_analytics.correlation_history_rollover_period",
+                    TimeValue.timeValueHours(12),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<TimeValue> IOC_FINDING_HISTORY_ROLLOVER_PERIOD = Setting.positiveTimeSetting(
-            "plugins.security_analytics.ioc_finding_history_rollover_period",
-            TimeValue.timeValueHours(12),
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> IOC_FINDING_HISTORY_ROLLOVER_PERIOD =
+            Setting.positiveTimeSetting(
+                    "plugins.security_analytics.ioc_finding_history_rollover_period",
+                    TimeValue.timeValueHours(12),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<TimeValue> ALERT_HISTORY_INDEX_MAX_AGE = Setting.positiveTimeSetting(
-            "plugins.security_analytics.alert_history_max_age",
-            new TimeValue(30, TimeUnit.DAYS),
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> ALERT_HISTORY_INDEX_MAX_AGE =
+            Setting.positiveTimeSetting(
+                    "plugins.security_analytics.alert_history_max_age",
+                    new TimeValue(30, TimeUnit.DAYS),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<TimeValue> FINDING_HISTORY_INDEX_MAX_AGE = Setting.positiveTimeSetting(
-            "plugins.security_analytics.finding_history_max_age",
-            new TimeValue(30, TimeUnit.DAYS),
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> FINDING_HISTORY_INDEX_MAX_AGE =
+            Setting.positiveTimeSetting(
+                    "plugins.security_analytics.finding_history_max_age",
+                    new TimeValue(30, TimeUnit.DAYS),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<TimeValue> CORRELATION_HISTORY_INDEX_MAX_AGE = Setting.positiveTimeSetting(
-            "plugins.security_analytics.correlation_history_max_age",
-            new TimeValue(30, TimeUnit.DAYS),
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> CORRELATION_HISTORY_INDEX_MAX_AGE =
+            Setting.positiveTimeSetting(
+                    "plugins.security_analytics.correlation_history_max_age",
+                    new TimeValue(30, TimeUnit.DAYS),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<TimeValue> IOC_FINDING_HISTORY_INDEX_MAX_AGE = Setting.positiveTimeSetting(
-            "plugins.security_analytics.ioc_finding_history_max_age",
-            new TimeValue(30, TimeUnit.DAYS),
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> IOC_FINDING_HISTORY_INDEX_MAX_AGE =
+            Setting.positiveTimeSetting(
+                    "plugins.security_analytics.ioc_finding_history_max_age",
+                    new TimeValue(30, TimeUnit.DAYS),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<Long> ALERT_HISTORY_MAX_DOCS = Setting.longSetting(
-            "plugins.security_analytics.alert_history_max_docs",
-            1000L,
-            0L,
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<Long> ALERT_HISTORY_MAX_DOCS =
+            Setting.longSetting(
+                    "plugins.security_analytics.alert_history_max_docs",
+                    1000L,
+                    0L,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<Long> FINDING_HISTORY_MAX_DOCS = Setting.longSetting(
-            "plugins.security_analytics.alert_finding_max_docs",
-            1000L,
-            0L,
-            Setting.Property.NodeScope, Setting.Property.Dynamic, Setting.Property.Deprecated
-    );
+    public static final Setting<Long> FINDING_HISTORY_MAX_DOCS =
+            Setting.longSetting(
+                    "plugins.security_analytics.alert_finding_max_docs",
+                    1000L,
+                    0L,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic,
+                    Setting.Property.Deprecated);
 
-    public static final Setting<Long> CORRELATION_HISTORY_MAX_DOCS = Setting.longSetting(
-            "plugins.security_analytics.correlation_history_max_docs",
-            1000L,
-            0L,
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<Long> CORRELATION_HISTORY_MAX_DOCS =
+            Setting.longSetting(
+                    "plugins.security_analytics.correlation_history_max_docs",
+                    1000L,
+                    0L,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<Long> IOC_FINDING_HISTORY_MAX_DOCS = Setting.longSetting(
-            "plugins.security_analytics.ioc_finding_history_max_docs",
-            1000L,
-            0L,
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<Long> IOC_FINDING_HISTORY_MAX_DOCS =
+            Setting.longSetting(
+                    "plugins.security_analytics.ioc_finding_history_max_docs",
+                    1000L,
+                    0L,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<TimeValue> ALERT_HISTORY_RETENTION_PERIOD = Setting.positiveTimeSetting(
-            "plugins.security_analytics.alert_history_retention_period",
-            new TimeValue(60, TimeUnit.DAYS),
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> ALERT_HISTORY_RETENTION_PERIOD =
+            Setting.positiveTimeSetting(
+                    "plugins.security_analytics.alert_history_retention_period",
+                    new TimeValue(60, TimeUnit.DAYS),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<TimeValue> FINDING_HISTORY_RETENTION_PERIOD = Setting.positiveTimeSetting(
-            "plugins.security_analytics.finding_history_retention_period",
-            new TimeValue(60, TimeUnit.DAYS),
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> FINDING_HISTORY_RETENTION_PERIOD =
+            Setting.positiveTimeSetting(
+                    "plugins.security_analytics.finding_history_retention_period",
+                    new TimeValue(60, TimeUnit.DAYS),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<TimeValue> CORRELATION_HISTORY_RETENTION_PERIOD = Setting.positiveTimeSetting(
-            "plugins.security_analytics.correlation_history_retention_period",
-            new TimeValue(60, TimeUnit.DAYS),
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> CORRELATION_HISTORY_RETENTION_PERIOD =
+            Setting.positiveTimeSetting(
+                    "plugins.security_analytics.correlation_history_retention_period",
+                    new TimeValue(60, TimeUnit.DAYS),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<TimeValue> IOC_FINDING_HISTORY_RETENTION_PERIOD = Setting.positiveTimeSetting(
-            "plugins.security_analytics.ioc_finding_history_retention_period",
-            new TimeValue(60, TimeUnit.DAYS),
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> IOC_FINDING_HISTORY_RETENTION_PERIOD =
+            Setting.positiveTimeSetting(
+                    "plugins.security_analytics.ioc_finding_history_retention_period",
+                    new TimeValue(60, TimeUnit.DAYS),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<TimeValue> REQUEST_TIMEOUT = Setting.positiveTimeSetting(
-            "plugins.security_analytics.request_timeout",
-            TimeValue.timeValueSeconds(10),
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> REQUEST_TIMEOUT =
+            Setting.positiveTimeSetting(
+                    "plugins.security_analytics.request_timeout",
+                    TimeValue.timeValueSeconds(10),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<TimeValue> MAX_ACTION_THROTTLE_VALUE = Setting.positiveTimeSetting(
-            "plugins.security_analytics.action_throttle_max_value",
-            TimeValue.timeValueHours(24),
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> MAX_ACTION_THROTTLE_VALUE =
+            Setting.positiveTimeSetting(
+                    "plugins.security_analytics.action_throttle_max_value",
+                    TimeValue.timeValueHours(24),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<Boolean> FILTER_BY_BACKEND_ROLES = Setting.boolSetting(
-            "plugins.security_analytics.filter_by_backend_roles",
-            false,
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<Boolean> FILTER_BY_BACKEND_ROLES =
+            Setting.boolSetting(
+                    "plugins.security_analytics.filter_by_backend_roles",
+                    false,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<Boolean> ENABLE_WORKFLOW_USAGE = Setting.boolSetting(
-        "plugins.security_analytics.enable_workflow_usage",
-        true,
-        Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<Boolean> ENABLE_WORKFLOW_USAGE =
+            Setting.boolSetting(
+                    "plugins.security_analytics.enable_workflow_usage",
+                    true,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<Boolean> IS_CORRELATION_INDEX_SETTING = Setting.boolSetting(CORRELATION_INDEX, false, Setting.Property.IndexScope);
+    public static final Setting<Boolean> IS_CORRELATION_INDEX_SETTING =
+            Setting.boolSetting(CORRELATION_INDEX, false, Setting.Property.IndexScope);
 
-    public static final Setting<TimeValue> CORRELATION_TIME_WINDOW = Setting.positiveTimeSetting(
-            "plugins.security_analytics.correlation_time_window",
-            new TimeValue(5, TimeUnit.MINUTES),
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> CORRELATION_TIME_WINDOW =
+            Setting.positiveTimeSetting(
+                    "plugins.security_analytics.correlation_time_window",
+                    new TimeValue(5, TimeUnit.MINUTES),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    /**
-     * Setting which enables auto correlations
-     */
-    public static final Setting<Boolean> ENABLE_AUTO_CORRELATIONS = Setting.boolSetting(
-            "plugins.security_analytics.auto_correlations_enabled",
-            false,
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    /** Setting which enables auto correlations */
+    public static final Setting<Boolean> ENABLE_AUTO_CORRELATIONS =
+            Setting.boolSetting(
+                    "plugins.security_analytics.auto_correlations_enabled",
+                    false,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<String> DEFAULT_MAPPING_SCHEMA = Setting.simpleString(
-            "plugins.security_analytics.mappings.default_schema",
-            "ecs",
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<String> DEFAULT_MAPPING_SCHEMA =
+            Setting.simpleString(
+                    "plugins.security_analytics.mappings.default_schema",
+                    "ecs",
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
     // threat intel settings
-    public static final Setting<TimeValue> TIF_UPDATE_INTERVAL = Setting.timeSetting(
-            "plugins.security_analytics.threatintel.tifjob.update_interval",
-            TimeValue.timeValueMinutes(1440),
-            Setting.Property.NodeScope,
-            Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> TIF_UPDATE_INTERVAL =
+            Setting.timeSetting(
+                    "plugins.security_analytics.threatintel.tifjob.update_interval",
+                    TimeValue.timeValueMinutes(1440),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    /**
-     * Bulk size for indexing threat intel feed data
-     */
-    public static final Setting<Integer> BATCH_SIZE = Setting.intSetting(
-            "plugins.security_analytics.threatintel.tifjob.batch_size",
-            10000,
-            1,
-            Setting.Property.NodeScope,
-            Setting.Property.Dynamic
-    );
+    /** Bulk size for indexing threat intel feed data */
+    public static final Setting<Integer> BATCH_SIZE =
+            Setting.intSetting(
+                    "plugins.security_analytics.threatintel.tifjob.batch_size",
+                    10000,
+                    1,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    /**
-     * Timeout value for threat intel processor
-     */
-    public static final Setting<TimeValue> THREAT_INTEL_TIMEOUT = Setting.timeSetting(
-            "plugins.security_analytics.threat_intel_timeout",
-            TimeValue.timeValueSeconds(30),
-            TimeValue.timeValueSeconds(1),
-            Setting.Property.NodeScope,
-            Setting.Property.Dynamic
-    );
+    /** Timeout value for threat intel processor */
+    public static final Setting<TimeValue> THREAT_INTEL_TIMEOUT =
+            Setting.timeSetting(
+                    "plugins.security_analytics.threat_intel_timeout",
+                    TimeValue.timeValueSeconds(30),
+                    TimeValue.timeValueSeconds(1),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
     /**
      * Return all settings of threat intel feature
+     *
      * @return a list of all settings for threat intel feature
      */
     public static final List<Setting<?>> settings() {
@@ -225,40 +263,83 @@ public class SecurityAnalyticsSettings {
     }
 
     // Threat Intel IOC Settings
-    public static final Setting<TimeValue> IOC_INDEX_RETENTION_PERIOD = Setting.timeSetting(
-            "plugins.security_analytics.ioc.index_retention_period",
-            new TimeValue(30, TimeUnit.DAYS),
-            new TimeValue(1, TimeUnit.DAYS),
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> IOC_INDEX_RETENTION_PERIOD =
+            Setting.timeSetting(
+                    "plugins.security_analytics.ioc.index_retention_period",
+                    new TimeValue(30, TimeUnit.DAYS),
+                    new TimeValue(1, TimeUnit.DAYS),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<Integer> IOC_MAX_INDICES_PER_INDEX_PATTERN = Setting.intSetting(
-            "plugins.security_analytics.ioc.max_indices_per_alias",
-            2,
-            1,
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<Integer> IOC_MAX_INDICES_PER_INDEX_PATTERN =
+            Setting.intSetting(
+                    "plugins.security_analytics.ioc.max_indices_per_alias",
+                    2,
+                    1,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
+
+    /** Maximum terms in Terms query search query submitted during ioc scan */
+    public static final Setting<Integer> IOC_SCAN_MAX_TERMS_COUNT =
+            Setting.intSetting(
+                    "plugins.security_analytics.ioc.scan_max_terms_count",
+                    65536,
+                    1,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
+
+    public static final Setting<Boolean> ENABLE_DETECTORS_WITH_DEDICATED_QUERY_INDICES =
+            Setting.boolSetting(
+                    "plugins.security_analytics.enable_detectors_with_dedicated_query_indices",
+                    true,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
+
+    public static final Setting<Boolean> ENRICHED_FINDINGS_ENABLED =
+            Setting.boolSetting(
+                    "plugins.security_analytics.enriched_findings_index_enabled",
+                    true,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
     /**
-     * Maximum terms in Terms query search query submitted during ioc scan
+     * TTL for the in-memory monitor-id to detector cache consulted by {@code
+     * TransportCorrelateFindingAction}. Eliminates the per-finding nested-query lookup against the
+     * detectors index when many findings of one fan-out share the same monitor id. Set to zero to
+     * disable the cache entirely.
      */
-    public static final Setting<Integer> IOC_SCAN_MAX_TERMS_COUNT  = Setting.intSetting(
-            "plugins.security_analytics.ioc.scan_max_terms_count",
-            65536,
-            1,
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    public static final Setting<TimeValue> CORRELATION_DETECTOR_CACHE_TTL =
+            Setting.timeSetting(
+                    "plugins.security_analytics.correlation.detector_cache_ttl",
+                    TimeValue.timeValueMinutes(5),
+                    TimeValue.timeValueSeconds(0),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<Boolean> ENABLE_DETECTORS_WITH_DEDICATED_QUERY_INDICES = Setting.boolSetting(
-            "plugins.security_analytics.enable_detectors_with_dedicated_query_indices",
-            true,
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
+    /**
+     * Maximum number of correlation pipelines allowed to run concurrently in {@code
+     * TransportCorrelateFindingAction}. Bounds peak demand on the search thread pool when doc-level
+     * alerting fan-outs publish many findings at once; excess findings queue until a slot frees up.
+     */
+    public static final Setting<Integer> CORRELATION_MAX_IN_FLIGHT_FINDINGS =
+            Setting.intSetting(
+                    "plugins.security_analytics.correlation.max_in_flight_findings",
+                    50,
+                    1,
+                    1000,
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 
-    public static final Setting<Boolean> ENRICHED_FINDINGS_ENABLED = Setting.boolSetting(
-            "plugins.security_analytics.enriched_findings_index_enabled",
-            true,
-            Setting.Property.NodeScope, Setting.Property.Dynamic
-    );
-
+    /**
+     * TTL for the in-memory caches of slow-changing correlation metadata (log type list and
+     * correlation rules by detector type). Each cached lookup eliminates a per-finding {@code size:
+     * 10000} search against the corresponding system index. Set to zero to disable both caches.
+     */
+    public static final Setting<TimeValue> CORRELATION_METADATA_CACHE_TTL =
+            Setting.timeSetting(
+                    "plugins.security_analytics.correlation.metadata_cache_ttl",
+                    TimeValue.timeValueMinutes(5),
+                    TimeValue.timeValueSeconds(0),
+                    Setting.Property.NodeScope,
+                    Setting.Property.Dynamic);
 }

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingAction.java
@@ -56,7 +56,10 @@ import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.securityanalytics.correlation.CorrelationRulesCache;
+import org.opensearch.securityanalytics.correlation.DetectorLookupCache;
 import org.opensearch.securityanalytics.correlation.JoinEngine;
+import org.opensearch.securityanalytics.correlation.LogTypeListCache;
 import org.opensearch.securityanalytics.correlation.VectorEmbeddingsEngine;
 import org.opensearch.securityanalytics.correlation.alert.CorrelationAlertService;
 import org.opensearch.securityanalytics.correlation.alert.notifications.NotificationService;
@@ -81,8 +84,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 public class TransportCorrelateFindingAction
         extends HandledTransportAction<ActionRequest, SubscribeFindingsResponse>
@@ -119,6 +126,27 @@ public class TransportCorrelateFindingAction
     private final NotificationService notificationService;
 
     private final WazuhEnrichedFindingService enrichedFindingService;
+
+    private final DetectorLookupCache detectorLookupCache;
+
+    private final LogTypeListCache logTypeListCache;
+
+    private final CorrelationRulesCache correlationRulesCache;
+
+    /**
+     * Limits the number of correlation pipelines (one per published finding) running concurrently.
+     * When alerting's doc-level monitor fan-out publishes many findings at once, this semaphore caps
+     * peak demand on the search thread pool to avoid {@code OpenSearchRejectedExecutionException}
+     * from the search thread pool's bounded queue.
+     */
+    private final Semaphore correlationPermits;
+
+    /** Pipelines waiting for an in-flight permit; drained as permits are released. */
+    private final ConcurrentLinkedQueue<AsyncCorrelateFindingAction> pendingStarts =
+            new ConcurrentLinkedQueue<>();
+
+    /** Tracks the current configured permit count to compute deltas on dynamic updates. */
+    private volatile int currentMaxInFlight;
 
     static Map<String, CustomLogType> buildLogTypesFromHits(
             SearchHit[] hits, String monitorId, String findingId) {
@@ -173,7 +201,10 @@ public class TransportCorrelateFindingAction
             ActionFilters actionFilters,
             CorrelationAlertService correlationAlertService,
             NotificationService notificationService,
-            WazuhEnrichedFindingService enrichedFindingService) {
+            WazuhEnrichedFindingService enrichedFindingService,
+            DetectorLookupCache detectorLookupCache,
+            LogTypeListCache logTypeListCache,
+            CorrelationRulesCache correlationRulesCache) {
         super(
                 AlertingActions.SUBSCRIBE_FINDINGS_ACTION_NAME,
                 transportService,
@@ -189,6 +220,12 @@ public class TransportCorrelateFindingAction
         this.correlationAlertService = correlationAlertService;
         this.notificationService = notificationService;
         this.enrichedFindingService = enrichedFindingService;
+        this.detectorLookupCache = detectorLookupCache;
+        this.logTypeListCache = logTypeListCache;
+        this.correlationRulesCache = correlationRulesCache;
+        this.currentMaxInFlight =
+                SecurityAnalyticsSettings.CORRELATION_MAX_IN_FLIGHT_FINDINGS.get(settings);
+        this.correlationPermits = new AdjustableSemaphore(this.currentMaxInFlight);
         this.threadPool = this.detectorIndices.getThreadPool();
 
         this.indexTimeout = SecurityAnalyticsSettings.INDEX_TIMEOUT.get(this.settings);
@@ -214,7 +251,72 @@ public class TransportCorrelateFindingAction
                 .addSettingsUpdateConsumer(
                         SecurityAnalyticsSettings.ENRICHED_FINDINGS_ENABLED,
                         enrichedFindingService::setEnabled);
+        this.clusterService
+                .getClusterSettings()
+                .addSettingsUpdateConsumer(
+                        SecurityAnalyticsSettings.CORRELATION_DETECTOR_CACHE_TTL, detectorLookupCache::setTtl);
+        this.clusterService
+                .getClusterSettings()
+                .addSettingsUpdateConsumer(
+                        SecurityAnalyticsSettings.CORRELATION_MAX_IN_FLIGHT_FINDINGS, this::adjustMaxInFlight);
+        this.clusterService
+                .getClusterSettings()
+                .addSettingsUpdateConsumer(
+                        SecurityAnalyticsSettings.CORRELATION_METADATA_CACHE_TTL,
+                        ttl -> {
+                            logTypeListCache.setTtl(ttl);
+                            correlationRulesCache.setTtl(ttl);
+                        });
         this.setupTimestamp = System.currentTimeMillis();
+    }
+
+    /**
+     * Adds {@code action} to the in-flight queue and starts as many queued pipelines as permits
+     * allow. The terminal callbacks ({@link AsyncCorrelateFindingAction#onOperation()}, {@link
+     * AsyncCorrelateFindingAction#onFailures(Exception)}) release the permit.
+     */
+    private void scheduleCorrelation(AsyncCorrelateFindingAction action) {
+        pendingStarts.add(action);
+        drainPending();
+    }
+
+    private void drainPending() {
+        while (correlationPermits.tryAcquire()) {
+            AsyncCorrelateFindingAction next = pendingStarts.poll();
+            if (next == null) {
+                correlationPermits.release();
+                return;
+            }
+            next.markPermitAcquired();
+            next.doStart();
+        }
+    }
+
+    private void releasePermitAndDrain() {
+        correlationPermits.release();
+        drainPending();
+    }
+
+    private synchronized void adjustMaxInFlight(int newMax) {
+        int delta = newMax - currentMaxInFlight;
+        if (delta > 0) {
+            correlationPermits.release(delta);
+        } else if (delta < 0) {
+            ((AdjustableSemaphore) correlationPermits).reducePermits(-delta);
+        }
+        currentMaxInFlight = newMax;
+    }
+
+    /** Exposes {@link Semaphore#reducePermits(int)} so the dynamic setting can shrink the cap. */
+    private static final class AdjustableSemaphore extends Semaphore {
+        AdjustableSemaphore(int permits) {
+            super(permits);
+        }
+
+        @Override
+        public void reducePermits(int reduction) {
+            super.reducePermits(reduction);
+        }
     }
 
     @Override
@@ -222,6 +324,21 @@ public class TransportCorrelateFindingAction
             Task task, ActionRequest request, ActionListener<SubscribeFindingsResponse> actionListener) {
         try {
             PublishFindingsRequest transformedRequest = transformRequest(request);
+
+            // Dispatch enrichment up front, completely outside the correlation throttle. The
+            // throttle's pendingStarts queue and per-pipeline permit are exposed to permit
+            // leaks if any async chain in JoinEngine/VectorEmbeddingsEngine fails to reach a
+            // terminal callback (e.g. under search-pool rejection). Decoupling enrichment
+            // here guarantees every published finding produces an enrichment dispatch.
+            try {
+                enrichedFindingService.enrich(transformedRequest.getFinding());
+            } catch (Exception e) {
+                log.warn(
+                        "Enrichment dispatch failed for finding {}",
+                        transformedRequest.getFinding().getId(),
+                        e);
+            }
+
             AsyncCorrelateFindingAction correlateFindingAction =
                     new AsyncCorrelateFindingAction(
                             task, transformedRequest, readUserFromThreadContext(this.threadPool), actionListener);
@@ -329,8 +446,13 @@ public class TransportCorrelateFindingAction
                 correlateFindingAction.start();
             }
         } catch (Exception e) {
-            throw new SecurityAnalyticsException(
-                    "Unknown exception occurred", RestStatus.INTERNAL_SERVER_ERROR, e);
+            // Route synchronous failures to the listener instead of rethrowing. The caller
+            // is the alerting plugin's publishFinding loop, and a synchronous throw there
+            // unwinds the forEach and silently drops every subsequent finding in the batch.
+            log.error("Unknown exception occurred while handling publish-findings request", e);
+            actionListener.onFailure(
+                    new SecurityAnalyticsException(
+                            "Unknown exception occurred", RestStatus.INTERNAL_SERVER_ERROR, e));
         }
     }
 
@@ -343,6 +465,13 @@ public class TransportCorrelateFindingAction
         private final AtomicReference<Object> response;
         private final AtomicBoolean counter = new AtomicBoolean();
         private final Task task;
+
+        /**
+         * Set to {@code true} when this pipeline has acquired an in-flight permit; gates the permit
+         * release in {@link #onOperation()} / {@link #onFailures(Exception)} so early failures (before
+         * {@link #start()} ever runs) do not over-release.
+         */
+        private volatile boolean permitAcquired = false;
 
         AsyncCorrelateFindingAction(
                 Task task,
@@ -365,72 +494,31 @@ public class TransportCorrelateFindingAction
                             enableAutoCorrelation,
                             correlationAlertService,
                             notificationService,
-                            user);
+                            user,
+                            correlationRulesCache);
             this.vectorEmbeddingsEngine =
                     new VectorEmbeddingsEngine(client, indexTimeout, corrTimeWindow, this);
         }
 
+        /**
+         * Public entry point. Hands the pipeline to the outer transport action, which queues it until
+         * an in-flight permit is available; once acquired, {@link #doStart()} runs.
+         */
         void start() {
+            scheduleCorrelation(this);
+        }
+
+        void markPermitAcquired() {
+            this.permitAcquired = true;
+        }
+
+        /** Body of {@code start()}; only invoked once a permit has been acquired. */
+        void doStart() {
             TransportCorrelateFindingAction.this.threadPool.getThreadContext().stashContext();
             String monitorId = request.getMonitorId();
             Finding finding = request.getFinding();
 
-            if (detectorIndices.detectorIndexExists()) {
-                NestedQueryBuilder queryBuilder =
-                        QueryBuilders.nestedQuery(
-                                "detector",
-                                QueryBuilders.matchQuery("detector.monitor_id", monitorId),
-                                ScoreMode.None);
-
-                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-                searchSourceBuilder.query(queryBuilder);
-                searchSourceBuilder.fetchSource(true);
-                searchSourceBuilder.size(1);
-                SearchRequest searchRequest = new SearchRequest();
-                searchRequest.indices(Detector.DETECTORS_INDEX);
-                searchRequest.source(searchSourceBuilder);
-                searchRequest.preference(Preference.PRIMARY_FIRST.type());
-                searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(30L));
-
-                client.search(
-                        searchRequest,
-                        ActionListener.wrap(
-                                response -> {
-                                    if (response.isTimedOut()) {
-                                        onFailures(
-                                                new OpenSearchStatusException(
-                                                        "Search request timed out", RestStatus.REQUEST_TIMEOUT));
-                                    }
-
-                                    SearchHits hits = response.getHits();
-                                    if (hits.getHits().length > 0) {
-                                        try {
-                                            SearchHit hit = hits.getAt(0);
-
-                                            XContentParser xcp =
-                                                    XContentType.JSON
-                                                            .xContent()
-                                                            .createParser(
-                                                                    xContentRegistry,
-                                                                    LoggingDeprecationHandler.INSTANCE,
-                                                                    hit.getSourceAsString());
-                                            Detector detector = Detector.docParse(xcp, hit.getId(), hit.getVersion());
-                                            // Fire-and-forget enrichment — must not block the correlation path
-                                            enrichedFindingService.enrich(finding);
-                                            joinEngine.onSearchDetectorResponse(detector, finding);
-                                        } catch (Exception e) {
-                                            log.error("Exception for request {}", searchRequest, e);
-                                            onFailures(e);
-                                        }
-                                    } else {
-                                        onFailures(
-                                                new OpenSearchStatusException(
-                                                        "detector not found given monitor id " + request.getMonitorId(),
-                                                        RestStatus.INTERNAL_SERVER_ERROR));
-                                    }
-                                },
-                                this::onFailures));
-            } else {
+            if (!detectorIndices.detectorIndexExists()) {
                 onFailures(
                         new SecurityAnalyticsException(
                                 String.format(
@@ -439,7 +527,72 @@ public class TransportCorrelateFindingAction
                                         Detector.DETECTORS_INDEX),
                                 RestStatus.INTERNAL_SERVER_ERROR,
                                 new RuntimeException()));
+                return;
             }
+
+            Optional<Detector> cached = detectorLookupCache.get(monitorId);
+            if (cached.isPresent()) {
+                try {
+                    joinEngine.onSearchDetectorResponse(cached.get(), finding);
+                } catch (Exception e) {
+                    onFailures(e);
+                }
+                return;
+            }
+
+            NestedQueryBuilder queryBuilder =
+                    QueryBuilders.nestedQuery(
+                            "detector",
+                            QueryBuilders.matchQuery("detector.monitor_id", monitorId),
+                            ScoreMode.None);
+
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+            searchSourceBuilder.query(queryBuilder);
+            searchSourceBuilder.fetchSource(true);
+            searchSourceBuilder.size(1);
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.indices(Detector.DETECTORS_INDEX);
+            searchRequest.source(searchSourceBuilder);
+            searchRequest.preference(Preference.PRIMARY_FIRST.type());
+            searchRequest.setCancelAfterTimeInterval(TimeValue.timeValueSeconds(30L));
+
+            client.search(
+                    searchRequest,
+                    ActionListener.wrap(
+                            response -> {
+                                if (response.isTimedOut()) {
+                                    onFailures(
+                                            new OpenSearchStatusException(
+                                                    "Search request timed out", RestStatus.REQUEST_TIMEOUT));
+                                }
+
+                                SearchHits hits = response.getHits();
+                                if (hits.getHits().length > 0) {
+                                    try {
+                                        SearchHit hit = hits.getAt(0);
+
+                                        XContentParser xcp =
+                                                XContentType.JSON
+                                                        .xContent()
+                                                        .createParser(
+                                                                xContentRegistry,
+                                                                LoggingDeprecationHandler.INSTANCE,
+                                                                hit.getSourceAsString());
+                                        Detector detector = Detector.docParse(xcp, hit.getId(), hit.getVersion());
+                                        detectorLookupCache.put(monitorId, detector);
+                                        joinEngine.onSearchDetectorResponse(detector, finding);
+                                    } catch (Exception e) {
+                                        log.error("Exception for request {}", searchRequest, e);
+                                        onFailures(e);
+                                    }
+                                } else {
+                                    onFailures(
+                                            new OpenSearchStatusException(
+                                                    "detector not found given monitor id " + request.getMonitorId(),
+                                                    RestStatus.INTERNAL_SERVER_ERROR));
+                                }
+                            },
+                            this::onFailures));
         }
 
         public void initCorrelationIndex(
@@ -535,93 +688,23 @@ public class TransportCorrelateFindingAction
                                                                                             IndexRequest scoreIndexRequest =
                                                                                                     getCorrelationMetadataIndexRequest(
                                                                                                             id, newScoreTimestamp);
+                                                                                            float fixedTimestampFeature =
+                                                                                                    Long.valueOf(
+                                                                                                                    CorrelationIndices
+                                                                                                                                    .FIXED_HISTORICAL_INTERVAL
+                                                                                                                            / 1000L)
+                                                                                                            .floatValue();
 
                                                                                             client.index(
                                                                                                     scoreIndexRequest,
                                                                                                     ActionListener.wrap(
-                                                                                                            indexResponse -> {
-                                                                                                                SearchRequest searchRequest =
-                                                                                                                        getSearchLogTypeIndexRequest();
-
-                                                                                                                client.search(
-                                                                                                                        searchRequest,
-                                                                                                                        ActionListener.wrap(
-                                                                                                                                searchResponse -> {
-                                                                                                                                    if (searchResponse.isTimedOut()) {
-                                                                                                                                        onFailures(
-                                                                                                                                                new OpenSearchStatusException(
-                                                                                                                                                        "Search request timed out",
-                                                                                                                                                        RestStatus
-                                                                                                                                                                .REQUEST_TIMEOUT));
-                                                                                                                                    }
-
-                                                                                                                                    SearchHit[] hits =
-                                                                                                                                            searchResponse
-                                                                                                                                                    .getHits()
-                                                                                                                                                    .getHits();
-                                                                                                                                    Map<String, CustomLogType>
-                                                                                                                                            logTypes = new HashMap<>();
-                                                                                                                                    for (SearchHit hit : hits) {
-                                                                                                                                        Map<String, Object> sourceMap =
-                                                                                                                                                hit.getSourceAsMap();
-                                                                                                                                        logTypes.put(
-                                                                                                                                                sourceMap
-                                                                                                                                                        .get("name")
-                                                                                                                                                        .toString(),
-                                                                                                                                                new CustomLogType(
-                                                                                                                                                        sourceMap));
-                                                                                                                                    }
-
-                                                                                                                                    if (correlatedFindings != null) {
-                                                                                                                                        if (correlatedFindings
-                                                                                                                                                .isEmpty()) {
-                                                                                                                                            vectorEmbeddingsEngine
-                                                                                                                                                    .insertOrphanFindings(
-                                                                                                                                                            detectorType,
-                                                                                                                                                            request.getFinding(),
-                                                                                                                                                            Long.valueOf(
-                                                                                                                                                                            CorrelationIndices
-                                                                                                                                                                                            .FIXED_HISTORICAL_INTERVAL
-                                                                                                                                                                                    / 1000L)
-                                                                                                                                                                    .floatValue(),
-                                                                                                                                                            logTypes);
-                                                                                                                                        }
-                                                                                                                                        for (Map.Entry<
-                                                                                                                                                        String, List<String>>
-                                                                                                                                                correlatedFinding :
-                                                                                                                                                        correlatedFindings
-                                                                                                                                                                .entrySet()) {
-                                                                                                                                            vectorEmbeddingsEngine
-                                                                                                                                                    .insertCorrelatedFindings(
-                                                                                                                                                            detectorType,
-                                                                                                                                                            request.getFinding(),
-                                                                                                                                                            correlatedFinding
-                                                                                                                                                                    .getKey(),
-                                                                                                                                                            correlatedFinding
-                                                                                                                                                                    .getValue(),
-                                                                                                                                                            Long.valueOf(
-                                                                                                                                                                            CorrelationIndices
-                                                                                                                                                                                            .FIXED_HISTORICAL_INTERVAL
-                                                                                                                                                                                    / 1000L)
-                                                                                                                                                                    .floatValue(),
-                                                                                                                                                            correlationRules,
-                                                                                                                                                            logTypes);
-                                                                                                                                        }
-                                                                                                                                    } else {
-                                                                                                                                        vectorEmbeddingsEngine
-                                                                                                                                                .insertOrphanFindings(
-                                                                                                                                                        detectorType,
-                                                                                                                                                        orphanFinding,
-                                                                                                                                                        Long.valueOf(
-                                                                                                                                                                        CorrelationIndices
-                                                                                                                                                                                        .FIXED_HISTORICAL_INTERVAL
-                                                                                                                                                                                / 1000L)
-                                                                                                                                                                .floatValue(),
-                                                                                                                                                        logTypes);
-                                                                                                                                    }
-                                                                                                                                },
-                                                                                                                                this::onFailures));
-                                                                                                            },
+                                                                                                            indexResponse ->
+                                                                                                                    insertFindings(
+                                                                                                                            fixedTimestampFeature,
+                                                                                                                            correlatedFindings,
+                                                                                                                            detectorType,
+                                                                                                                            correlationRules,
+                                                                                                                            orphanFinding),
                                                                                                             this::onFailures));
                                                                                         } catch (Exception ex) {
                                                                                             onFailures(ex);
@@ -632,11 +715,8 @@ public class TransportCorrelateFindingAction
                                                                                                                 (findingTimestamp - scoreTimestamp) / 1000L)
                                                                                                         .floatValue();
 
-                                                                                        SearchRequest searchRequest =
-                                                                                                getSearchLogTypeIndexRequest();
                                                                                         insertFindings(
                                                                                                 timestampFeature,
-                                                                                                searchRequest,
                                                                                                 correlatedFindings,
                                                                                                 detectorType,
                                                                                                 correlationRules,
@@ -679,79 +759,27 @@ public class TransportCorrelateFindingAction
                                             if (newScoreTimestamp > scoreTimestamp) {
                                                 IndexRequest scoreIndexRequest =
                                                         getCorrelationMetadataIndexRequest(id, newScoreTimestamp);
+                                                float fixedTimestampFeature =
+                                                        Long.valueOf(CorrelationIndices.FIXED_HISTORICAL_INTERVAL / 1000L)
+                                                                .floatValue();
 
                                                 client.index(
                                                         scoreIndexRequest,
                                                         ActionListener.wrap(
-                                                                indexResponse -> {
-                                                                    SearchRequest searchRequest = getSearchLogTypeIndexRequest();
-
-                                                                    client.search(
-                                                                            searchRequest,
-                                                                            ActionListener.wrap(
-                                                                                    searchResponse -> {
-                                                                                        if (searchResponse.isTimedOut()) {
-                                                                                            onFailures(
-                                                                                                    new OpenSearchStatusException(
-                                                                                                            "Search request timed out",
-                                                                                                            RestStatus.REQUEST_TIMEOUT));
-                                                                                        }
-
-                                                                                        SearchHit[] hits = searchResponse.getHits().getHits();
-                                                                                        Map<String, CustomLogType> logTypes =
-                                                                                                buildLogTypes(hits);
-
-                                                                                        if (correlatedFindings != null) {
-                                                                                            if (correlatedFindings.isEmpty()) {
-                                                                                                vectorEmbeddingsEngine.insertOrphanFindings(
-                                                                                                        detectorType,
-                                                                                                        request.getFinding(),
-                                                                                                        Long.valueOf(
-                                                                                                                        CorrelationIndices
-                                                                                                                                        .FIXED_HISTORICAL_INTERVAL
-                                                                                                                                / 1000L)
-                                                                                                                .floatValue(),
-                                                                                                        logTypes);
-                                                                                            }
-                                                                                            for (Map.Entry<String, List<String>>
-                                                                                                    correlatedFinding :
-                                                                                                            correlatedFindings.entrySet()) {
-                                                                                                vectorEmbeddingsEngine.insertCorrelatedFindings(
-                                                                                                        detectorType,
-                                                                                                        request.getFinding(),
-                                                                                                        correlatedFinding.getKey(),
-                                                                                                        correlatedFinding.getValue(),
-                                                                                                        Long.valueOf(
-                                                                                                                        CorrelationIndices
-                                                                                                                                        .FIXED_HISTORICAL_INTERVAL
-                                                                                                                                / 1000L)
-                                                                                                                .floatValue(),
-                                                                                                        correlationRules,
-                                                                                                        logTypes);
-                                                                                            }
-                                                                                        } else {
-                                                                                            vectorEmbeddingsEngine.insertOrphanFindings(
-                                                                                                    detectorType,
-                                                                                                    orphanFinding,
-                                                                                                    Long.valueOf(
-                                                                                                                    CorrelationIndices
-                                                                                                                                    .FIXED_HISTORICAL_INTERVAL
-                                                                                                                            / 1000L)
-                                                                                                            .floatValue(),
-                                                                                                    logTypes);
-                                                                                        }
-                                                                                    },
-                                                                                    this::onFailures));
-                                                                },
+                                                                indexResponse ->
+                                                                        insertFindings(
+                                                                                fixedTimestampFeature,
+                                                                                correlatedFindings,
+                                                                                detectorType,
+                                                                                correlationRules,
+                                                                                orphanFinding),
                                                                 this::onFailures));
                                             } else {
                                                 float timestampFeature =
                                                         Long.valueOf((findingTimestamp - scoreTimestamp) / 1000L).floatValue();
 
-                                                SearchRequest searchRequest = getSearchLogTypeIndexRequest();
                                                 insertFindings(
                                                         timestampFeature,
-                                                        searchRequest,
                                                         correlatedFindings,
                                                         detectorType,
                                                         correlationRules,
@@ -800,44 +828,59 @@ public class TransportCorrelateFindingAction
 
         private void insertFindings(
                 float timestampFeature,
-                SearchRequest searchRequest,
                 Map<String, List<String>> correlatedFindings,
                 String detectorType,
                 List<String> correlationRules,
                 Finding orphanFinding) {
+            withLogTypes(
+                    logTypes -> {
+                        if (correlatedFindings != null) {
+                            if (correlatedFindings.isEmpty()) {
+                                vectorEmbeddingsEngine.insertOrphanFindings(
+                                        detectorType, request.getFinding(), timestampFeature, logTypes);
+                            }
+                            for (Map.Entry<String, List<String>> correlatedFinding :
+                                    correlatedFindings.entrySet()) {
+                                vectorEmbeddingsEngine.insertCorrelatedFindings(
+                                        detectorType,
+                                        request.getFinding(),
+                                        correlatedFinding.getKey(),
+                                        correlatedFinding.getValue(),
+                                        timestampFeature,
+                                        correlationRules,
+                                        logTypes);
+                            }
+                        } else {
+                            vectorEmbeddingsEngine.insertOrphanFindings(
+                                    detectorType, orphanFinding, timestampFeature, logTypes);
+                        }
+                    });
+        }
+
+        /**
+         * Calls {@code onLogTypes} with the cached log type list if a fresh entry is available,
+         * otherwise issues the size-10000 search against {@link LogTypeService#LOG_TYPE_INDEX},
+         * populates the cache, and then invokes the consumer.
+         */
+        private void withLogTypes(Consumer<Map<String, CustomLogType>> onLogTypes) {
+            Optional<Map<String, CustomLogType>> cached = logTypeListCache.get();
+            if (cached.isPresent()) {
+                onLogTypes.accept(cached.get());
+                return;
+            }
             client.search(
-                    searchRequest,
+                    getSearchLogTypeIndexRequest(),
                     ActionListener.wrap(
                             response -> {
                                 if (response.isTimedOut()) {
                                     onFailures(
                                             new OpenSearchStatusException(
                                                     "Search request timed out", RestStatus.REQUEST_TIMEOUT));
+                                    return;
                                 }
-
-                                SearchHit[] hits = response.getHits().getHits();
-                                Map<String, CustomLogType> logTypes = buildLogTypes(hits);
-
-                                if (correlatedFindings != null) {
-                                    if (correlatedFindings.isEmpty()) {
-                                        vectorEmbeddingsEngine.insertOrphanFindings(
-                                                detectorType, request.getFinding(), timestampFeature, logTypes);
-                                    }
-                                    for (Map.Entry<String, List<String>> correlatedFinding :
-                                            correlatedFindings.entrySet()) {
-                                        vectorEmbeddingsEngine.insertCorrelatedFindings(
-                                                detectorType,
-                                                request.getFinding(),
-                                                correlatedFinding.getKey(),
-                                                correlatedFinding.getValue(),
-                                                timestampFeature,
-                                                correlationRules,
-                                                logTypes);
-                                    }
-                                } else {
-                                    vectorEmbeddingsEngine.insertOrphanFindings(
-                                            detectorType, orphanFinding, timestampFeature, logTypes);
-                                }
+                                Map<String, CustomLogType> logTypes = buildLogTypes(response.getHits().getHits());
+                                logTypeListCache.put(logTypes);
+                                onLogTypes.accept(logTypes);
                             },
                             this::onFailures));
         }
@@ -861,6 +904,9 @@ public class TransportCorrelateFindingAction
         public void onOperation() {
             this.response.set(RestStatus.OK);
             if (counter.compareAndSet(false, true)) {
+                if (permitAcquired) {
+                    releasePermitAndDrain();
+                }
                 finishHim(null);
             }
         }
@@ -872,6 +918,9 @@ public class TransportCorrelateFindingAction
                     request.getFinding().getId(),
                     t);
             if (counter.compareAndSet(false, true)) {
+                if (permitAcquired) {
+                    releasePermitAndDrain();
+                }
                 finishHim(t);
             }
         }

--- a/src/test/java/org/opensearch/securityanalytics/correlation/CorrelationRulesCacheTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/correlation/CorrelationRulesCacheTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opensearch.securityanalytics.correlation;
+
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.securityanalytics.model.CorrelationRule;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.opensearch.securityanalytics.TestHelpers.randomCorrelationRule;
+
+public class CorrelationRulesCacheTests extends OpenSearchTestCase {
+
+    public void testHitAndMiss() {
+        CorrelationRulesCache cache = new CorrelationRulesCache(TimeValue.timeValueMinutes(5));
+        List<CorrelationRule> rules =
+                List.of(randomCorrelationRule("rule-a"), randomCorrelationRule("rule-b"));
+
+        assertTrue(cache.get("network").isEmpty());
+
+        cache.put("network", rules);
+        Optional<List<CorrelationRule>> hit = cache.get("network");
+        assertTrue(hit.isPresent());
+        assertEquals(2, hit.get().size());
+
+        assertTrue(cache.get("system-activity").isEmpty());
+    }
+
+    public void testStoredListIsImmutable() {
+        CorrelationRulesCache cache = new CorrelationRulesCache(TimeValue.timeValueMinutes(5));
+        List<CorrelationRule> mutable =
+                new java.util.ArrayList<>(List.of(randomCorrelationRule("rule-a")));
+        cache.put("network", mutable);
+
+        mutable.add(randomCorrelationRule("rule-b"));
+        assertEquals(
+                "cache should snapshot input list, not share reference",
+                1,
+                cache.get("network").get().size());
+    }
+
+    public void testTtlExpiry() {
+        AtomicLong now = new AtomicLong(0);
+        CorrelationRulesCache cache =
+                new CorrelationRulesCache(TimeValue.timeValueSeconds(10), now::get);
+        cache.put("network", List.of(randomCorrelationRule("rule-a")));
+        assertTrue(cache.get("network").isPresent());
+
+        now.addAndGet(TimeValue.timeValueSeconds(9).nanos());
+        assertTrue(cache.get("network").isPresent());
+
+        now.addAndGet(TimeValue.timeValueSeconds(2).nanos());
+        assertTrue(cache.get("network").isEmpty());
+        assertEquals(0, cache.size());
+    }
+
+    public void testInvalidate() {
+        CorrelationRulesCache cache = new CorrelationRulesCache(TimeValue.timeValueMinutes(5));
+        cache.put("network", List.of(randomCorrelationRule("a")));
+        cache.put("system-activity", List.of(randomCorrelationRule("b")));
+
+        cache.invalidate("network");
+        assertTrue(cache.get("network").isEmpty());
+        assertTrue(cache.get("system-activity").isPresent());
+
+        cache.invalidateAll();
+        assertEquals(0, cache.size());
+    }
+
+    public void testZeroTtlDisablesCache() {
+        CorrelationRulesCache cache = new CorrelationRulesCache(TimeValue.timeValueMillis(0));
+        cache.put("network", List.of(randomCorrelationRule("a")));
+        assertEquals(0, cache.size());
+        assertTrue(cache.get("network").isEmpty());
+    }
+
+    public void testSetTtlClearsCacheWhenDisabled() {
+        CorrelationRulesCache cache = new CorrelationRulesCache(TimeValue.timeValueMinutes(5));
+        cache.put("network", List.of(randomCorrelationRule("a")));
+        assertEquals(1, cache.size());
+
+        cache.setTtl(TimeValue.timeValueMillis(0));
+        assertEquals(0, cache.size());
+    }
+}

--- a/src/test/java/org/opensearch/securityanalytics/correlation/DetectorLookupCacheTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/correlation/DetectorLookupCacheTests.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opensearch.securityanalytics.correlation;
+
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.securityanalytics.model.Detector;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.opensearch.securityanalytics.TestHelpers.randomDetector;
+
+public class DetectorLookupCacheTests extends OpenSearchTestCase {
+
+    public void testHitAndMiss() {
+        DetectorLookupCache cache = new DetectorLookupCache(TimeValue.timeValueMinutes(5));
+        Detector detector = randomDetector(List.of(UUID.randomUUID().toString()));
+
+        assertTrue(cache.get("monitor-1").isEmpty());
+
+        cache.put("monitor-1", detector);
+        Optional<Detector> hit = cache.get("monitor-1");
+        assertTrue(hit.isPresent());
+        assertSame(detector, hit.get());
+
+        assertTrue(cache.get("monitor-2").isEmpty());
+    }
+
+    public void testTtlExpiry() {
+        AtomicLong now = new AtomicLong(0);
+        DetectorLookupCache cache = new DetectorLookupCache(TimeValue.timeValueSeconds(10), now::get);
+        Detector detector = randomDetector(List.of(UUID.randomUUID().toString()));
+
+        cache.put("monitor-1", detector);
+        assertTrue(cache.get("monitor-1").isPresent());
+
+        now.addAndGet(TimeValue.timeValueSeconds(9).nanos());
+        assertTrue("entry should still be live before TTL", cache.get("monitor-1").isPresent());
+
+        now.addAndGet(TimeValue.timeValueSeconds(2).nanos());
+        assertTrue("entry should be expired after TTL", cache.get("monitor-1").isEmpty());
+        assertEquals("expired entry should be evicted", 0, cache.size());
+    }
+
+    public void testInvalidate() {
+        DetectorLookupCache cache = new DetectorLookupCache(TimeValue.timeValueMinutes(5));
+        Detector detector = randomDetector(List.of(UUID.randomUUID().toString()));
+
+        cache.put("monitor-1", detector);
+        cache.put("monitor-2", detector);
+
+        cache.invalidate("monitor-1");
+        assertTrue(cache.get("monitor-1").isEmpty());
+        assertTrue(cache.get("monitor-2").isPresent());
+
+        cache.invalidateAll();
+        assertTrue(cache.get("monitor-2").isEmpty());
+        assertEquals(0, cache.size());
+    }
+
+    public void testZeroTtlDisablesCache() {
+        DetectorLookupCache cache = new DetectorLookupCache(TimeValue.timeValueMillis(0));
+        Detector detector = randomDetector(List.of(UUID.randomUUID().toString()));
+
+        cache.put("monitor-1", detector);
+        assertEquals("put should be a no-op when ttl=0", 0, cache.size());
+        assertTrue(cache.get("monitor-1").isEmpty());
+    }
+
+    public void testSetTtlClearsCacheWhenDisabled() {
+        DetectorLookupCache cache = new DetectorLookupCache(TimeValue.timeValueMinutes(5));
+        Detector detector = randomDetector(List.of(UUID.randomUUID().toString()));
+
+        cache.put("monitor-1", detector);
+        assertEquals(1, cache.size());
+
+        cache.setTtl(TimeValue.timeValueMillis(0));
+        assertEquals("disabling cache should evict all entries", 0, cache.size());
+        assertTrue(cache.get("monitor-1").isEmpty());
+    }
+
+    public void testNullDetectorIsNotStored() {
+        DetectorLookupCache cache = new DetectorLookupCache(TimeValue.timeValueMinutes(5));
+        cache.put("monitor-1", null);
+        assertEquals(0, cache.size());
+        assertTrue(cache.get("monitor-1").isEmpty());
+    }
+
+    public void testConcurrentPutAndGet() throws Exception {
+        DetectorLookupCache cache = new DetectorLookupCache(TimeValue.timeValueMinutes(5));
+        Detector detector = randomDetector(List.of(UUID.randomUUID().toString()));
+        int threads = 8;
+        int opsPerThread = 1000;
+
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+
+        for (int t = 0; t < threads; t++) {
+            int finalT = t;
+            pool.submit(
+                    () -> {
+                        try {
+                            start.await();
+                            for (int i = 0; i < opsPerThread; i++) {
+                                String key = "monitor-" + (finalT % 4);
+                                cache.put(key, detector);
+                                cache.get(key);
+                            }
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        } finally {
+                            done.countDown();
+                        }
+                    });
+        }
+
+        start.countDown();
+        assertTrue(done.await(10, TimeUnit.SECONDS));
+        pool.shutdownNow();
+
+        assertEquals(4, cache.size());
+        for (int i = 0; i < 4; i++) {
+            assertSame(detector, cache.get("monitor-" + i).orElse(null));
+        }
+    }
+}

--- a/src/test/java/org/opensearch/securityanalytics/correlation/LogTypeListCacheTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/correlation/LogTypeListCacheTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opensearch.securityanalytics.correlation;
+
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.securityanalytics.model.CustomLogType;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.opensearch.securityanalytics.TestHelpers.randomCustomLogType;
+
+public class LogTypeListCacheTests extends OpenSearchTestCase {
+
+    public void testHitAndMiss() {
+        LogTypeListCache cache = new LogTypeListCache(TimeValue.timeValueMinutes(5));
+        Map<String, CustomLogType> snapshot =
+                Map.of("system-activity", randomCustomLogType("system-activity", null, null, null));
+
+        assertTrue(cache.get().isEmpty());
+
+        cache.put(snapshot);
+        Optional<Map<String, CustomLogType>> hit = cache.get();
+        assertTrue(hit.isPresent());
+        assertSame(snapshot, hit.get());
+    }
+
+    public void testTtlExpiry() {
+        AtomicLong now = new AtomicLong(0);
+        LogTypeListCache cache = new LogTypeListCache(TimeValue.timeValueSeconds(10), now::get);
+        Map<String, CustomLogType> snapshot = Map.of("a", randomCustomLogType("a", null, null, null));
+
+        cache.put(snapshot);
+        assertTrue(cache.get().isPresent());
+
+        now.addAndGet(TimeValue.timeValueSeconds(9).nanos());
+        assertTrue(cache.get().isPresent());
+
+        now.addAndGet(TimeValue.timeValueSeconds(2).nanos());
+        assertTrue(cache.get().isEmpty());
+    }
+
+    public void testInvalidate() {
+        LogTypeListCache cache = new LogTypeListCache(TimeValue.timeValueMinutes(5));
+        cache.put(Map.of("a", randomCustomLogType("a", null, null, null)));
+        assertTrue(cache.get().isPresent());
+
+        cache.invalidate();
+        assertTrue(cache.get().isEmpty());
+    }
+
+    public void testZeroTtlDisablesCache() {
+        LogTypeListCache cache = new LogTypeListCache(TimeValue.timeValueMillis(0));
+        cache.put(Map.of("a", randomCustomLogType("a", null, null, null)));
+        assertTrue(cache.get().isEmpty());
+    }
+
+    public void testSetTtlClearsCacheWhenDisabled() {
+        LogTypeListCache cache = new LogTypeListCache(TimeValue.timeValueMinutes(5));
+        cache.put(Map.of("a", randomCustomLogType("a", null, null, null)));
+        assertTrue(cache.get().isPresent());
+
+        cache.setTtl(TimeValue.timeValueMillis(0));
+        assertTrue(cache.get().isEmpty());
+    }
+
+    public void testNullPutIsNoOp() {
+        LogTypeListCache cache = new LogTypeListCache(TimeValue.timeValueMinutes(5));
+        cache.put(null);
+        assertTrue(cache.get().isEmpty());
+    }
+}

--- a/src/test/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingActionTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/transport/TransportCorrelateFindingActionTests.java
@@ -25,12 +25,16 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.commons.alerting.action.PublishFindingsRequest;
 import org.opensearch.commons.alerting.action.SubscribeFindingsResponse;
 import org.opensearch.commons.alerting.model.Finding;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.securityanalytics.correlation.CorrelationRulesCache;
+import org.opensearch.securityanalytics.correlation.DetectorLookupCache;
+import org.opensearch.securityanalytics.correlation.LogTypeListCache;
 import org.opensearch.securityanalytics.correlation.alert.CorrelationAlertService;
 import org.opensearch.securityanalytics.correlation.alert.notifications.NotificationService;
 import org.opensearch.securityanalytics.enrichment.WazuhEnrichedFindingService;
@@ -150,7 +154,10 @@ public class TransportCorrelateFindingActionTests extends OpenSearchTestCase {
                                         SecurityAnalyticsSettings.INDEX_TIMEOUT,
                                         SecurityAnalyticsSettings.CORRELATION_TIME_WINDOW,
                                         SecurityAnalyticsSettings.ENABLE_AUTO_CORRELATIONS,
-                                        SecurityAnalyticsSettings.ENRICHED_FINDINGS_ENABLED)));
+                                        SecurityAnalyticsSettings.ENRICHED_FINDINGS_ENABLED,
+                                        SecurityAnalyticsSettings.CORRELATION_DETECTOR_CACHE_TTL,
+                                        SecurityAnalyticsSettings.CORRELATION_MAX_IN_FLIGHT_FINDINGS,
+                                        SecurityAnalyticsSettings.CORRELATION_METADATA_CACHE_TTL)));
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
         when(clusterService.state()).thenReturn(ClusterState.builder(new ClusterName("test")).build());
         when(s.detectorIndices.getThreadPool()).thenReturn(s.threadPool);
@@ -182,7 +189,10 @@ public class TransportCorrelateFindingActionTests extends OpenSearchTestCase {
                         new ActionFilters(Collections.emptySet()),
                         mock(CorrelationAlertService.class),
                         mock(NotificationService.class),
-                        mock(WazuhEnrichedFindingService.class));
+                        mock(WazuhEnrichedFindingService.class),
+                        new DetectorLookupCache(TimeValue.ZERO),
+                        new LogTypeListCache(TimeValue.ZERO),
+                        new CorrelationRulesCache(TimeValue.ZERO));
         return s;
     }
 


### PR DESCRIPTION
### Description
Under high ingest volume, findings could be missing from the enriched findings index. This PR restructures the correlation transport action so enrichment is no longer coupled to the success of the correlation pipeline, and reduces the per-finding load that was driving the search thread pool into rejection.

**Enrichment is dispatched up front**, before correlation runs. Previously it was triggered from inside the correlation pipeline's detector-lookup callback, so any failure earlier in the chain silently skipped enrichment. A related fix routes synchronous failures through the action listener instead of rethrowing — a rethrow inside the alerting plugin's publish loop was dropping every subsequent finding in the batch. The enrichment service itself is also hardened so a single failed event no longer stalls the queue.

**Correlation work is now bounded.** A configurable semaphore caps the number of correlation pipelines running concurrently; excess findings queue and start as slots free up. This keeps fan-outs from saturating the search thread pool.

**Slow-changing lookups are cached in memory** (detector by monitor id, log type list, and correlation rules by detector type). Each was previously a per-finding search against a system index and was the largest contributor to search-pool pressure during fan-outs. All caches are TTL-based and configurable, with sensible defaults and a `0` value to disable.

New cluster settings:
- `plugins.security_analytics.correlation.max_in_flight_findings` (default 50)
- `plugins.security_analytics.correlation.detector_cache_ttl` (default 5m)
- `plugins.security_analytics.correlation.metadata_cache_ttl` (default 5m)

### Related Issues
Resolves #168