### PR TITLE
Fix ClassCastException in WTransportDeleteSpaceResourcesAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix stale detector references after rule deletion [(#152)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/152)
 - Fix race condition and missing else branch on correlation metadata index creation [(#148)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/184)
 - Fix contains conditions using white spaces [(#162)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/162)
+- Fix ClassCastException in WTransportDeleteSpaceResourcesAction [(#205)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/205)
 
 ### Security
 -

--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportDeleteSpaceResourcesAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportDeleteSpaceResourcesAction.java
@@ -361,7 +361,7 @@ public class WTransportDeleteSpaceResourcesAction
      * otherwise propagates the failure. Callers pass the empty result that matches their listener's
      * type (e.g. {@code 0} for {@code Integer}, {@code Collections.emptyList()} for {@code List}).
      */
-    private static <T> void resolveOrFail(Exception e, T emptyValue, ActionListener<T> listener) {
+    static <T> void resolveOrFail(Exception e, T emptyValue, ActionListener<T> listener) {
         if (e instanceof IndexNotFoundException
                 || (e.getCause() != null && e.getCause() instanceof IndexNotFoundException)) {
             listener.onResponse(emptyValue);

--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportDeleteSpaceResourcesAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportDeleteSpaceResourcesAction.java
@@ -42,6 +42,7 @@ import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -197,7 +198,7 @@ public class WTransportDeleteSpaceResourcesAction
                             this.deleteDetectorsSequentially(
                                     ids.iterator(), refreshPolicy, new AtomicInteger(0), listener);
                         },
-                        e -> resolveOrFail(e, listener)));
+                        e -> resolveOrFail(e, 0, listener)));
     }
 
     private void deleteDetectorsSequentially(
@@ -270,7 +271,7 @@ public class WTransportDeleteSpaceResourcesAction
                 new SearchRequest(ruleIndex).source(source),
                 ActionListener.wrap(
                         response -> listener.onResponse(collectIds(response)),
-                        e -> resolveOrFail(e, listener)));
+                        e -> resolveOrFail(e, Collections.emptyList(), listener)));
     }
 
     /**
@@ -311,7 +312,7 @@ public class WTransportDeleteSpaceResourcesAction
                             }
                             listener.onResponse(result);
                         },
-                        e -> resolveOrFail(e, listener)));
+                        e -> resolveOrFail(e, Collections.emptyList(), listener)));
     }
 
     /**
@@ -356,19 +357,14 @@ public class WTransportDeleteSpaceResourcesAction
     }
 
     /**
-     * If the exception is an {@link IndexNotFoundException}, resolves with an empty result; otherwise
-     * propagates the failure.
+     * If the exception is an {@link IndexNotFoundException}, resolves with the supplied empty value;
+     * otherwise propagates the failure. Callers pass the empty result that matches their listener's
+     * type (e.g. {@code 0} for {@code Integer}, {@code Collections.emptyList()} for {@code List}).
      */
-    @SuppressWarnings("unchecked")
-    private static <T> void resolveOrFail(Exception e, ActionListener<T> listener) {
+    private static <T> void resolveOrFail(Exception e, T emptyValue, ActionListener<T> listener) {
         if (e instanceof IndexNotFoundException
                 || (e.getCause() != null && e.getCause() instanceof IndexNotFoundException)) {
-            // Index does not exist — nothing to delete / return empty list.
-            try {
-                listener.onResponse((T) new ArrayList<>());
-            } catch (ClassCastException cce) {
-                listener.onResponse((T) Integer.valueOf(0));
-            }
+            listener.onResponse(emptyValue);
         } else {
             listener.onFailure(e);
         }

--- a/src/test/java/org/opensearch/securityanalytics/transport/WTransportDeleteSpaceResourcesActionTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/transport/WTransportDeleteSpaceResourcesActionTests.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opensearch.securityanalytics.transport;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class WTransportDeleteSpaceResourcesActionTests extends OpenSearchTestCase {
+
+    /**
+     * Captures the outcome of an {@link ActionListener} so tests can assert on the value or failure
+     * delivered to it.
+     */
+    private static final class CapturingListener<T> implements ActionListener<T> {
+        final AtomicReference<T> response = new AtomicReference<>();
+        final AtomicReference<Exception> failure = new AtomicReference<>();
+
+        @Override
+        public void onResponse(T value) {
+            response.set(value);
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            failure.set(e);
+        }
+    }
+
+    public void testResolveOrFail_indexNotFound_resolvesWithIntegerEmptyValue() {
+        CapturingListener<Integer> listener = new CapturingListener<>();
+
+        WTransportDeleteSpaceResourcesAction.resolveOrFail(
+                new IndexNotFoundException("missing"), 0, listener);
+
+        assertEquals(Integer.valueOf(0), listener.response.get());
+        assertNull(listener.failure.get());
+    }
+
+    public void testResolveOrFail_indexNotFound_resolvesWithEmptyList() {
+        CapturingListener<List<String>> listener = new CapturingListener<>();
+
+        WTransportDeleteSpaceResourcesAction.resolveOrFail(
+                new IndexNotFoundException("missing"), Collections.emptyList(), listener);
+
+        assertNotNull(listener.response.get());
+        assertTrue(listener.response.get().isEmpty());
+        assertNull(listener.failure.get());
+    }
+
+    public void testResolveOrFail_indexNotFoundAsCause_resolves() {
+        CapturingListener<Integer> listener = new CapturingListener<>();
+        Exception wrapped = new OpenSearchException("wrap", new IndexNotFoundException("missing"));
+
+        WTransportDeleteSpaceResourcesAction.resolveOrFail(wrapped, 0, listener);
+
+        assertEquals(Integer.valueOf(0), listener.response.get());
+        assertNull(listener.failure.get());
+    }
+
+    public void testResolveOrFail_otherException_propagatesFailure() {
+        CapturingListener<Integer> listener = new CapturingListener<>();
+        Exception unrelated = new IllegalStateException("boom");
+
+        WTransportDeleteSpaceResourcesAction.resolveOrFail(unrelated, 0, listener);
+
+        assertNull(listener.response.get());
+        assertSame(unrelated, listener.failure.get());
+    }
+
+    /**
+     * Regression test for the {@code ClassCastException} reported on first-startup space cleanup.
+     * Previously the helper unconditionally returned an {@code ArrayList} and relied on a dead {@code
+     * catch (ClassCastException)} block, so an {@code Integer}-typed listener received a value of the
+     * wrong runtime type and the cast surfaced later as a partial-failure.
+     */
+    public void testResolveOrFail_indexNotFound_integerListenerReceivesInteger() {
+        CapturingListener<Integer> listener = new CapturingListener<>();
+
+        WTransportDeleteSpaceResourcesAction.resolveOrFail(
+                new IndexNotFoundException("missing"), 0, listener);
+
+        Object delivered = listener.response.get();
+        assertNotNull(delivered);
+        assertTrue(
+                "expected Integer but got " + delivered.getClass().getName(), delivered instanceof Integer);
+    }
+}


### PR DESCRIPTION
### Description
Fix `ClassCastException` thrown by `WTransportDeleteSpaceResourcesAction` during wazuh-indexer startup when deleting Security Analytics resources for the `standard` space.

The shared `resolveOrFail` helper used a single generic type parameter to serve three callers expecting different result types (`Integer`, `List<String>`, `List<IntegrationInfo>`). Due to type erasure, the unchecked `(T) new ArrayList<>()` cast did not throw at the `onResponse` callsite, instead, the wrong type propagated through `ActionListener.wrap` and surfaced later as `class java.util.ArrayList cannot be cast to class java.lang.Integer`, ending in a partial-failure log on every fresh-cluster startup.

The helper now takes an explicit `emptyValue` parameter, so each caller supplies the correct empty result for its listener type. This removes the unchecked cast and the unreachable `catch (ClassCastException)` block.

#### Validation

- On stardard space update, the `Deleting all Security Analytics resources for space [standard]` is displayed and no error is raised
    ```bash
    [2026-05-08T00:54:04,082][INFO ][o.o.s.t.WTransportDeleteSpaceResourcesAction] [node-1] Deleting all Security Analytics resources for space [standard]
    [2026-05-08T00:54:04,110][INFO ][o.o.s.t.WTransportDeleteSpaceResourcesAction] [node-1] Space [standard] delete complete: [0] detectors, [0] rules, [22] integrations
    ```
    ```bash
    # grep "ClassCastException" /var/log/wazuh-indexer/wazuh-cluster.log 
    root@vagrant:/home/vagrant# 
    ```

### Related Issues
Closes https://github.com/wazuh/wazuh-indexer-plugins/issues/1150

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
