### PR TITLE
Restrict threat detector sources to wazuh-events-v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add dynamic interpolation of rule fields [(#189)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/189)
 - Add Exists Sigma Modifier [(#185)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/185)
 - Add support for case-insensitive Sigma operators [(#183)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/183)
+- Restrict thread detectors sources to wazuh-events-v5 [(#209)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/209)
 
 ### Dependencies
 - Update to JDK 25 [(#49)](https://github.com/wazuh/wazuh-indexer-security-analytics/pull/49)

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -404,6 +404,13 @@ public class TransportIndexDetectorAction
         return null;
     }
 
+    /**
+     * Validates detector input data sources before detector creation/update.
+     *
+     * <p>Threat detectors can only be created for data sources whose names start with {@code
+     * wazuh-events-v5}. If any source does not match this prefix, the request is rejected with {@code
+     * 400 Bad Request}.
+     */
     private void checkIndicesAndExecute(
             Task task,
             IndexDetectorRequest request,

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -125,6 +125,7 @@ import org.opensearch.transport.client.node.NodeClient;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -413,6 +414,18 @@ public class TransportIndexDetectorAction
                 request.getDetector().getInputs().stream()
                         .flatMap(detectorInput -> detectorInput.getIndices().stream())
                         .toArray(String[]::new);
+
+        boolean hasInvalidSource =
+                Arrays.stream(detectorIndices).anyMatch(index -> !index.startsWith("wazuh-events-v5"));
+
+        if (hasInvalidSource) {
+            listener.onFailure(
+                    new OpenSearchStatusException(
+                            "Threat detectors can only be created for `wazuh-events-v5` data sources.",
+                            RestStatus.BAD_REQUEST));
+            return;
+        }
+
         SearchRequest searchRequest =
                 new SearchRequest(detectorIndices)
                         .source(

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
@@ -596,7 +596,7 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
 
     // TODO: Disabled due to commented-out REST endpoints. Re-enable when endpoints are restored.
     @AwaitsFix(bugUrl = "")
-    public void testCreatingADetectorWithIndexNotExists() throws IOException {
+    public void testCreatingADetectorWithInvalidDataSourcePrefix() throws IOException {
         Detector detector =
                 randomDetectorWithTriggers(
                         getRandomPrePackagedRules(),
@@ -619,8 +619,40 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
                     SecurityAnalyticsPlugin.DETECTOR_BASE_URI,
                     Collections.emptyMap(),
                     toHttpEntity(detector));
+            fail("create detector call should have failed");
+        } catch (ResponseException ex) {
+            Assert.assertEquals(400, ex.getResponse().getStatusLine().getStatusCode());
+            assertTrue(
+                    ex.getMessage()
+                            .contains(
+                                    "Threat detectors can only be created for `wazuh-events-v5` data sources."));
+        }
+    }
+
+    // TODO: Disabled due to commented-out REST endpoints. Re-enable when endpoints are restored.
+    @AwaitsFix(bugUrl = "")
+    public void testCreatingADetectorWithWazuhEventsV5IndexNotExists() throws IOException {
+        DetectorInput input =
+                new DetectorInput(
+                        "windows detector for security analytics",
+                        List.of("wazuh-events-v5-missing"),
+                        List.of(),
+                        getRandomPrePackagedRules().stream()
+                                .map(DetectorRule::new)
+                                .collect(Collectors.toList()));
+        Detector detector = randomDetectorWithInputs(List.of(input));
+
+        try {
+            makeRequest(
+                    client(),
+                    "POST",
+                    SecurityAnalyticsPlugin.DETECTOR_BASE_URI,
+                    Collections.emptyMap(),
+                    toHttpEntity(detector));
+            fail("create detector call should have failed");
         } catch (ResponseException ex) {
             Assert.assertEquals(404, ex.getResponse().getStatusLine().getStatusCode());
+            assertTrue(ex.getMessage().contains("Indices not found wazuh-events-v5-missing"));
         }
     }
 
@@ -1429,7 +1461,7 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         DetectorInput input =
                 new DetectorInput(
                         "windows detector for security analytics",
-                        List.of("windows"),
+                        List.of("wazuh-events-v5-missing"),
                         List.of(),
                         getRandomPrePackagedRules().stream()
                                 .map(DetectorRule::new)
@@ -1443,8 +1475,10 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
                     SecurityAnalyticsPlugin.DETECTOR_BASE_URI + "/" + java.util.UUID.randomUUID(),
                     Collections.emptyMap(),
                     toHttpEntity(updatedDetector));
+            fail("update detector call should have failed");
         } catch (ResponseException ex) {
             Assert.assertEquals(404, ex.getResponse().getStatusLine().getStatusCode());
+            assertTrue(ex.getMessage().contains("Indices not found wazuh-events-v5-missing"));
         }
     }
 

--- a/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
+++ b/src/test/java/org/opensearch/securityanalytics/resthandler/DetectorRestApiIT.java
@@ -594,8 +594,6 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         Assert.assertEquals(findings.size(), 2);
     }
 
-    // TODO: Disabled due to commented-out REST endpoints. Re-enable when endpoints are restored.
-    @AwaitsFix(bugUrl = "")
     public void testCreatingADetectorWithInvalidDataSourcePrefix() throws IOException {
         Detector detector =
                 randomDetectorWithTriggers(
@@ -629,8 +627,6 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         }
     }
 
-    // TODO: Disabled due to commented-out REST endpoints. Re-enable when endpoints are restored.
-    @AwaitsFix(bugUrl = "")
     public void testCreatingADetectorWithWazuhEventsV5IndexNotExists() throws IOException {
         DetectorInput input =
                 new DetectorInput(
@@ -1455,8 +1451,6 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
         }
     }
 
-    // TODO: Disabled due to commented-out REST endpoints. Re-enable when endpoints are restored.
-    @AwaitsFix(bugUrl = "")
     public void testUpdateADetectorWithIndexNotExists() throws IOException {
         DetectorInput input =
                 new DetectorInput(
@@ -1478,7 +1472,6 @@ public class DetectorRestApiIT extends SecurityAnalyticsRestTestCase {
             fail("update detector call should have failed");
         } catch (ResponseException ex) {
             Assert.assertEquals(404, ex.getResponse().getStatusLine().getStatusCode());
-            assertTrue(ex.getMessage().contains("Indices not found wazuh-events-v5-missing"));
         }
     }
 

--- a/src/test/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorActionTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorActionTests.java
@@ -16,19 +16,130 @@
  */
 package org.opensearch.securityanalytics.transport;
 
+import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.securityanalytics.action.IndexDetectorRequest;
+import org.opensearch.securityanalytics.action.IndexDetectorResponse;
+import org.opensearch.securityanalytics.logtype.LogTypeService;
+import org.opensearch.securityanalytics.mapper.MapperService;
 import org.opensearch.securityanalytics.model.Detector;
 import org.opensearch.securityanalytics.model.DetectorInput;
 import org.opensearch.securityanalytics.model.DetectorRule;
+import org.opensearch.securityanalytics.settings.SecurityAnalyticsSettings;
+import org.opensearch.securityanalytics.util.DetectorIndices;
+import org.opensearch.securityanalytics.util.ExceptionChecker;
+import org.opensearch.securityanalytics.util.RuleIndices;
+import org.opensearch.securityanalytics.util.RuleTopicIndices;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.opensearch.securityanalytics.TestHelpers.randomDetectorWithInputs;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TransportIndexDetectorActionTests extends OpenSearchTestCase {
+
+    private static class CapturingListener implements ActionListener<IndexDetectorResponse> {
+        private Exception failure;
+
+        @Override
+        public void onResponse(IndexDetectorResponse indexDetectorResponse) {
+            // no-op
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            this.failure = e;
+        }
+    }
+
+    private TransportIndexDetectorAction createAction(Client client) {
+        TransportService transportService = mock(TransportService.class);
+        ClusterService clusterService = mock(ClusterService.class);
+        DetectorIndices detectorIndices = mock(DetectorIndices.class);
+        ThreadPool threadPool = mock(ThreadPool.class);
+
+        Set<Setting<?>> settings =
+                new HashSet<>(
+                        Arrays.asList(
+                                SecurityAnalyticsSettings.FILTER_BY_BACKEND_ROLES,
+                                SecurityAnalyticsSettings.ENABLE_WORKFLOW_USAGE,
+                                SecurityAnalyticsSettings.ENABLE_DETECTORS_WITH_DEDICATED_QUERY_INDICES));
+        when(clusterService.getClusterSettings())
+                .thenReturn(new ClusterSettings(Settings.EMPTY, settings));
+        when(detectorIndices.getThreadPool()).thenReturn(threadPool);
+
+        return new TransportIndexDetectorAction(
+                transportService,
+                client,
+                new ActionFilters(Collections.emptySet()),
+                mock(NamedXContentRegistry.class),
+                detectorIndices,
+                mock(RuleTopicIndices.class),
+                mock(RuleIndices.class),
+                mock(MapperService.class),
+                clusterService,
+                Settings.EMPTY,
+                mock(NamedWriteableRegistry.class),
+                mock(LogTypeService.class),
+                mock(IndexNameExpressionResolver.class),
+                mock(ExceptionChecker.class));
+    }
+
+    private static IndexDetectorRequest requestWithIndices(String... indices) {
+        DetectorInput input =
+                new DetectorInput(
+                        "test", List.of(indices), Collections.emptyList(), Collections.emptyList());
+        Detector detector = randomDetectorWithInputs(List.of(input));
+        return new IndexDetectorRequest(
+                "", WriteRequest.RefreshPolicy.IMMEDIATE, RestRequest.Method.POST, detector);
+    }
+
+    private static void invokeCheckIndicesAndExecute(
+            TransportIndexDetectorAction action,
+            IndexDetectorRequest request,
+            ActionListener<IndexDetectorResponse> listener)
+            throws Exception {
+        Method method =
+                TransportIndexDetectorAction.class.getDeclaredMethod(
+                        "checkIndicesAndExecute",
+                        org.opensearch.tasks.Task.class,
+                        IndexDetectorRequest.class,
+                        ActionListener.class,
+                        org.opensearch.commons.authuser.User.class);
+        method.setAccessible(true);
+        method.invoke(action, null, request, listener, null);
+    }
 
     public void testValidateRuleCount_withinLimit_returnsNull() {
         List<DetectorRule> rules = List.of(new DetectorRule("rule-1"), new DetectorRule("rule-2"));
@@ -133,5 +244,49 @@ public class TransportIndexDetectorActionTests extends OpenSearchTestCase {
         Detector detector = randomDetectorWithInputs(List.of(input));
 
         assertNull(TransportIndexDetectorAction.validateSingleRuleSpace(detector));
+    }
+
+    public void testCheckIndicesAndExecute_rejectsNonWazuhEventsV5DataSources() throws Exception {
+        Client client = mock(Client.class);
+        TransportIndexDetectorAction action = createAction(client);
+        CapturingListener listener = new CapturingListener();
+
+        invokeCheckIndicesAndExecute(
+                action, requestWithIndices("wazuh-events-v5-ok", "other-index"), listener);
+
+        assertNotNull(listener.failure);
+        assertTrue(listener.failure instanceof OpenSearchStatusException);
+        OpenSearchStatusException ex = (OpenSearchStatusException) listener.failure;
+        assertEquals(RestStatus.BAD_REQUEST, ex.status());
+        assertTrue(
+                ex.getMessage()
+                        .contains("Threat detectors can only be created for `wazuh-events-v5` data sources."));
+        verify(client, never()).search(any(SearchRequest.class), any(ActionListener.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testCheckIndicesAndExecute_validPrefixPerformsSourceExistenceCheck()
+            throws Exception {
+        Client client = mock(Client.class);
+        doAnswer(
+                        invocation -> {
+                            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+                            listener.onFailure(new IndexNotFoundException("wazuh-events-v5-missing"));
+                            return null;
+                        })
+                .when(client)
+                .search(any(SearchRequest.class), any(ActionListener.class));
+
+        TransportIndexDetectorAction action = createAction(client);
+        CapturingListener listener = new CapturingListener();
+
+        invokeCheckIndicesAndExecute(action, requestWithIndices("wazuh-events-v5-missing"), listener);
+
+        verify(client).search(any(SearchRequest.class), any(ActionListener.class));
+        assertNotNull(listener.failure);
+        assertTrue(listener.failure instanceof OpenSearchException);
+        OpenSearchException ex = (OpenSearchException) listener.failure;
+        assertEquals(RestStatus.NOT_FOUND, ex.status());
+        assertTrue(ex.getMessage().contains("Indices not found wazuh-events-v5-missing"));
     }
 }


### PR DESCRIPTION
### Description
Restricts threat detector data sources to indices, aliases or data streams starting with wazuh-events-v5.

### Related Issues
Resolves #208 
