### PR TITLE
Modify MITRE processing to include new fields

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/enrichment/TemplateInterpolator.java
+++ b/src/main/java/org/opensearch/securityanalytics/enrichment/TemplateInterpolator.java
@@ -176,6 +176,38 @@ public final class TemplateInterpolator {
         return result;
     }
 
+    // Nested MITRE map interpolation
+
+    /**
+     * Interpolates a nested MITRE map where each top-level key ({@code tactic}, {@code technique},
+     * {@code subtechnique}) maps to an object containing {@code id} and {@code name} arrays. Applies
+     * list interpolation to each inner array. Categories whose inner map becomes empty after
+     * interpolation are removed.
+     *
+     * @param map the MITRE map to interpolate, may be {@code null}
+     * @param source the event {@code _source} map
+     * @return a new map with interpolated values
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> interpolateNestedMitreMap(
+            Map<String, ?> map, Map<String, Object> source) {
+        if (map == null || map.isEmpty()) {
+            return map == null ? null : Map.of();
+        }
+        LinkedHashMap<String, Object> result = new LinkedHashMap<>();
+        for (Map.Entry<String, ?> entry : map.entrySet()) {
+            Object rawValue = entry.getValue();
+            if (rawValue instanceof Map) {
+                Map<String, List<String>> interpolated =
+                        interpolateMapOfLists((Map<String, ?>) rawValue, source);
+                if (interpolated != null && !interpolated.isEmpty()) {
+                    result.put(entry.getKey(), interpolated);
+                }
+            }
+        }
+        return result;
+    }
+
     // Path resolution
 
     /**

--- a/src/main/java/org/opensearch/securityanalytics/enrichment/WazuhEnrichedFindingService.java
+++ b/src/main/java/org/opensearch/securityanalytics/enrichment/WazuhEnrichedFindingService.java
@@ -467,8 +467,8 @@ public class WazuhEnrichedFindingService implements Closeable {
 
         Object mitre = nested.get("mitre");
         if (mitre instanceof Map) {
-            Map<String, List<String>> interpolated =
-                    TemplateInterpolator.interpolateMapOfLists((Map<String, ?>) mitre, eventSource);
+            Map<String, Object> interpolated =
+                    TemplateInterpolator.interpolateNestedMitreMap((Map<String, ?>) mitre, eventSource);
             if (interpolated != null && !interpolated.isEmpty()) {
                 rule.put("mitre", interpolated);
             }

--- a/src/main/java/org/opensearch/securityanalytics/rules/objects/SigmaMitre.java
+++ b/src/main/java/org/opensearch/securityanalytics/rules/objects/SigmaMitre.java
@@ -27,30 +27,61 @@ import java.util.Map;
 /**
  * MITRE ATT&amp;CK block for Wazuh Sigma rules.
  *
- * <p>Parses a top-level {@code mitre} structure containing flat arrays for {@code tactic}, {@code
- * technique}, and {@code subtechnique}.
+ * <p>Parses a top-level {@code mitre} structure where each category ({@code tactic}, {@code
+ * technique}, {@code subtechnique}) is an object containing {@code id} and {@code name} arrays.
+ *
+ * <pre>{@code
+ * mitre:
+ *   tactic:
+ *     id:
+ *       - TA0003
+ *     name:
+ *       - Persistence
+ *   technique:
+ *     id:
+ *       - T1098
+ *     name:
+ *       - Account Manipulation
+ * }</pre>
  */
 public class SigmaMitre {
 
-    private final List<String> tactic;
-    private final List<String> technique;
-    private final List<String> subtechnique;
+    private final List<String> tacticId;
+    private final List<String> tacticName;
+    private final List<String> techniqueId;
+    private final List<String> techniqueName;
+    private final List<String> subtechniqueId;
+    private final List<String> subtechniqueName;
 
     /**
-     * Constructs a new SigmaMitre instance with specified tactics, techniques, and sub-techniques.
+     * Constructs a new SigmaMitre instance.
      *
-     * @param tactic a list of MITRE tactics; if null, an empty list is used
-     * @param technique a list of MITRE techniques; if null, an empty list is used
-     * @param subtechnique a list of MITRE sub-techniques; if null, an empty list is used
+     * @param tacticId list of MITRE tactic IDs; if null, an empty list is used
+     * @param tacticName list of MITRE tactic names; if null, an empty list is used
+     * @param techniqueId list of MITRE technique IDs; if null, an empty list is used
+     * @param techniqueName list of MITRE technique names; if null, an empty list is used
+     * @param subtechniqueId list of MITRE sub-technique IDs; if null, an empty list is used
+     * @param subtechniqueName list of MITRE sub-technique names; if null, an empty list is used
      */
-    public SigmaMitre(List<String> tactic, List<String> technique, List<String> subtechnique) {
-        this.tactic = tactic != null ? tactic : Collections.emptyList();
-        this.technique = technique != null ? technique : Collections.emptyList();
-        this.subtechnique = subtechnique != null ? subtechnique : Collections.emptyList();
+    public SigmaMitre(
+            List<String> tacticId,
+            List<String> tacticName,
+            List<String> techniqueId,
+            List<String> techniqueName,
+            List<String> subtechniqueId,
+            List<String> subtechniqueName) {
+        this.tacticId = tacticId != null ? tacticId : Collections.emptyList();
+        this.tacticName = tacticName != null ? tacticName : Collections.emptyList();
+        this.techniqueId = techniqueId != null ? techniqueId : Collections.emptyList();
+        this.techniqueName = techniqueName != null ? techniqueName : Collections.emptyList();
+        this.subtechniqueId = subtechniqueId != null ? subtechniqueId : Collections.emptyList();
+        this.subtechniqueName = subtechniqueName != null ? subtechniqueName : Collections.emptyList();
     }
 
     /**
-     * Creates a {@link SigmaMitre} instance from a dictionary/map representation.
+     * Creates a {@link SigmaMitre} instance from a dictionary/map representation. Each category
+     * ({@code tactic}, {@code technique}, {@code subtechnique}) is expected to be an object with
+     * {@code id} and {@code name} array fields.
      *
      * @param map the map containing 'tactic', 'technique', and 'subtechnique' keys
      * @return a new SigmaMitre instance, or null if the input map is null
@@ -62,34 +93,84 @@ public class SigmaMitre {
             return null;
         }
 
-        List<String> tactic = toStringList(map.get("tactic"));
-        List<String> technique = toStringList(map.get("technique"));
-        List<String> subtechnique = toStringList(map.get("subtechnique"));
+        List<String> tacticId = Collections.emptyList();
+        List<String> tacticName = Collections.emptyList();
+        List<String> techniqueId = Collections.emptyList();
+        List<String> techniqueName = Collections.emptyList();
+        List<String> subtechniqueId = Collections.emptyList();
+        List<String> subtechniqueName = Collections.emptyList();
 
-        return new SigmaMitre(tactic, technique, subtechnique);
+        Object tacticObj = map.get("tactic");
+        if (tacticObj instanceof Map) {
+            Map<String, Object> tacticMap = (Map<String, Object>) tacticObj;
+            tacticId = toStringList(tacticMap.get("id"));
+            tacticName = toStringList(tacticMap.get("name"));
+        }
+
+        Object techniqueObj = map.get("technique");
+        if (techniqueObj instanceof Map) {
+            Map<String, Object> techniqueMap = (Map<String, Object>) techniqueObj;
+            techniqueId = toStringList(techniqueMap.get("id"));
+            techniqueName = toStringList(techniqueMap.get("name"));
+        }
+
+        Object subtechniqueObj = map.get("subtechnique");
+        if (subtechniqueObj instanceof Map) {
+            Map<String, Object> subtechniqueMap = (Map<String, Object>) subtechniqueObj;
+            subtechniqueId = toStringList(subtechniqueMap.get("id"));
+            subtechniqueName = toStringList(subtechniqueMap.get("name"));
+        }
+
+        return new SigmaMitre(
+                tacticId, tacticName, techniqueId, techniqueName, subtechniqueId, subtechniqueName);
     }
 
     /**
-     * Flattens the MITRE data into a format suitable for WCS indexing. Per the WCS spec,
-     * sub-technique IDs are merged into the technique array.
+     * Builds the MITRE data into the nested format for WCS indexing. Per the WCS spec, sub-technique
+     * IDs and names are merged into the technique arrays.
      *
-     * @return a map representing the flattened MITRE ATT&amp;CK data
+     * @return a map representing the nested MITRE ATT&amp;CK data
      */
     public Map<String, Object> toMitreMap() {
         Map<String, Object> mitreMap = new HashMap<>();
-        if (!this.tactic.isEmpty()) {
-            mitreMap.put("tactic", new ArrayList<>(this.tactic));
+
+        if (!this.tacticId.isEmpty() || !this.tacticName.isEmpty()) {
+            Map<String, Object> tacticMap = new HashMap<>();
+            if (!this.tacticId.isEmpty()) {
+                tacticMap.put("id", new ArrayList<>(this.tacticId));
+            }
+            if (!this.tacticName.isEmpty()) {
+                tacticMap.put("name", new ArrayList<>(this.tacticName));
+            }
+            mitreMap.put("tactic", tacticMap);
         }
 
-        List<String> allTechniques = new ArrayList<>(this.technique);
-        allTechniques.addAll(this.subtechnique);
-        if (!allTechniques.isEmpty()) {
-            mitreMap.put("technique", allTechniques);
+        List<String> allTechniqueIds = new ArrayList<>(this.techniqueId);
+        allTechniqueIds.addAll(this.subtechniqueId);
+        List<String> allTechniqueNames = new ArrayList<>(this.techniqueName);
+        allTechniqueNames.addAll(this.subtechniqueName);
+        if (!allTechniqueIds.isEmpty() || !allTechniqueNames.isEmpty()) {
+            Map<String, Object> techniqueMap = new HashMap<>();
+            if (!allTechniqueIds.isEmpty()) {
+                techniqueMap.put("id", allTechniqueIds);
+            }
+            if (!allTechniqueNames.isEmpty()) {
+                techniqueMap.put("name", allTechniqueNames);
+            }
+            mitreMap.put("technique", techniqueMap);
         }
 
-        if (!this.subtechnique.isEmpty()) {
-            mitreMap.put("subtechnique", new ArrayList<>(this.subtechnique));
+        if (!this.subtechniqueId.isEmpty() || !this.subtechniqueName.isEmpty()) {
+            Map<String, Object> subtechniqueMap = new HashMap<>();
+            if (!this.subtechniqueId.isEmpty()) {
+                subtechniqueMap.put("id", new ArrayList<>(this.subtechniqueId));
+            }
+            if (!this.subtechniqueName.isEmpty()) {
+                subtechniqueMap.put("name", new ArrayList<>(this.subtechniqueName));
+            }
+            mitreMap.put("subtechnique", subtechniqueMap);
         }
+
         return mitreMap;
     }
 
@@ -116,23 +197,44 @@ public class SigmaMitre {
     }
 
     /**
-     * @return the list of tactics
+     * @return the list of tactic IDs
      */
-    public List<String> getTactic() {
-        return this.tactic;
+    public List<String> getTacticId() {
+        return this.tacticId;
     }
 
     /**
-     * @return the list of techniques
+     * @return the list of tactic names
      */
-    public List<String> getTechnique() {
-        return this.technique;
+    public List<String> getTacticName() {
+        return this.tacticName;
     }
 
     /**
-     * @return the list of sub-techniques
+     * @return the list of technique IDs
      */
-    public List<String> getSubtechnique() {
-        return this.subtechnique;
+    public List<String> getTechniqueId() {
+        return this.techniqueId;
+    }
+
+    /**
+     * @return the list of technique names
+     */
+    public List<String> getTechniqueName() {
+        return this.techniqueName;
+    }
+
+    /**
+     * @return the list of sub-technique IDs
+     */
+    public List<String> getSubtechniqueId() {
+        return this.subtechniqueId;
+    }
+
+    /**
+     * @return the list of sub-technique names
+     */
+    public List<String> getSubtechniqueName() {
+        return this.subtechniqueName;
     }
 }

--- a/src/test/java/org/opensearch/securityanalytics/rules/objects/WazuhExtensionsTests.java
+++ b/src/test/java/org/opensearch/securityanalytics/rules/objects/WazuhExtensionsTests.java
@@ -87,12 +87,22 @@ public class WazuhExtensionsTests extends OpenSearchTestCase {
                     + "        - wazuh-4.8\n"
                     + "mitre:\n"
                     + "    tactic:\n"
-                    + "        - TA0005\n"
-                    + "        - TA0043\n"
+                    + "        id:\n"
+                    + "            - TA0005\n"
+                    + "            - TA0043\n"
+                    + "        name:\n"
+                    + "            - Defense Evasion\n"
+                    + "            - Reconnaissance\n"
                     + "    technique:\n"
-                    + "        - T1222\n"
+                    + "        id:\n"
+                    + "            - T1222\n"
+                    + "        name:\n"
+                    + "            - File and Directory Permissions Modification\n"
                     + "    subtechnique:\n"
-                    + "        - T1222.002\n"
+                    + "        id:\n"
+                    + "            - T1222.002\n"
+                    + "        name:\n"
+                    + "            - 'File and Directory Permissions Modification: Linux and Mac File and Directory Permissions Modification'\n"
                     + "compliance:\n"
                     + "    pci_dss:\n"
                     + "        - '11.5'\n"
@@ -123,19 +133,32 @@ public class WazuhExtensionsTests extends OpenSearchTestCase {
         // Mitre (updated from Threat)
         SigmaMitre mitre = rule.getMitre();
         Assert.assertNotNull(mitre);
-        Assert.assertEquals(2, mitre.getTactic().size());
-        Assert.assertEquals("TA0005", mitre.getTactic().get(0));
-        Assert.assertEquals("TA0043", mitre.getTactic().get(1));
-        Assert.assertEquals(1, mitre.getTechnique().size());
-        Assert.assertEquals("T1222", mitre.getTechnique().get(0));
-        Assert.assertEquals(1, mitre.getSubtechnique().size());
-        Assert.assertEquals("T1222.002", mitre.getSubtechnique().get(0));
+        Assert.assertEquals(2, mitre.getTacticId().size());
+        Assert.assertEquals("TA0005", mitre.getTacticId().get(0));
+        Assert.assertEquals("TA0043", mitre.getTacticId().get(1));
+        Assert.assertEquals(2, mitre.getTacticName().size());
+        Assert.assertEquals("Defense Evasion", mitre.getTacticName().get(0));
+        Assert.assertEquals("Reconnaissance", mitre.getTacticName().get(1));
+        Assert.assertEquals(1, mitre.getTechniqueId().size());
+        Assert.assertEquals("T1222", mitre.getTechniqueId().get(0));
+        Assert.assertEquals(1, mitre.getTechniqueName().size());
+        Assert.assertEquals(
+                "File and Directory Permissions Modification", mitre.getTechniqueName().get(0));
+        Assert.assertEquals(1, mitre.getSubtechniqueId().size());
+        Assert.assertEquals("T1222.002", mitre.getSubtechniqueId().get(0));
 
-        // Mitre -> WCS map for indexing
+        // Mitre -> WCS map for indexing (nested structure)
         Map<String, Object> mitreMap = mitre.toMitreMap();
-        Assert.assertEquals(List.of("TA0005", "TA0043"), mitreMap.get("tactic"));
-        Assert.assertEquals(List.of("T1222", "T1222.002"), mitreMap.get("technique"));
-        Assert.assertEquals(List.of("T1222.002"), mitreMap.get("subtechnique"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> tacticMap = (Map<String, Object>) mitreMap.get("tactic");
+        Assert.assertEquals(List.of("TA0005", "TA0043"), tacticMap.get("id"));
+        Assert.assertEquals(List.of("Defense Evasion", "Reconnaissance"), tacticMap.get("name"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> techniqueMap = (Map<String, Object>) mitreMap.get("technique");
+        Assert.assertEquals(List.of("T1222", "T1222.002"), techniqueMap.get("id"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> subtechniqueMap = (Map<String, Object>) mitreMap.get("subtechnique");
+        Assert.assertEquals(List.of("T1222.002"), subtechniqueMap.get("id"));
 
         // Compliance
         SigmaCompliance compliance = rule.getCompliance();
@@ -339,9 +362,15 @@ public class WazuhExtensionsTests extends OpenSearchTestCase {
                         + "    condition: selection\n"
                         + "mitre:\n"
                         + "    tactic:\n"
-                        + "        - TA0002\n"
+                        + "        id:\n"
+                        + "            - TA0002\n"
+                        + "        name:\n"
+                        + "            - Execution\n"
                         + "    technique:\n"
-                        + "        - T1059\n";
+                        + "        id:\n"
+                        + "            - T1059\n"
+                        + "        name:\n"
+                        + "            - Command and Scripting Interpreter\n";
 
         SigmaRule rule = SigmaRule.fromYaml(yaml, true);
         Assert.assertTrue(rule.getErrors().getErrors().isEmpty());
@@ -349,8 +378,14 @@ public class WazuhExtensionsTests extends OpenSearchTestCase {
         SigmaMitre mitre = rule.getMitre();
         Assert.assertNotNull(mitre);
         Map<String, Object> mitreMap = mitre.toMitreMap();
-        Assert.assertEquals(List.of("TA0002"), mitreMap.get("tactic"));
-        Assert.assertEquals(List.of("T1059"), mitreMap.get("technique"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> tacticMap = (Map<String, Object>) mitreMap.get("tactic");
+        Assert.assertEquals(List.of("TA0002"), tacticMap.get("id"));
+        Assert.assertEquals(List.of("Execution"), tacticMap.get("name"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> techniqueMap = (Map<String, Object>) mitreMap.get("technique");
+        Assert.assertEquals(List.of("T1059"), techniqueMap.get("id"));
+        Assert.assertEquals(List.of("Command and Scripting Interpreter"), techniqueMap.get("name"));
         Assert.assertFalse(mitreMap.containsKey("subtechnique"));
     }
 }


### PR DESCRIPTION
### Description
This PR modifies the Sigma syntax to include new MITRE fields that include:
- `mitre.tactic.id`
- `mitre.tactic.name`
- `mitre.technique.id`
- `mitre.technique.name`
- `mitre.subtechnique.id`
- `mitre.subtechnique.name`

Also enables the interpolation of those fields

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-plugins/issues/1208

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
