### PR TITLE
Add support for dynamic configuration of threat detectors

### DIFF
--- a/commons/src/main/java/com/wazuh/securityanalytics/action/WIndexDetectorRequest.java
+++ b/commons/src/main/java/com/wazuh/securityanalytics/action/WIndexDetectorRequest.java
@@ -40,6 +40,9 @@ public class WIndexDetectorRequest extends ActionRequest {
     private final String category;
     private final List<String> rules;
     private final WriteRequest.RefreshPolicy refreshPolicy;
+    private final List<String> sources;
+    private final int interval;
+    private final boolean enabled;
 
     /**
      * Constructs a new WIndexDetectorRequest.
@@ -55,13 +58,19 @@ public class WIndexDetectorRequest extends ActionRequest {
             String logTypeName,
             String category,
             List<String> rules,
-            WriteRequest.RefreshPolicy refreshPolicy) {
+            WriteRequest.RefreshPolicy refreshPolicy,
+            List<String> sources,
+            int interval,
+            boolean enabled) {
         super();
         this.detectorId = detectorId;
         this.logTypeName = logTypeName;
         this.category = category;
         this.rules = rules;
         this.refreshPolicy = refreshPolicy;
+        this.sources = sources;
+        this.interval = interval;
+        this.enabled = enabled;
     }
 
     /**
@@ -76,7 +85,10 @@ public class WIndexDetectorRequest extends ActionRequest {
                 sin.readString(),
                 sin.readString(),
                 sin.readStringList(),
-                WriteRequest.RefreshPolicy.readFrom(sin));
+                WriteRequest.RefreshPolicy.readFrom(sin),
+                sin.readStringList(),
+                sin.readInt(),
+                sin.readBoolean());
     }
 
     @Override
@@ -91,6 +103,9 @@ public class WIndexDetectorRequest extends ActionRequest {
         out.writeString(this.category);
         out.writeStringCollection(this.rules);
         this.refreshPolicy.writeTo(out);
+        out.writeStringCollection(this.sources);
+        out.writeInt(this.interval);
+        out.writeBoolean(this.enabled);
     }
 
     public String getDetectorId() {
@@ -111,5 +126,17 @@ public class WIndexDetectorRequest extends ActionRequest {
 
     public WriteRequest.RefreshPolicy getRefreshPolicy() {
         return this.refreshPolicy;
+    }
+
+    public List<String> getSources() {
+        return this.sources;
+    }
+
+    public int getInterval() {
+        return this.interval;
+    }
+
+    public boolean isEnabled() {
+        return this.enabled;
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorAction.java
@@ -391,7 +391,12 @@ public class WTransportIndexDetectorAction
             List<String> validRuleIds) {
         Detector detector =
                 DetectorFactory.createDetector(
-                        request.getLogTypeName(), request.getCategory(), validRuleIds);
+                        request.getLogTypeName(),
+                        request.getCategory(),
+                        validRuleIds,
+                        request.getSources(),
+                        request.getInterval(),
+                        request.isEnabled());
         detector.setId(request.getDetectorId());
 
         IndexDetectorRequest indexDetectorRequest =

--- a/src/main/java/org/opensearch/securityanalytics/util/DetectorFactory.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/DetectorFactory.java
@@ -94,6 +94,6 @@ public class DetectorFactory {
                 null,
                 null,
                 false,
-                null); // TODO capture source: standard, custom
+                Detector.STANDARD_SOURCE);
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/util/DetectorFactory.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/DetectorFactory.java
@@ -99,6 +99,7 @@ public class DetectorFactory {
                 null,
                 null,
                 null,
-                false);
+                false,
+                null);
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/util/DetectorFactory.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/DetectorFactory.java
@@ -58,6 +58,12 @@ public class DetectorFactory {
 
     public static Detector createDetector(
             String integration, String category, List<String> detectorRules, String source) {
+            String integration,
+            String category,
+            List<String> detectorRules,
+            List<String> sources,
+            int interval,
+            boolean isEnabled) {
 
         List<DetectorRule> rules = new ArrayList<>();
         detectorRules.forEach(rule -> rules.add(new DetectorRule(rule)));
@@ -65,16 +71,18 @@ public class DetectorFactory {
         Long version = 1L;
         String name = integration.toLowerCase(Locale.ROOT);
         String description = "Detector for " + integration + " integration";
-        String dataStream = "wazuh-events-v5-" + category.toLowerCase(Locale.ROOT);
-        IntervalSchedule schedule = new IntervalSchedule(2, ChronoUnit.MINUTES, null);
-        DetectorInput detectorInput =
-                new DetectorInput(description, List.of(dataStream), new ArrayList<>(), rules);
+        List<String> inputs =
+                (sources != null && !sources.isEmpty())
+                        ? sources
+                        : List.of("wazuh-events-v5-" + category.toLowerCase(Locale.ROOT));
+        IntervalSchedule schedule = new IntervalSchedule(interval, ChronoUnit.MINUTES, null);
+        DetectorInput detectorInput = new DetectorInput(description, inputs, new ArrayList<>(), rules);
         // Generate Detector object with this template
         return new Detector(
                 "Detector for " + integration,
                 version,
                 name,
-                true,
+                isEnabled,
                 schedule,
                 Instant.now(),
                 Instant.now(),

--- a/src/main/java/org/opensearch/securityanalytics/util/DetectorFactory.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/DetectorFactory.java
@@ -91,7 +91,6 @@ public class DetectorFactory {
                 null,
                 null,
                 null,
-                false,
-                source);
+                false);
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/util/DetectorFactory.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/DetectorFactory.java
@@ -52,12 +52,6 @@ public class DetectorFactory {
      * @return a new {@link Detector} instance configured for the integration
      */
     public static Detector createDetector(
-            String integration, String category, List<String> detectorRules) {
-        return createDetector(integration, category, detectorRules, Detector.STANDARD_SOURCE);
-    }
-
-    public static Detector createDetector(
-            String integration, String category, List<String> detectorRules, String source) {
             String integration,
             String category,
             List<String> detectorRules,
@@ -87,7 +81,7 @@ public class DetectorFactory {
                 Instant.now(),
                 Instant.now(),
                 integration,
-                null,
+                null, // TODO capture user
                 List.of(detectorInput),
                 new ArrayList<>(),
                 null,
@@ -100,6 +94,6 @@ public class DetectorFactory {
                 null,
                 null,
                 false,
-                null);
+                null); // TODO capture source: standard, custom
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/action/IndexDetectorRequestTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/action/IndexDetectorRequestTests.java
@@ -1,12 +1,21 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.opensearch.securityanalytics.action;
 
-import java.util.Collections;
-import java.util.stream.Collectors;
-import org.junit.Assert;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -15,10 +24,15 @@ import org.opensearch.securityanalytics.model.Detector;
 import org.opensearch.securityanalytics.model.DetectorInput;
 import org.opensearch.securityanalytics.model.DetectorRule;
 import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Assert;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
+
+import com.wazuh.securityanalytics.action.WIndexDetectorRequest;
 
 import static org.opensearch.securityanalytics.TestHelpers.randomDetector;
 import static org.opensearch.securityanalytics.TestHelpers.randomDetectorWithInputs;
@@ -27,7 +41,12 @@ public class IndexDetectorRequestTests extends OpenSearchTestCase {
 
     public void testIndexDetectorPostRequest() throws IOException {
         String detectorId = UUID.randomUUID().toString();
-        IndexDetectorRequest request = new IndexDetectorRequest(detectorId, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST, randomDetector(List.of(UUID.randomUUID().toString())));
+        IndexDetectorRequest request =
+                new IndexDetectorRequest(
+                        detectorId,
+                        WriteRequest.RefreshPolicy.IMMEDIATE,
+                        RestRequest.Method.POST,
+                        randomDetector(List.of(UUID.randomUUID().toString())));
 
         Assert.assertNotNull(request);
 
@@ -45,13 +64,23 @@ public class IndexDetectorRequestTests extends OpenSearchTestCase {
         String detectorId = UUID.randomUUID().toString();
 
         List<String> rules = List.of(UUID.randomUUID().toString());
-        DetectorInput input1 = new DetectorInput("windows detector for security analytics", List.of("windows-1"), Collections.emptyList(),
-                rules.stream().map(DetectorRule::new).collect(Collectors.toList()));
-        DetectorInput input2 = new DetectorInput("windows detector for security analytics", List.of("windows-2"), Collections.emptyList(),
-                rules.stream().map(DetectorRule::new).collect(Collectors.toList()));
+        DetectorInput input1 =
+                new DetectorInput(
+                        "windows detector for security analytics",
+                        List.of("windows-1"),
+                        Collections.emptyList(),
+                        rules.stream().map(DetectorRule::new).collect(Collectors.toList()));
+        DetectorInput input2 =
+                new DetectorInput(
+                        "windows detector for security analytics",
+                        List.of("windows-2"),
+                        Collections.emptyList(),
+                        rules.stream().map(DetectorRule::new).collect(Collectors.toList()));
 
         Detector detector = randomDetectorWithInputs(List.of(input1));
-        IndexDetectorRequest request = new IndexDetectorRequest(detectorId, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST, detector);
+        IndexDetectorRequest request =
+                new IndexDetectorRequest(
+                        detectorId, WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST, detector);
 
         Assert.assertNotNull(request);
 
@@ -63,5 +92,48 @@ public class IndexDetectorRequestTests extends OpenSearchTestCase {
         Assert.assertEquals(detectorId, request.getDetectorId());
         Assert.assertEquals(RestRequest.Method.POST, newRequest.getMethod());
         Assert.assertNotNull(newRequest.getDetector());
+    }
+
+    /**
+     * Tests the serialization and deserialization of WIndexDetectorRequest. This ensures that all
+     * custom Wazuh fields are correctly preserved when the request is sent over the network between
+     * nodes.
+     */
+    public void testWIndexDetectorRequestSerialization() throws IOException {
+        // Prepare mock data for the Wazuh Index Request
+        String detectorId = UUID.randomUUID().toString();
+        String logTypeName = "apache";
+        String category = "web";
+        List<String> rules = List.of("rule_1", "rule_2");
+        List<String> sources = List.of("wazuh-events-v5-apache");
+        int interval = 10;
+        boolean enabled = true;
+        WriteRequest.RefreshPolicy refreshPolicy = WriteRequest.RefreshPolicy.IMMEDIATE;
+
+        // Initialize the request
+        WIndexDetectorRequest request =
+                new WIndexDetectorRequest(
+                        detectorId, logTypeName, category, rules, refreshPolicy, sources, interval, enabled);
+
+        // Serialize the request to a byte stream
+        BytesStreamOutput out = new BytesStreamOutput();
+        request.writeTo(out);
+
+        // Deserialize the request from the byte stream
+        StreamInput sin = StreamInput.wrap(out.bytes().toBytesRef().bytes);
+        WIndexDetectorRequest deserializedRequest = new WIndexDetectorRequest(sin);
+
+        // Assert that all fields were preserved during serialization/deserialization
+        Assert.assertEquals(
+                "Detector ID should match", detectorId, deserializedRequest.getDetectorId());
+        Assert.assertEquals(
+                "Log type name should match", logTypeName, deserializedRequest.getLogTypeName());
+        Assert.assertEquals("Category should match", category, deserializedRequest.getCategory());
+        Assert.assertEquals("Rules list should match", rules, deserializedRequest.getRules());
+        Assert.assertEquals(
+                "Refresh policy should match", refreshPolicy, deserializedRequest.getRefreshPolicy());
+        Assert.assertEquals("Sources list should match", sources, deserializedRequest.getSources());
+        Assert.assertEquals("Interval should match", interval, deserializedRequest.getInterval());
+        Assert.assertEquals("Enabled flag should match", enabled, deserializedRequest.isEnabled());
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/util/DetectorFactoryTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/util/DetectorFactoryTests.java
@@ -35,7 +35,9 @@ public class DetectorFactoryTests extends OpenSearchTestCase {
         String category = "Network Activity";
         List<String> ruleIds = List.of("rule-1", "rule-2", "rule-3");
 
-        Detector detector = DetectorFactory.createDetector(integration, category, ruleIds);
+        // sources=null, interval=2, isEnabled=true
+        Detector detector =
+                DetectorFactory.createDetector(integration, category, ruleIds, null, 2, true);
 
         Assert.assertNotNull(detector);
         Assert.assertEquals("apache", detector.getName());
@@ -48,7 +50,8 @@ public class DetectorFactoryTests extends OpenSearchTestCase {
         String category = "Security";
         List<String> ruleIds = List.of("rule-1");
 
-        Detector detector = DetectorFactory.createDetector(integration, category, ruleIds);
+        Detector detector =
+                DetectorFactory.createDetector(integration, category, ruleIds, null, 2, true);
 
         Assert.assertEquals("nginx", detector.getName());
     }
@@ -58,7 +61,8 @@ public class DetectorFactoryTests extends OpenSearchTestCase {
         String category = "Network Activity";
         List<String> ruleIds = List.of("rule-1");
 
-        Detector detector = DetectorFactory.createDetector(integration, category, ruleIds);
+        Detector detector =
+                DetectorFactory.createDetector(integration, category, ruleIds, null, 2, true);
 
         DetectorInput input = detector.getInputs().get(0);
         String expectedDataStream = "wazuh-events-v5-network activity";
@@ -70,7 +74,8 @@ public class DetectorFactoryTests extends OpenSearchTestCase {
         String category = "SECURITY";
         List<String> ruleIds = List.of("rule-1");
 
-        Detector detector = DetectorFactory.createDetector(integration, category, ruleIds);
+        Detector detector =
+                DetectorFactory.createDetector(integration, category, ruleIds, null, 2, true);
 
         DetectorInput input = detector.getInputs().get(0);
         String expectedDataStream = "wazuh-events-v5-security";
@@ -82,7 +87,8 @@ public class DetectorFactoryTests extends OpenSearchTestCase {
         String category = "Security";
         List<String> ruleIds = List.of("rule-1", "rule-2");
 
-        Detector detector = DetectorFactory.createDetector(integration, category, ruleIds);
+        Detector detector =
+                DetectorFactory.createDetector(integration, category, ruleIds, null, 2, true);
 
         DetectorInput input = detector.getInputs().get(0);
         List<DetectorRule> rules = input.getPrePackagedRules();
@@ -96,7 +102,8 @@ public class DetectorFactoryTests extends OpenSearchTestCase {
         String category = "Security";
         List<String> ruleIds = Collections.emptyList();
 
-        Detector detector = DetectorFactory.createDetector(integration, category, ruleIds);
+        Detector detector =
+                DetectorFactory.createDetector(integration, category, ruleIds, null, 2, true);
 
         DetectorInput input = detector.getInputs().get(0);
         Assert.assertTrue(input.getPrePackagedRules().isEmpty());
@@ -107,7 +114,8 @@ public class DetectorFactoryTests extends OpenSearchTestCase {
         String category = "Security";
         List<String> ruleIds = List.of("rule-1");
 
-        Detector detector = DetectorFactory.createDetector(integration, category, ruleIds);
+        Detector detector =
+                DetectorFactory.createDetector(integration, category, ruleIds, null, 2, true);
 
         Assert.assertTrue(detector.getSchedule() instanceof IntervalSchedule);
         IntervalSchedule schedule = (IntervalSchedule) detector.getSchedule();
@@ -120,7 +128,8 @@ public class DetectorFactoryTests extends OpenSearchTestCase {
         String category = "Security";
         List<String> ruleIds = List.of("rule-1");
 
-        Detector detector = DetectorFactory.createDetector(integration, category, ruleIds);
+        Detector detector =
+                DetectorFactory.createDetector(integration, category, ruleIds, null, 2, true);
 
         // Verify the detector version is 1
         Assert.assertEquals(Long.valueOf(1L), detector.getVersion());
@@ -131,7 +140,8 @@ public class DetectorFactoryTests extends OpenSearchTestCase {
         String category = "Security";
         List<String> ruleIds = List.of("rule-1");
 
-        Detector detector = DetectorFactory.createDetector(integration, category, ruleIds);
+        Detector detector =
+                DetectorFactory.createDetector(integration, category, ruleIds, null, 2, true);
 
         Assert.assertTrue(detector.getEnabled());
     }
@@ -141,7 +151,8 @@ public class DetectorFactoryTests extends OpenSearchTestCase {
         String category = "Other";
         List<String> ruleIds = List.of("rule-1");
 
-        Detector detector = DetectorFactory.createDetector(integration, category, ruleIds);
+        Detector detector =
+                DetectorFactory.createDetector(integration, category, ruleIds, null, 2, true);
 
         Assert.assertEquals("CustomIntegration", detector.getLogType());
     }
@@ -151,7 +162,8 @@ public class DetectorFactoryTests extends OpenSearchTestCase {
         String category = "Security";
         List<String> ruleIds = List.of("rule-1");
 
-        Detector detector = DetectorFactory.createDetector(integration, category, ruleIds);
+        Detector detector =
+                DetectorFactory.createDetector(integration, category, ruleIds, null, 2, true);
 
         Assert.assertEquals(1, detector.getInputs().size());
     }
@@ -161,9 +173,45 @@ public class DetectorFactoryTests extends OpenSearchTestCase {
         String category = "Security";
         List<String> ruleIds = List.of("rule-1");
 
-        Detector detector = DetectorFactory.createDetector(integration, category, ruleIds);
+        Detector detector =
+                DetectorFactory.createDetector(integration, category, ruleIds, null, 2, true);
 
         DetectorInput input = detector.getInputs().get(0);
         Assert.assertEquals("Detector for Apache integration", input.getDescription());
+    }
+
+    /**
+     * Verifies that the detector is created with custom index sources instead of the default naming
+     * convention.
+     */
+    public void testCreateDetector_withCustomSources() {
+        List<String> customSources = List.of("index-1", "index-2");
+
+        Detector detector =
+                DetectorFactory.createDetector("apache", "security", List.of("r1"), customSources, 5, true);
+
+        DetectorInput input = detector.getInputs().get(0);
+        Assert.assertEquals(customSources, input.getIndices());
+        Assert.assertEquals(2, input.getIndices().size());
+    }
+
+    /** Verifies that the detector schedule is correctly set using the custom interval provided. */
+    public void testCreateDetector_withCustomInterval() {
+        int customInterval = 10;
+
+        Detector detector =
+                DetectorFactory.createDetector(
+                        "apache", "security", List.of("r1"), null, customInterval, true);
+
+        IntervalSchedule schedule = (IntervalSchedule) detector.getSchedule();
+        Assert.assertEquals(customInterval, schedule.getInterval());
+    }
+
+    /** Verifies that the detector's enabled/disabled state is correctly assigned during creation. */
+    public void testCreateDetector_disabledState() {
+        Detector detector =
+                DetectorFactory.createDetector("apache", "security", List.of("r1"), null, 2, false);
+
+        Assert.assertFalse("Detector should be disabled", detector.getEnabled());
     }
 }


### PR DESCRIPTION
### Description
Extends the configuration of threat detectors to allow dynamic `sources`, `interval` and `isEnabled` values.

**Validation**


5 min
<img width="1485" height="467" alt="image" src="https://github.com/user-attachments/assets/5a4b7317-f8d2-4361-8740-b19af79021c4" />


1 min
<img width="1485" height="467" alt="image" src="https://github.com/user-attachments/assets/62c4cea0-c460-40fc-8dc2-6e8a6a3d27c7" />


2 min
<img width="1485" height="467" alt="image" src="https://github.com/user-attachments/assets/3c533583-857e-44f6-80c8-c43c9b1eaf8c" />


### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-plugins/issues/1029

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
