### PR TITLE
Nest `rule` under `wazuh` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Disable standard threat detectors modification [(#121)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/121)
 - Remove duplicated metadata fields for rules [(#163)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/163)
 - Normalize space values to lowercase across SAP [(#174)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/174)
+- Nest rule under wazuh object [(#204)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/204)
 
 ### Deprecated
 -

--- a/src/main/java/org/opensearch/securityanalytics/enrichment/WazuhEnrichedFindingService.java
+++ b/src/main/java/org/opensearch/securityanalytics/enrichment/WazuhEnrichedFindingService.java
@@ -387,7 +387,7 @@ public class WazuhEnrichedFindingService implements Closeable {
             if (existingWazuh instanceof Map) {
                 wazuhObj.putAll((Map<String, Object>) existingWazuh);
             }
-            wazuhObj.put("rule", this.buildRuleObject(primaryQuery, ruleMetadata,eventSource));
+            wazuhObj.put("rule", this.buildRuleObject(primaryQuery, ruleMetadata, eventSource));
             doc.put("wazuh", wazuhObj);
         }
 

--- a/src/main/java/org/opensearch/securityanalytics/enrichment/WazuhEnrichedFindingService.java
+++ b/src/main/java/org/opensearch/securityanalytics/enrichment/WazuhEnrichedFindingService.java
@@ -379,9 +379,16 @@ public class WazuhEnrichedFindingService implements Closeable {
         eventObj.put("ingested", eventSource.get("@timestamp"));
         doc.put("event", eventObj);
 
-        // rule.*
+        // wazuh.rule — merge into existing wazuh map (defensive copy: eventSource's
+        // wazuh map is shared with doc via the shallow copy above).
         if (primaryQuery != null) {
-            doc.put("rule", this.buildRuleObject(primaryQuery, ruleMetadata));
+            Map<String, Object> wazuhObj = new HashMap<>();
+            Object existingWazuh = eventSource.get("wazuh");
+            if (existingWazuh instanceof Map) {
+                wazuhObj.putAll((Map<String, Object>) existingWazuh);
+            }
+            wazuhObj.put("rule", this.buildRuleObject(primaryQuery, ruleMetadata));
+            doc.put("wazuh", wazuhObj);
         }
 
         this.indexEnrichedFinding(category, doc);


### PR DESCRIPTION
### Description
This PR indexes enrichments to the `wazuh.rule` object instead of the top-level `rule` one.

### Issues Resolved
Resolves https://github.com/wazuh/wazuh-indexer-plugins/issues/1121
