### PR TITLE
Change rule field from nested to object

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/model/Rule.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/Rule.java
@@ -72,6 +72,7 @@ public class Rule implements Writeable, ToXContentObject {
     public static final String MITRE = "mitre";
     public static final String COMPLIANCE = "compliance";
     public static final String METADATA = "metadata";
+    public static final String DOCUMENT = "document";
 
     public static final String PRE_PACKAGED_RULES_INDEX = ".opensearch-sap-pre-packaged-rules-config";
     public static final String CUSTOM_RULES_INDEX = ".opensearch-sap-custom-rules-config";
@@ -375,7 +376,7 @@ public class Rule implements Writeable, ToXContentObject {
         }
 
         if (this.documentId != null) {
-            builder.field(DOCUMENT_ID_FIELD, this.documentId);
+            builder.startObject(DOCUMENT).field("id", this.documentId).endObject();
         }
         if (this.space != null) {
             builder.field(SPACE_FIELD, this.space);
@@ -507,8 +508,16 @@ public class Rule implements Writeable, ToXContentObject {
                 case METADATA:
                     metadata = RuleMetadata.parse(xcp);
                     break;
-                case DOCUMENT_ID_FIELD:
-                    documentId = xcp.textOrNull();
+                case DOCUMENT:
+                    XContentParserUtils.ensureExpectedToken(
+                            XContentParser.Token.START_OBJECT, xcp.currentToken(), xcp);
+                    while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+                        if (xcp.currentToken() == XContentParser.Token.FIELD_NAME
+                                && "id".equals(xcp.currentName())) {
+                            xcp.nextToken();
+                            documentId = xcp.textOrNull();
+                        }
+                    }
                     break;
                 case SPACE_FIELD:
                     space = xcp.textOrNull();

--- a/src/main/java/org/opensearch/securityanalytics/model/Rule.java
+++ b/src/main/java/org/opensearch/securityanalytics/model/Rule.java
@@ -73,6 +73,7 @@ public class Rule implements Writeable, ToXContentObject {
     public static final String COMPLIANCE = "compliance";
     public static final String METADATA = "metadata";
     public static final String DOCUMENT = "document";
+    public static final String ID_FIELD = "id";
 
     public static final String PRE_PACKAGED_RULES_INDEX = ".opensearch-sap-pre-packaged-rules-config";
     public static final String CUSTOM_RULES_INDEX = ".opensearch-sap-custom-rules-config";
@@ -376,7 +377,7 @@ public class Rule implements Writeable, ToXContentObject {
         }
 
         if (this.documentId != null) {
-            builder.startObject(DOCUMENT).field("id", this.documentId).endObject();
+            builder.startObject(DOCUMENT).field(ID_FIELD, this.documentId).endObject();
         }
         if (this.space != null) {
             builder.field(SPACE_FIELD, this.space);

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexDetectorAction.java
@@ -19,7 +19,6 @@ package org.opensearch.securityanalytics.transport;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.search.join.ScoreMode;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.ActionRunnable;
 import org.opensearch.action.StepListener;
@@ -2160,12 +2159,9 @@ public class TransportIndexDetectorAction
                             .collect(Collectors.toList());
 
             QueryBuilder queryBuilder =
-                    QueryBuilders.nestedQuery(
-                            "rule",
-                            QueryBuilders.boolQuery()
-                                    .must(QueryBuilders.matchQuery("rule.category", ruleTopic))
-                                    .must(QueryBuilders.termsQuery("_id", ruleIds.toArray(new String[] {}))),
-                            ScoreMode.Avg);
+                    QueryBuilders.boolQuery()
+                            .must(QueryBuilders.matchQuery("rule.category", ruleTopic))
+                            .must(QueryBuilders.termsQuery("_id", ruleIds.toArray(new String[] {})));
 
             SearchRequest searchRequest =
                     new SearchRequest(Rule.PRE_PACKAGED_RULES_INDEX)
@@ -2327,14 +2323,10 @@ public class TransportIndexDetectorAction
             // Querying by _id would fail because the IDs received here are document.id values,
             // not the internal _id of the custom rules index.
             QueryBuilder queryBuilder =
-                    QueryBuilders.nestedQuery(
-                            "rule",
-                            QueryBuilders.boolQuery()
-                                    .filter(
-                                            QueryBuilders.termsQuery(
-                                                    "rule.document.id", ruleIds.toArray(new String[] {})))
-                                    .filter(QueryBuilders.termQuery("rule.space", "custom")),
-                            ScoreMode.None);
+                    QueryBuilders.boolQuery()
+                            .filter(
+                                    QueryBuilders.termsQuery("rule.document.id", ruleIds.toArray(new String[] {})))
+                            .filter(QueryBuilders.termQuery("rule.space", "custom"));
             SearchRequest searchRequest =
                     new SearchRequest(Rule.CUSTOM_RULES_INDEX)
                             .source(

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexRuleAction.java
@@ -465,12 +465,9 @@ public class TransportIndexRuleAction
                 String documentId,
                 String space) {
             QueryBuilder query =
-                    QueryBuilders.nestedQuery(
-                            "rule",
-                            QueryBuilders.boolQuery()
-                                    .filter(QueryBuilders.termQuery("rule.document.id", documentId))
-                                    .filter(QueryBuilders.termQuery("rule.space", space)),
-                            ScoreMode.None);
+                    QueryBuilders.boolQuery()
+                            .filter(QueryBuilders.termQuery("rule.document.id", documentId))
+                            .filter(QueryBuilders.termQuery("rule.space", space));
             SearchRequest searchRequest =
                     new SearchRequest(Rule.CUSTOM_RULES_INDEX)
                             .source(new SearchSourceBuilder().query(query).size(1))

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportIndexRuleAction.java
@@ -466,8 +466,8 @@ public class TransportIndexRuleAction
                 String space) {
             QueryBuilder query =
                     QueryBuilders.boolQuery()
-                            .filter(QueryBuilders.termQuery("rule.document.id", documentId))
-                            .filter(QueryBuilders.termQuery("rule.space", space));
+                            .filter(QueryBuilders.termQuery(Rule.RULE + "." + Rule.DOCUMENT_ID_FIELD, documentId))
+                            .filter(QueryBuilders.termQuery(Rule.RULE + "." + Rule.SPACE_FIELD, space));
             SearchRequest searchRequest =
                     new SearchRequest(Rule.CUSTOM_RULES_INDEX)
                             .source(new SearchSourceBuilder().query(query).size(1))

--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportDeleteCustomRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportDeleteCustomRuleAction.java
@@ -18,7 +18,6 @@ package org.opensearch.securityanalytics.transport;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.search.join.ScoreMode;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
@@ -72,20 +71,14 @@ public class WTransportDeleteCustomRuleAction
 
     private void resolveAndDelete(
             Task task, WDeleteCustomRuleRequest request, ActionListener<WDeleteRuleResponse> listener) {
-        // Rules are stored in a nested "rule" object; query nested fields.
         SearchSourceBuilder searchSource =
                 new SearchSourceBuilder()
                         .query(
-                                QueryBuilders.nestedQuery(
-                                        "rule",
-                                        QueryBuilders.boolQuery()
-                                                .must(
-                                                        QueryBuilders.termQuery(
-                                                                "rule." + Rule.DOCUMENT_ID_FIELD, request.getDocumentId()))
-                                                .must(
-                                                        QueryBuilders.termQuery(
-                                                                "rule." + Rule.SPACE_FIELD, request.getSpace())),
-                                        ScoreMode.None))
+                                QueryBuilders.boolQuery()
+                                        .must(
+                                                QueryBuilders.termQuery(
+                                                        "rule." + Rule.DOCUMENT_ID_FIELD, request.getDocumentId()))
+                                        .must(QueryBuilders.termQuery("rule." + Rule.SPACE_FIELD, request.getSpace())))
                         .size(1);
         SearchRequest searchRequest = new SearchRequest(Rule.CUSTOM_RULES_INDEX).source(searchSource);
 

--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportDeleteRuleAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportDeleteRuleAction.java
@@ -18,7 +18,6 @@ package org.opensearch.securityanalytics.transport;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.search.join.ScoreMode;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
@@ -79,16 +78,11 @@ public class WTransportDeleteRuleAction
         SearchSourceBuilder searchSource =
                 new SearchSourceBuilder()
                         .query(
-                                QueryBuilders.nestedQuery(
-                                        "rule",
-                                        QueryBuilders.boolQuery()
-                                                .must(
-                                                        QueryBuilders.termQuery(
-                                                                "rule." + Rule.DOCUMENT_ID_FIELD, request.getDocumentId()))
-                                                .must(
-                                                        QueryBuilders.termQuery(
-                                                                "rule." + Rule.SPACE_FIELD, request.getSpace())),
-                                        ScoreMode.None))
+                                QueryBuilders.boolQuery()
+                                        .must(
+                                                QueryBuilders.termQuery(
+                                                        "rule." + Rule.DOCUMENT_ID_FIELD, request.getDocumentId()))
+                                        .must(QueryBuilders.termQuery("rule." + Rule.SPACE_FIELD, request.getSpace())))
                         .size(1);
         SearchRequest searchRequest =
                 new SearchRequest(Rule.PRE_PACKAGED_RULES_INDEX).source(searchSource);

--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportDeleteSpaceResourcesAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportDeleteSpaceResourcesAction.java
@@ -259,11 +259,7 @@ public class WTransportDeleteSpaceResourcesAction
     private void findRuleIds(String ruleIndex, String space, ActionListener<List<String>> listener) {
         SearchSourceBuilder source =
                 new SearchSourceBuilder()
-                        .query(
-                                QueryBuilders.nestedQuery(
-                                        RULE_NESTED_PATH,
-                                        QueryBuilders.termQuery(RULE_NESTED_PATH + "." + Rule.SPACE_FIELD, space),
-                                        ScoreMode.None))
+                        .query(QueryBuilders.termQuery(RULE_NESTED_PATH + "." + Rule.SPACE_FIELD, space))
                         .size(MAX_RESULTS)
                         .fetchSource(false);
 

--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorAction.java
@@ -18,7 +18,6 @@ package org.opensearch.securityanalytics.transport;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.search.join.ScoreMode;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
@@ -199,9 +198,7 @@ public class WTransportIndexDetectorAction
 
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
 
-        sourceBuilder.query(
-                QueryBuilders.nestedQuery(
-                        "rule", QueryBuilders.termsQuery("rule.document.id", expectedRuleIds), ScoreMode.None));
+        sourceBuilder.query(QueryBuilders.termsQuery("rule.document.id", expectedRuleIds));
 
         sourceBuilder.size(Math.min(expectedRuleIds.size(), 10000));
         searchRequest.source(sourceBuilder);
@@ -222,7 +219,10 @@ public class WTransportIndexDetectorAction
                             String space = null;
 
                             if (ruleMap != null) {
-                                docId = (String) ruleMap.get("document.id");
+                                Object docObj = ruleMap.get("document");
+                                if (docObj instanceof Map) {
+                                    docId = (String) ((Map<?, ?>) docObj).get("id");
+                                }
                                 space = (String) ruleMap.get("space");
                             }
 

--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexDetectorAction.java
@@ -198,7 +198,8 @@ public class WTransportIndexDetectorAction
 
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
 
-        sourceBuilder.query(QueryBuilders.termsQuery("rule.document.id", expectedRuleIds));
+        sourceBuilder.query(
+                QueryBuilders.termsQuery(Rule.RULE + "." + Rule.DOCUMENT_ID_FIELD, expectedRuleIds));
 
         sourceBuilder.size(Math.min(expectedRuleIds.size(), 10000));
         searchRequest.source(sourceBuilder);

--- a/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
+++ b/src/main/java/org/opensearch/securityanalytics/util/RuleIndices.java
@@ -18,7 +18,6 @@ package org.opensearch.securityanalytics.util;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.search.join.ScoreMode;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
@@ -300,10 +299,7 @@ public class RuleIndices {
 
     public void searchRules(String logTypeName, ActionListener<SearchResponse> listener) {
         QueryBuilder queryBuilder =
-                QueryBuilders.nestedQuery(
-                        "rule",
-                        QueryBuilders.boolQuery().must(QueryBuilders.matchQuery("rule.category", logTypeName)),
-                        ScoreMode.Avg);
+                QueryBuilders.boolQuery().must(QueryBuilders.matchQuery("rule.category", logTypeName));
 
         SearchRequest searchRequest =
                 new SearchRequest(Rule.CUSTOM_RULES_INDEX)

--- a/src/main/resources/mappings/rules.json
+++ b/src/main/resources/mappings/rules.json
@@ -4,7 +4,7 @@
   },
   "properties": {
     "rule": {
-      "type": "nested",
+      "type": "object",
       "dynamic": "false",
       "properties": {
         "title": {
@@ -118,8 +118,12 @@
             }
           }
         },
-        "document.id": {
-          "type": "keyword"
+        "document": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            }
+          }
         },
         "space": {
           "type": "keyword"


### PR DESCRIPTION
### Description
This PR changes the structure of the rules indices so they use and object structure instead of a nested one, now queries can be performed normally and all the functionalities still work

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-plugins/issues/1214
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
