### PR TITLE
Remove ANTLR version mismatch warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ configurations {
 dependencies {
     javaRestTestImplementation project.sourceSets.main.runtimeClasspath
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: "${versions.commonslang}"
-    compileOnly "org.antlr:antlr4-runtime:4.10.1"
+    compileOnly "org.antlr:antlr4-runtime:4.13.1"
     compileOnly "com.cronutils:cron-utils:9.1.7"
     compileOnly "com.wazuh:wazuh-indexer-common-utils:${common_utils_version}@jar"
     compileOnly "org.opensearch.client:opensearch-rest-client:${opensearch_version}"

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionBaseListener.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionBaseListener.java
@@ -1,4 +1,19 @@
-// Generated from java-escape by ANTLR 4.11.1
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.opensearch.securityanalytics.rules.condition;
 
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -6,107 +21,136 @@ import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
 /**
- * This class provides an empty implementation of {@link ConditionListener},
- * which can be extended to create a listener which only needs to handle a subset
- * of the available methods.
+ * This class provides an empty implementation of {@link ConditionListener}, which can be extended
+ * to create a listener which only needs to handle a subset of the available methods.
  */
 @SuppressWarnings("CheckReturnValue")
 public class ConditionBaseListener implements ConditionListener {
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation does nothing.</p>
+     * <p>The default implementation does nothing.
      */
-    @Override public void enterStart(ConditionParser.StartContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void exitStart(ConditionParser.StartContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void enterOrExpression(ConditionParser.OrExpressionContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void exitOrExpression(ConditionParser.OrExpressionContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void enterIdentOrSelectExpression(ConditionParser.IdentOrSelectExpressionContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void exitIdentOrSelectExpression(ConditionParser.IdentOrSelectExpressionContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void enterAndExpression(ConditionParser.AndExpressionContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void exitAndExpression(ConditionParser.AndExpressionContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void enterNotExpression(ConditionParser.NotExpressionContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void exitNotExpression(ConditionParser.NotExpressionContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void enterParenExpression(ConditionParser.ParenExpressionContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void exitParenExpression(ConditionParser.ParenExpressionContext ctx) { }
+    @Override
+    public void enterStart(ConditionParser.StartContext ctx) {}
 
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation does nothing.</p>
+     * <p>The default implementation does nothing.
      */
-    @Override public void enterEveryRule(ParserRuleContext ctx) { }
+    @Override
+    public void exitStart(ConditionParser.StartContext ctx) {}
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation does nothing.</p>
+     * <p>The default implementation does nothing.
      */
-    @Override public void exitEveryRule(ParserRuleContext ctx) { }
+    @Override
+    public void enterOrExpression(ConditionParser.OrExpressionContext ctx) {}
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation does nothing.</p>
+     * <p>The default implementation does nothing.
      */
-    @Override public void visitTerminal(TerminalNode node) { }
+    @Override
+    public void exitOrExpression(ConditionParser.OrExpressionContext ctx) {}
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation does nothing.</p>
+     * <p>The default implementation does nothing.
      */
-    @Override public void visitErrorNode(ErrorNode node) { }
+    @Override
+    public void enterIdentOrSelectExpression(ConditionParser.IdentOrSelectExpressionContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void exitIdentOrSelectExpression(ConditionParser.IdentOrSelectExpressionContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void enterAndExpression(ConditionParser.AndExpressionContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void exitAndExpression(ConditionParser.AndExpressionContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void enterNotExpression(ConditionParser.NotExpressionContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void exitNotExpression(ConditionParser.NotExpressionContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void enterParenExpression(ConditionParser.ParenExpressionContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void exitParenExpression(ConditionParser.ParenExpressionContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void enterEveryRule(ParserRuleContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void exitEveryRule(ParserRuleContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void visitTerminal(TerminalNode node) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void visitErrorNode(ErrorNode node) {}
 }

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionBaseVisitor.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionBaseVisitor.java
@@ -1,57 +1,96 @@
-// Generated from java-escape by ANTLR 4.11.1
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.opensearch.securityanalytics.rules.condition;
+
 import org.antlr.v4.runtime.tree.AbstractParseTreeVisitor;
 
 /**
- * This class provides an empty implementation of {@link ConditionVisitor},
- * which can be extended to create a visitor which only needs to handle a subset
- * of the available methods.
+ * This class provides an empty implementation of {@link ConditionVisitor}, which can be extended to
+ * create a visitor which only needs to handle a subset of the available methods.
  *
- * @param <T> The return type of the visit operation. Use {@link Void} for
- * operations with no return type.
+ * @param <T> The return type of the visit operation. Use {@link Void} for operations with no return
+ *     type.
  */
 @SuppressWarnings("CheckReturnValue")
-public class ConditionBaseVisitor<T> extends AbstractParseTreeVisitor<T> implements ConditionVisitor<T> {
+public class ConditionBaseVisitor<T> extends AbstractParseTreeVisitor<T>
+        implements ConditionVisitor<T> {
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation returns the result of calling
-     * {@link #visitChildren} on {@code ctx}.</p>
+     * <p>The default implementation returns the result of calling {@link #visitChildren} on {@code
+     * ctx}.
      */
-    @Override public T visitStart(ConditionParser.StartContext ctx) { return visitChildren(ctx); }
+    @Override
+    public T visitStart(ConditionParser.StartContext ctx) {
+        return visitChildren(ctx);
+    }
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation returns the result of calling
-     * {@link #visitChildren} on {@code ctx}.</p>
+     * <p>The default implementation returns the result of calling {@link #visitChildren} on {@code
+     * ctx}.
      */
-    @Override public T visitOrExpression(ConditionParser.OrExpressionContext ctx) { return visitChildren(ctx); }
+    @Override
+    public T visitOrExpression(ConditionParser.OrExpressionContext ctx) {
+        return visitChildren(ctx);
+    }
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation returns the result of calling
-     * {@link #visitChildren} on {@code ctx}.</p>
+     * <p>The default implementation returns the result of calling {@link #visitChildren} on {@code
+     * ctx}.
      */
-    @Override public T visitIdentOrSelectExpression(ConditionParser.IdentOrSelectExpressionContext ctx) { return visitChildren(ctx); }
+    @Override
+    public T visitIdentOrSelectExpression(ConditionParser.IdentOrSelectExpressionContext ctx) {
+        return visitChildren(ctx);
+    }
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation returns the result of calling
-     * {@link #visitChildren} on {@code ctx}.</p>
+     * <p>The default implementation returns the result of calling {@link #visitChildren} on {@code
+     * ctx}.
      */
-    @Override public T visitAndExpression(ConditionParser.AndExpressionContext ctx) { return visitChildren(ctx); }
+    @Override
+    public T visitAndExpression(ConditionParser.AndExpressionContext ctx) {
+        return visitChildren(ctx);
+    }
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation returns the result of calling
-     * {@link #visitChildren} on {@code ctx}.</p>
+     * <p>The default implementation returns the result of calling {@link #visitChildren} on {@code
+     * ctx}.
      */
-    @Override public T visitNotExpression(ConditionParser.NotExpressionContext ctx) { return visitChildren(ctx); }
+    @Override
+    public T visitNotExpression(ConditionParser.NotExpressionContext ctx) {
+        return visitChildren(ctx);
+    }
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation returns the result of calling
-     * {@link #visitChildren} on {@code ctx}.</p>
+     * <p>The default implementation returns the result of calling {@link #visitChildren} on {@code
+     * ctx}.
      */
-    @Override public T visitParenExpression(ConditionParser.ParenExpressionContext ctx) { return visitChildren(ctx); }
+    @Override
+    public T visitParenExpression(ConditionParser.ParenExpressionContext ctx) {
+        return visitChildren(ctx);
+    }
 }

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionLexer.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionLexer.java
@@ -1,58 +1,84 @@
-// Generated from java-escape by ANTLR 4.11.1
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.opensearch.securityanalytics.rules.condition;
-import org.antlr.v4.runtime.Lexer;
-import org.antlr.v4.runtime.CharStream;
-import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.TokenStream;
+
 import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.Lexer;
 import org.antlr.v4.runtime.atn.*;
 import org.antlr.v4.runtime.dfa.DFA;
 import org.antlr.v4.runtime.misc.*;
 
-@SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast", "CheckReturnValue"})
+@SuppressWarnings({
+    "all",
+    "warnings",
+    "unchecked",
+    "unused",
+    "cast",
+    "CheckReturnValue",
+    "this-escape"
+})
 public class ConditionLexer extends Lexer {
-    static { RuntimeMetaData.checkVersion("4.11.1", RuntimeMetaData.VERSION); }
+    static {
+        RuntimeMetaData.checkVersion("4.13.1", RuntimeMetaData.VERSION);
+    }
 
     protected static final DFA[] _decisionToDFA;
-    protected static final PredictionContextCache _sharedContextCache =
-        new PredictionContextCache();
-    public static final int
-        AND=1, OR=2, NOT=3, LPAREN=4, RPAREN=5, SELECTOR=6, IDENTIFIER=7, WHITESPACE=8;
-    public static String[] channelNames = {
-        "DEFAULT_TOKEN_CHANNEL", "HIDDEN"
-    };
+    protected static final PredictionContextCache _sharedContextCache = new PredictionContextCache();
+    public static final int AND = 1,
+            OR = 2,
+            NOT = 3,
+            LPAREN = 4,
+            RPAREN = 5,
+            SELECTOR = 6,
+            IDENTIFIER = 7,
+            WHITESPACE = 8;
+    public static String[] channelNames = {"DEFAULT_TOKEN_CHANNEL", "HIDDEN"};
 
-    public static String[] modeNames = {
-        "DEFAULT_MODE"
-    };
+    public static String[] modeNames = {"DEFAULT_MODE"};
 
     private static String[] makeRuleNames() {
         return new String[] {
             "AND", "OR", "NOT", "LPAREN", "RPAREN", "SELECTOR", "IDENTIFIER", "WHITESPACE"
         };
     }
+
     public static final String[] ruleNames = makeRuleNames();
 
     private static String[] makeLiteralNames() {
-        return new String[] {
-            null, "'and'", "'or'", "'not'", "'('", "')'"
-        };
+        return new String[] {null, "'and'", "'or'", "'not'", "'('", "')'"};
     }
+
     private static final String[] _LITERAL_NAMES = makeLiteralNames();
+
     private static String[] makeSymbolicNames() {
         return new String[] {
-            null, "AND", "OR", "NOT", "LPAREN", "RPAREN", "SELECTOR", "IDENTIFIER",
-            "WHITESPACE"
+            null, "AND", "OR", "NOT", "LPAREN", "RPAREN", "SELECTOR", "IDENTIFIER", "WHITESPACE"
         };
     }
+
     private static final String[] _SYMBOLIC_NAMES = makeSymbolicNames();
     public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
 
     /**
      * @deprecated Use {@link #VOCABULARY} instead.
      */
-    @Deprecated
-    public static final String[] tokenNames;
+    @Deprecated public static final String[] tokenNames;
+
     static {
         tokenNames = new String[_SYMBOLIC_NAMES.length];
         for (int i = 0; i < tokenNames.length; i++) {
@@ -74,80 +100,90 @@ public class ConditionLexer extends Lexer {
     }
 
     @Override
-
     public Vocabulary getVocabulary() {
         return VOCABULARY;
     }
 
-
     public ConditionLexer(CharStream input) {
         super(input);
-        _interp = new LexerATNSimulator(this,_ATN,_decisionToDFA,_sharedContextCache);
+        _interp = new LexerATNSimulator(this, _ATN, _decisionToDFA, _sharedContextCache);
     }
 
     @Override
-    public String getGrammarFileName() { return "Condition.g4"; }
+    public String getGrammarFileName() {
+        return "Condition.g4";
+    }
 
     @Override
-    public String[] getRuleNames() { return ruleNames; }
+    public String[] getRuleNames() {
+        return ruleNames;
+    }
 
     @Override
-    public String getSerializedATN() { return _serializedATN; }
+    public String getSerializedATN() {
+        return _serializedATN;
+    }
 
     @Override
-    public String[] getChannelNames() { return channelNames; }
+    public String[] getChannelNames() {
+        return channelNames;
+    }
 
     @Override
-    public String[] getModeNames() { return modeNames; }
+    public String[] getModeNames() {
+        return modeNames;
+    }
 
     @Override
-    public ATN getATN() { return _ATN; }
+    public ATN getATN() {
+        return _ATN;
+    }
 
     public static final String _serializedATN =
-        "\u0004\u0000\bA\u0006\uffff\uffff\u0002\u0000\u0007\u0000\u0002\u0001"+
-        "\u0007\u0001\u0002\u0002\u0007\u0002\u0002\u0003\u0007\u0003\u0002\u0004"+
-        "\u0007\u0004\u0002\u0005\u0007\u0005\u0002\u0006\u0007\u0006\u0002\u0007"+
-        "\u0007\u0007\u0001\u0000\u0001\u0000\u0001\u0000\u0001\u0000\u0001\u0001"+
-        "\u0001\u0001\u0001\u0001\u0001\u0002\u0001\u0002\u0001\u0002\u0001\u0002"+
-        "\u0001\u0003\u0001\u0003\u0001\u0004\u0001\u0004\u0001\u0005\u0001\u0005"+
-        "\u0001\u0005\u0001\u0005\u0001\u0005\u0001\u0005\u0001\u0005\u0003\u0005"+
-        "(\b\u0005\u0001\u0005\u0001\u0005\u0001\u0005\u0001\u0005\u0001\u0005"+
-        "\u0001\u0005\u0004\u00050\b\u0005\u000b\u0005\f\u00051\u0001\u0006\u0001"+
-        "\u0006\u0005\u00066\b\u0006\n\u0006\f\u00069\t\u0006\u0001\u0007\u0004"+
-        "\u0007<\b\u0007\u000b\u0007\f\u0007=\u0001\u0007\u0001\u0007\u0000\u0000"+
-        "\b\u0001\u0001\u0003\u0002\u0005\u0003\u0007\u0004\t\u0005\u000b\u0006"+
-        "\r\u0007\u000f\b\u0001\u0000\u0004\u0005\u0000**09AZ__az\u0003\u0000A"+
-        "Z__az\u0004\u000009AZ__az\u0003\u0000\t\n\r\r  E\u0000\u0001\u0001\u0000"+
-        "\u0000\u0000\u0000\u0003\u0001\u0000\u0000\u0000\u0000\u0005\u0001\u0000"+
-        "\u0000\u0000\u0000\u0007\u0001\u0000\u0000\u0000\u0000\t\u0001\u0000\u0000"+
-        "\u0000\u0000\u000b\u0001\u0000\u0000\u0000\u0000\r\u0001\u0000\u0000\u0000"+
-        "\u0000\u000f\u0001\u0000\u0000\u0000\u0001\u0011\u0001\u0000\u0000\u0000"+
-        "\u0003\u0015\u0001\u0000\u0000\u0000\u0005\u0018\u0001\u0000\u0000\u0000"+
-        "\u0007\u001c\u0001\u0000\u0000\u0000\t\u001e\u0001\u0000\u0000\u0000\u000b"+
-        "\'\u0001\u0000\u0000\u0000\r3\u0001\u0000\u0000\u0000\u000f;\u0001\u0000"+
-        "\u0000\u0000\u0011\u0012\u0005a\u0000\u0000\u0012\u0013\u0005n\u0000\u0000"+
-        "\u0013\u0014\u0005d\u0000\u0000\u0014\u0002\u0001\u0000\u0000\u0000\u0015"+
-        "\u0016\u0005o\u0000\u0000\u0016\u0017\u0005r\u0000\u0000\u0017\u0004\u0001"+
-        "\u0000\u0000\u0000\u0018\u0019\u0005n\u0000\u0000\u0019\u001a\u0005o\u0000"+
-        "\u0000\u001a\u001b\u0005t\u0000\u0000\u001b\u0006\u0001\u0000\u0000\u0000"+
-        "\u001c\u001d\u0005(\u0000\u0000\u001d\b\u0001\u0000\u0000\u0000\u001e"+
-        "\u001f\u0005)\u0000\u0000\u001f\n\u0001\u0000\u0000\u0000 (\u00051\u0000"+
-        "\u0000!\"\u0005a\u0000\u0000\"#\u0005n\u0000\u0000#(\u0005y\u0000\u0000"+
-        "$%\u0005a\u0000\u0000%&\u0005l\u0000\u0000&(\u0005l\u0000\u0000\' \u0001"+
-        "\u0000\u0000\u0000\'!\u0001\u0000\u0000\u0000\'$\u0001\u0000\u0000\u0000"+
-        "()\u0001\u0000\u0000\u0000)*\u0005 \u0000\u0000*+\u0005o\u0000\u0000+"+
-        ",\u0005f\u0000\u0000,-\u0005 \u0000\u0000-/\u0001\u0000\u0000\u0000.0"+
-        "\u0007\u0000\u0000\u0000/.\u0001\u0000\u0000\u000001\u0001\u0000\u0000"+
-        "\u00001/\u0001\u0000\u0000\u000012\u0001\u0000\u0000\u00002\f\u0001\u0000"+
-        "\u0000\u000037\u0007\u0001\u0000\u000046\u0007\u0002\u0000\u000054\u0001"+
-        "\u0000\u0000\u000069\u0001\u0000\u0000\u000075\u0001\u0000\u0000\u0000"+
-        "78\u0001\u0000\u0000\u00008\u000e\u0001\u0000\u0000\u000097\u0001\u0000"+
-        "\u0000\u0000:<\u0007\u0003\u0000\u0000;:\u0001\u0000\u0000\u0000<=\u0001"+
-        "\u0000\u0000\u0000=;\u0001\u0000\u0000\u0000=>\u0001\u0000\u0000\u0000"+
-        ">?\u0001\u0000\u0000\u0000?@\u0006\u0007\u0000\u0000@\u0010\u0001\u0000"+
-        "\u0000\u0000\u0005\u0000\'17=\u0001\u0006\u0000\u0000";
-    public static final ATN _ATN =
-        new ATNDeserializer().deserialize(_serializedATN.toCharArray());
+            "\u0004\u0000\bA\u0006\uffff\uffff\u0002\u0000\u0007\u0000\u0002\u0001"
+                    + "\u0007\u0001\u0002\u0002\u0007\u0002\u0002\u0003\u0007\u0003\u0002\u0004"
+                    + "\u0007\u0004\u0002\u0005\u0007\u0005\u0002\u0006\u0007\u0006\u0002\u0007"
+                    + "\u0007\u0007\u0001\u0000\u0001\u0000\u0001\u0000\u0001\u0000\u0001\u0001"
+                    + "\u0001\u0001\u0001\u0001\u0001\u0002\u0001\u0002\u0001\u0002\u0001\u0002"
+                    + "\u0001\u0003\u0001\u0003\u0001\u0004\u0001\u0004\u0001\u0005\u0001\u0005"
+                    + "\u0001\u0005\u0001\u0005\u0001\u0005\u0001\u0005\u0001\u0005\u0003\u0005"
+                    + "(\b\u0005\u0001\u0005\u0001\u0005\u0001\u0005\u0001\u0005\u0001\u0005"
+                    + "\u0001\u0005\u0004\u00050\b\u0005\u000b\u0005\f\u00051\u0001\u0006\u0001"
+                    + "\u0006\u0005\u00066\b\u0006\n\u0006\f\u00069\t\u0006\u0001\u0007\u0004"
+                    + "\u0007<\b\u0007\u000b\u0007\f\u0007=\u0001\u0007\u0001\u0007\u0000\u0000"
+                    + "\b\u0001\u0001\u0003\u0002\u0005\u0003\u0007\u0004\t\u0005\u000b\u0006"
+                    + "\r\u0007\u000f\b\u0001\u0000\u0004\u0005\u0000**09AZ__az\u0003\u0000A"
+                    + "Z__az\u0004\u000009AZ__az\u0003\u0000\t\n\r\r  E\u0000\u0001\u0001\u0000"
+                    + "\u0000\u0000\u0000\u0003\u0001\u0000\u0000\u0000\u0000\u0005\u0001\u0000"
+                    + "\u0000\u0000\u0000\u0007\u0001\u0000\u0000\u0000\u0000\t\u0001\u0000\u0000"
+                    + "\u0000\u0000\u000b\u0001\u0000\u0000\u0000\u0000\r\u0001\u0000\u0000\u0000"
+                    + "\u0000\u000f\u0001\u0000\u0000\u0000\u0001\u0011\u0001\u0000\u0000\u0000"
+                    + "\u0003\u0015\u0001\u0000\u0000\u0000\u0005\u0018\u0001\u0000\u0000\u0000"
+                    + "\u0007\u001c\u0001\u0000\u0000\u0000\t\u001e\u0001\u0000\u0000\u0000\u000b"
+                    + "\'\u0001\u0000\u0000\u0000\r3\u0001\u0000\u0000\u0000\u000f;\u0001\u0000"
+                    + "\u0000\u0000\u0011\u0012\u0005a\u0000\u0000\u0012\u0013\u0005n\u0000\u0000"
+                    + "\u0013\u0014\u0005d\u0000\u0000\u0014\u0002\u0001\u0000\u0000\u0000\u0015"
+                    + "\u0016\u0005o\u0000\u0000\u0016\u0017\u0005r\u0000\u0000\u0017\u0004\u0001"
+                    + "\u0000\u0000\u0000\u0018\u0019\u0005n\u0000\u0000\u0019\u001a\u0005o\u0000"
+                    + "\u0000\u001a\u001b\u0005t\u0000\u0000\u001b\u0006\u0001\u0000\u0000\u0000"
+                    + "\u001c\u001d\u0005(\u0000\u0000\u001d\b\u0001\u0000\u0000\u0000\u001e"
+                    + "\u001f\u0005)\u0000\u0000\u001f\n\u0001\u0000\u0000\u0000 (\u00051\u0000"
+                    + "\u0000!\"\u0005a\u0000\u0000\"#\u0005n\u0000\u0000#(\u0005y\u0000\u0000"
+                    + "$%\u0005a\u0000\u0000%&\u0005l\u0000\u0000&(\u0005l\u0000\u0000\' \u0001"
+                    + "\u0000\u0000\u0000\'!\u0001\u0000\u0000\u0000\'$\u0001\u0000\u0000\u0000"
+                    + "()\u0001\u0000\u0000\u0000)*\u0005 \u0000\u0000*+\u0005o\u0000\u0000+"
+                    + ",\u0005f\u0000\u0000,-\u0005 \u0000\u0000-/\u0001\u0000\u0000\u0000.0"
+                    + "\u0007\u0000\u0000\u0000/.\u0001\u0000\u0000\u000001\u0001\u0000\u0000"
+                    + "\u00001/\u0001\u0000\u0000\u000012\u0001\u0000\u0000\u00002\f\u0001\u0000"
+                    + "\u0000\u000037\u0007\u0001\u0000\u000046\u0007\u0002\u0000\u000054\u0001"
+                    + "\u0000\u0000\u000069\u0001\u0000\u0000\u000075\u0001\u0000\u0000\u0000"
+                    + "78\u0001\u0000\u0000\u00008\u000e\u0001\u0000\u0000\u000097\u0001\u0000"
+                    + "\u0000\u0000:<\u0007\u0003\u0000\u0000;:\u0001\u0000\u0000\u0000<=\u0001"
+                    + "\u0000\u0000\u0000=;\u0001\u0000\u0000\u0000=>\u0001\u0000\u0000\u0000"
+                    + ">?\u0001\u0000\u0000\u0000?@\u0006\u0007\u0000\u0000@\u0010\u0001\u0000"
+                    + "\u0000\u0000\u0005\u0000\'17=\u0001\u0006\u0000\u0000";
+    public static final ATN _ATN = new ATNDeserializer().deserialize(_serializedATN.toCharArray());
+
     static {
         _decisionToDFA = new DFA[_ATN.getNumberOfDecisions()];
         for (int i = 0; i < _ATN.getNumberOfDecisions(); i++) {

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionListener.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionListener.java
@@ -1,79 +1,117 @@
-// Generated from java-escape by ANTLR 4.11.1
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.opensearch.securityanalytics.rules.condition;
+
 import org.antlr.v4.runtime.tree.ParseTreeListener;
 
 /**
- * This interface defines a complete listener for a parse tree produced by
- * {@link ConditionParser}.
+ * This interface defines a complete listener for a parse tree produced by {@link ConditionParser}.
  */
 public interface ConditionListener extends ParseTreeListener {
     /**
      * Enter a parse tree produced by {@link ConditionParser#start}.
+     *
      * @param ctx the parse tree
      */
     void enterStart(ConditionParser.StartContext ctx);
+
     /**
      * Exit a parse tree produced by {@link ConditionParser#start}.
+     *
      * @param ctx the parse tree
      */
     void exitStart(ConditionParser.StartContext ctx);
+
     /**
-     * Enter a parse tree produced by the {@code orExpression}
-     * labeled alternative in {@link ConditionParser#expression}.
+     * Enter a parse tree produced by the {@code orExpression} labeled alternative in {@link
+     * ConditionParser#expression}.
+     *
      * @param ctx the parse tree
      */
     void enterOrExpression(ConditionParser.OrExpressionContext ctx);
+
     /**
-     * Exit a parse tree produced by the {@code orExpression}
-     * labeled alternative in {@link ConditionParser#expression}.
+     * Exit a parse tree produced by the {@code orExpression} labeled alternative in {@link
+     * ConditionParser#expression}.
+     *
      * @param ctx the parse tree
      */
     void exitOrExpression(ConditionParser.OrExpressionContext ctx);
+
     /**
-     * Enter a parse tree produced by the {@code identOrSelectExpression}
-     * labeled alternative in {@link ConditionParser#expression}.
+     * Enter a parse tree produced by the {@code identOrSelectExpression} labeled alternative in
+     * {@link ConditionParser#expression}.
+     *
      * @param ctx the parse tree
      */
     void enterIdentOrSelectExpression(ConditionParser.IdentOrSelectExpressionContext ctx);
+
     /**
-     * Exit a parse tree produced by the {@code identOrSelectExpression}
-     * labeled alternative in {@link ConditionParser#expression}.
+     * Exit a parse tree produced by the {@code identOrSelectExpression} labeled alternative in {@link
+     * ConditionParser#expression}.
+     *
      * @param ctx the parse tree
      */
     void exitIdentOrSelectExpression(ConditionParser.IdentOrSelectExpressionContext ctx);
+
     /**
-     * Enter a parse tree produced by the {@code andExpression}
-     * labeled alternative in {@link ConditionParser#expression}.
+     * Enter a parse tree produced by the {@code andExpression} labeled alternative in {@link
+     * ConditionParser#expression}.
+     *
      * @param ctx the parse tree
      */
     void enterAndExpression(ConditionParser.AndExpressionContext ctx);
+
     /**
-     * Exit a parse tree produced by the {@code andExpression}
-     * labeled alternative in {@link ConditionParser#expression}.
+     * Exit a parse tree produced by the {@code andExpression} labeled alternative in {@link
+     * ConditionParser#expression}.
+     *
      * @param ctx the parse tree
      */
     void exitAndExpression(ConditionParser.AndExpressionContext ctx);
+
     /**
-     * Enter a parse tree produced by the {@code notExpression}
-     * labeled alternative in {@link ConditionParser#expression}.
+     * Enter a parse tree produced by the {@code notExpression} labeled alternative in {@link
+     * ConditionParser#expression}.
+     *
      * @param ctx the parse tree
      */
     void enterNotExpression(ConditionParser.NotExpressionContext ctx);
+
     /**
-     * Exit a parse tree produced by the {@code notExpression}
-     * labeled alternative in {@link ConditionParser#expression}.
+     * Exit a parse tree produced by the {@code notExpression} labeled alternative in {@link
+     * ConditionParser#expression}.
+     *
      * @param ctx the parse tree
      */
     void exitNotExpression(ConditionParser.NotExpressionContext ctx);
+
     /**
-     * Enter a parse tree produced by the {@code parenExpression}
-     * labeled alternative in {@link ConditionParser#expression}.
+     * Enter a parse tree produced by the {@code parenExpression} labeled alternative in {@link
+     * ConditionParser#expression}.
+     *
      * @param ctx the parse tree
      */
     void enterParenExpression(ConditionParser.ParenExpressionContext ctx);
+
     /**
-     * Exit a parse tree produced by the {@code parenExpression}
-     * labeled alternative in {@link ConditionParser#expression}.
+     * Exit a parse tree produced by the {@code parenExpression} labeled alternative in {@link
+     * ConditionParser#expression}.
+     *
      * @param ctx the parse tree
      */
     void exitParenExpression(ConditionParser.ParenExpressionContext ctx);

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionParser.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionParser.java
@@ -1,52 +1,73 @@
-// Generated from java-escape by ANTLR 4.11.1
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.opensearch.securityanalytics.rules.condition;
+
+import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.atn.*;
 import org.antlr.v4.runtime.dfa.DFA;
-import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.misc.*;
 import org.antlr.v4.runtime.tree.*;
+
 import java.util.List;
-import java.util.Iterator;
-import java.util.ArrayList;
 
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast", "CheckReturnValue"})
 public class ConditionParser extends Parser {
-    static { RuntimeMetaData.checkVersion("4.11.1", RuntimeMetaData.VERSION); }
+    static {
+        RuntimeMetaData.checkVersion("4.13.1", RuntimeMetaData.VERSION);
+    }
 
     protected static final DFA[] _decisionToDFA;
-    protected static final PredictionContextCache _sharedContextCache =
-        new PredictionContextCache();
-    public static final int
-        AND=1, OR=2, NOT=3, LPAREN=4, RPAREN=5, SELECTOR=6, IDENTIFIER=7, WHITESPACE=8;
-    public static final int
-        RULE_start = 0, RULE_expression = 1;
+    protected static final PredictionContextCache _sharedContextCache = new PredictionContextCache();
+    public static final int AND = 1,
+            OR = 2,
+            NOT = 3,
+            LPAREN = 4,
+            RPAREN = 5,
+            SELECTOR = 6,
+            IDENTIFIER = 7,
+            WHITESPACE = 8;
+    public static final int RULE_start = 0, RULE_expression = 1;
+
     private static String[] makeRuleNames() {
-        return new String[] {
-            "start", "expression"
-        };
+        return new String[] {"start", "expression"};
     }
+
     public static final String[] ruleNames = makeRuleNames();
 
     private static String[] makeLiteralNames() {
-        return new String[] {
-            null, "'and'", "'or'", "'not'", "'('", "')'"
-        };
+        return new String[] {null, "'and'", "'or'", "'not'", "'('", "')'"};
     }
+
     private static final String[] _LITERAL_NAMES = makeLiteralNames();
+
     private static String[] makeSymbolicNames() {
         return new String[] {
-            null, "AND", "OR", "NOT", "LPAREN", "RPAREN", "SELECTOR", "IDENTIFIER",
-            "WHITESPACE"
+            null, "AND", "OR", "NOT", "LPAREN", "RPAREN", "SELECTOR", "IDENTIFIER", "WHITESPACE"
         };
     }
+
     private static final String[] _SYMBOLIC_NAMES = makeSymbolicNames();
     public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
 
     /**
      * @deprecated Use {@link #VOCABULARY} instead.
      */
-    @Deprecated
-    public static final String[] tokenNames;
+    @Deprecated public static final String[] tokenNames;
+
     static {
         tokenNames = new String[_SYMBOLIC_NAMES.length];
         for (int i = 0; i < tokenNames.length; i++) {
@@ -68,48 +89,64 @@ public class ConditionParser extends Parser {
     }
 
     @Override
-
     public Vocabulary getVocabulary() {
         return VOCABULARY;
     }
 
     @Override
-    public String getGrammarFileName() { return "java-escape"; }
+    public String getGrammarFileName() {
+        return "Condition.g4";
+    }
 
     @Override
-    public String[] getRuleNames() { return ruleNames; }
+    public String[] getRuleNames() {
+        return ruleNames;
+    }
 
     @Override
-    public String getSerializedATN() { return _serializedATN; }
+    public String getSerializedATN() {
+        return _serializedATN;
+    }
 
     @Override
-    public ATN getATN() { return _ATN; }
+    public ATN getATN() {
+        return _ATN;
+    }
 
     public ConditionParser(TokenStream input) {
         super(input);
-        _interp = new ParserATNSimulator(this,_ATN,_decisionToDFA,_sharedContextCache);
+        _interp = new ParserATNSimulator(this, _ATN, _decisionToDFA, _sharedContextCache);
     }
 
     @SuppressWarnings("CheckReturnValue")
     public static class StartContext extends ParserRuleContext {
         public ExpressionContext expression() {
-            return getRuleContext(ExpressionContext.class,0);
+            return getRuleContext(ExpressionContext.class, 0);
         }
+
         public StartContext(ParserRuleContext parent, int invokingState) {
             super(parent, invokingState);
         }
-        @Override public int getRuleIndex() { return RULE_start; }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_start;
+        }
+
         @Override
         public void enterRule(ParseTreeListener listener) {
-            if ( listener instanceof ConditionListener ) ((ConditionListener)listener).enterStart(this);
+            if (listener instanceof ConditionListener) ((ConditionListener) listener).enterStart(this);
         }
+
         @Override
         public void exitRule(ParseTreeListener listener) {
-            if ( listener instanceof ConditionListener ) ((ConditionListener)listener).exitStart(this);
+            if (listener instanceof ConditionListener) ((ConditionListener) listener).exitStart(this);
         }
+
         @Override
         public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-            if ( visitor instanceof ConditionVisitor ) return ((ConditionVisitor<? extends T>)visitor).visitStart(this);
+            if (visitor instanceof ConditionVisitor)
+                return ((ConditionVisitor<? extends T>) visitor).visitStart(this);
             else return visitor.visitChildren(this);
         }
     }
@@ -120,16 +157,14 @@ public class ConditionParser extends Parser {
         try {
             enterOuterAlt(_localctx, 1);
             {
-            setState(4);
-            expression(0);
+                setState(4);
+                expression(0);
             }
-        }
-        catch (RecognitionException re) {
+        } catch (RecognitionException re) {
             _localctx.exception = re;
             _errHandler.reportError(this, re);
             _errHandler.recover(this, re);
-        }
-        finally {
+        } finally {
             exitRule();
         }
         return _localctx;
@@ -140,127 +175,207 @@ public class ConditionParser extends Parser {
         public ExpressionContext(ParserRuleContext parent, int invokingState) {
             super(parent, invokingState);
         }
-        @Override public int getRuleIndex() { return RULE_expression; }
 
-        public ExpressionContext() { }
+        @Override
+        public int getRuleIndex() {
+            return RULE_expression;
+        }
+
+        public ExpressionContext() {}
+
         public void copyFrom(ExpressionContext ctx) {
             super.copyFrom(ctx);
         }
     }
+
     @SuppressWarnings("CheckReturnValue")
     public static class OrExpressionContext extends ExpressionContext {
         public ExpressionContext left;
         public Token operator;
         public ExpressionContext right;
+
         public List<ExpressionContext> expression() {
             return getRuleContexts(ExpressionContext.class);
         }
+
         public ExpressionContext expression(int i) {
-            return getRuleContext(ExpressionContext.class,i);
+            return getRuleContext(ExpressionContext.class, i);
         }
-        public TerminalNode OR() { return getToken(ConditionParser.OR, 0); }
-        public OrExpressionContext(ExpressionContext ctx) { copyFrom(ctx); }
+
+        public TerminalNode OR() {
+            return getToken(ConditionParser.OR, 0);
+        }
+
+        public OrExpressionContext(ExpressionContext ctx) {
+            copyFrom(ctx);
+        }
+
         @Override
         public void enterRule(ParseTreeListener listener) {
-            if ( listener instanceof ConditionListener ) ((ConditionListener)listener).enterOrExpression(this);
+            if (listener instanceof ConditionListener)
+                ((ConditionListener) listener).enterOrExpression(this);
         }
+
         @Override
         public void exitRule(ParseTreeListener listener) {
-            if ( listener instanceof ConditionListener ) ((ConditionListener)listener).exitOrExpression(this);
+            if (listener instanceof ConditionListener)
+                ((ConditionListener) listener).exitOrExpression(this);
         }
+
         @Override
         public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-            if ( visitor instanceof ConditionVisitor ) return ((ConditionVisitor<? extends T>)visitor).visitOrExpression(this);
+            if (visitor instanceof ConditionVisitor)
+                return ((ConditionVisitor<? extends T>) visitor).visitOrExpression(this);
             else return visitor.visitChildren(this);
         }
     }
+
     @SuppressWarnings("CheckReturnValue")
     public static class IdentOrSelectExpressionContext extends ExpressionContext {
-        public TerminalNode SELECTOR() { return getToken(ConditionParser.SELECTOR, 0); }
-        public TerminalNode IDENTIFIER() { return getToken(ConditionParser.IDENTIFIER, 0); }
-        public IdentOrSelectExpressionContext(ExpressionContext ctx) { copyFrom(ctx); }
+        public TerminalNode SELECTOR() {
+            return getToken(ConditionParser.SELECTOR, 0);
+        }
+
+        public TerminalNode IDENTIFIER() {
+            return getToken(ConditionParser.IDENTIFIER, 0);
+        }
+
+        public IdentOrSelectExpressionContext(ExpressionContext ctx) {
+            copyFrom(ctx);
+        }
+
         @Override
         public void enterRule(ParseTreeListener listener) {
-            if ( listener instanceof ConditionListener ) ((ConditionListener)listener).enterIdentOrSelectExpression(this);
+            if (listener instanceof ConditionListener)
+                ((ConditionListener) listener).enterIdentOrSelectExpression(this);
         }
+
         @Override
         public void exitRule(ParseTreeListener listener) {
-            if ( listener instanceof ConditionListener ) ((ConditionListener)listener).exitIdentOrSelectExpression(this);
+            if (listener instanceof ConditionListener)
+                ((ConditionListener) listener).exitIdentOrSelectExpression(this);
         }
+
         @Override
         public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-            if ( visitor instanceof ConditionVisitor ) return ((ConditionVisitor<? extends T>)visitor).visitIdentOrSelectExpression(this);
+            if (visitor instanceof ConditionVisitor)
+                return ((ConditionVisitor<? extends T>) visitor).visitIdentOrSelectExpression(this);
             else return visitor.visitChildren(this);
         }
     }
+
     @SuppressWarnings("CheckReturnValue")
     public static class AndExpressionContext extends ExpressionContext {
         public ExpressionContext left;
         public Token operator;
         public ExpressionContext right;
+
         public List<ExpressionContext> expression() {
             return getRuleContexts(ExpressionContext.class);
         }
+
         public ExpressionContext expression(int i) {
-            return getRuleContext(ExpressionContext.class,i);
+            return getRuleContext(ExpressionContext.class, i);
         }
-        public TerminalNode AND() { return getToken(ConditionParser.AND, 0); }
-        public AndExpressionContext(ExpressionContext ctx) { copyFrom(ctx); }
+
+        public TerminalNode AND() {
+            return getToken(ConditionParser.AND, 0);
+        }
+
+        public AndExpressionContext(ExpressionContext ctx) {
+            copyFrom(ctx);
+        }
+
         @Override
         public void enterRule(ParseTreeListener listener) {
-            if ( listener instanceof ConditionListener ) ((ConditionListener)listener).enterAndExpression(this);
+            if (listener instanceof ConditionListener)
+                ((ConditionListener) listener).enterAndExpression(this);
         }
+
         @Override
         public void exitRule(ParseTreeListener listener) {
-            if ( listener instanceof ConditionListener ) ((ConditionListener)listener).exitAndExpression(this);
+            if (listener instanceof ConditionListener)
+                ((ConditionListener) listener).exitAndExpression(this);
         }
+
         @Override
         public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-            if ( visitor instanceof ConditionVisitor ) return ((ConditionVisitor<? extends T>)visitor).visitAndExpression(this);
+            if (visitor instanceof ConditionVisitor)
+                return ((ConditionVisitor<? extends T>) visitor).visitAndExpression(this);
             else return visitor.visitChildren(this);
         }
     }
+
     @SuppressWarnings("CheckReturnValue")
     public static class NotExpressionContext extends ExpressionContext {
-        public TerminalNode NOT() { return getToken(ConditionParser.NOT, 0); }
-        public ExpressionContext expression() {
-            return getRuleContext(ExpressionContext.class,0);
+        public TerminalNode NOT() {
+            return getToken(ConditionParser.NOT, 0);
         }
-        public NotExpressionContext(ExpressionContext ctx) { copyFrom(ctx); }
+
+        public ExpressionContext expression() {
+            return getRuleContext(ExpressionContext.class, 0);
+        }
+
+        public NotExpressionContext(ExpressionContext ctx) {
+            copyFrom(ctx);
+        }
+
         @Override
         public void enterRule(ParseTreeListener listener) {
-            if ( listener instanceof ConditionListener ) ((ConditionListener)listener).enterNotExpression(this);
+            if (listener instanceof ConditionListener)
+                ((ConditionListener) listener).enterNotExpression(this);
         }
+
         @Override
         public void exitRule(ParseTreeListener listener) {
-            if ( listener instanceof ConditionListener ) ((ConditionListener)listener).exitNotExpression(this);
+            if (listener instanceof ConditionListener)
+                ((ConditionListener) listener).exitNotExpression(this);
         }
+
         @Override
         public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-            if ( visitor instanceof ConditionVisitor ) return ((ConditionVisitor<? extends T>)visitor).visitNotExpression(this);
+            if (visitor instanceof ConditionVisitor)
+                return ((ConditionVisitor<? extends T>) visitor).visitNotExpression(this);
             else return visitor.visitChildren(this);
         }
     }
+
     @SuppressWarnings("CheckReturnValue")
     public static class ParenExpressionContext extends ExpressionContext {
         public ExpressionContext inner;
-        public TerminalNode LPAREN() { return getToken(ConditionParser.LPAREN, 0); }
-        public TerminalNode RPAREN() { return getToken(ConditionParser.RPAREN, 0); }
-        public ExpressionContext expression() {
-            return getRuleContext(ExpressionContext.class,0);
+
+        public TerminalNode LPAREN() {
+            return getToken(ConditionParser.LPAREN, 0);
         }
-        public ParenExpressionContext(ExpressionContext ctx) { copyFrom(ctx); }
+
+        public TerminalNode RPAREN() {
+            return getToken(ConditionParser.RPAREN, 0);
+        }
+
+        public ExpressionContext expression() {
+            return getRuleContext(ExpressionContext.class, 0);
+        }
+
+        public ParenExpressionContext(ExpressionContext ctx) {
+            copyFrom(ctx);
+        }
+
         @Override
         public void enterRule(ParseTreeListener listener) {
-            if ( listener instanceof ConditionListener ) ((ConditionListener)listener).enterParenExpression(this);
+            if (listener instanceof ConditionListener)
+                ((ConditionListener) listener).enterParenExpression(this);
         }
+
         @Override
         public void exitRule(ParseTreeListener listener) {
-            if ( listener instanceof ConditionListener ) ((ConditionListener)listener).exitParenExpression(this);
+            if (listener instanceof ConditionListener)
+                ((ConditionListener) listener).exitParenExpression(this);
         }
+
         @Override
         public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-            if ( visitor instanceof ConditionVisitor ) return ((ConditionVisitor<? extends T>)visitor).visitParenExpression(this);
+            if (visitor instanceof ConditionVisitor)
+                return ((ConditionVisitor<? extends T>) visitor).visitParenExpression(this);
             else return visitor.visitChildren(this);
         }
     }
@@ -281,108 +396,109 @@ public class ConditionParser extends Parser {
             int _alt;
             enterOuterAlt(_localctx, 1);
             {
-            setState(14);
-            _errHandler.sync(this);
-            switch (_input.LA(1)) {
-            case SELECTOR:
-            case IDENTIFIER:
-                {
-                _localctx = new IdentOrSelectExpressionContext(_localctx);
-                _ctx = _localctx;
-                _prevctx = _localctx;
-
-                setState(7);
-                _la = _input.LA(1);
-                if ( !(_la==SELECTOR || _la==IDENTIFIER) ) {
-                _errHandler.recoverInline(this);
-                }
-                else {
-                    if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
-                    _errHandler.reportMatch(this);
-                    consume();
-                }
-                }
-                break;
-            case LPAREN:
-                {
-                _localctx = new ParenExpressionContext(_localctx);
-                _ctx = _localctx;
-                _prevctx = _localctx;
-                setState(8);
-                match(LPAREN);
-                setState(9);
-                ((ParenExpressionContext)_localctx).inner = expression(0);
-                setState(10);
-                match(RPAREN);
-                }
-                break;
-            case NOT:
-                {
-                _localctx = new NotExpressionContext(_localctx);
-                _ctx = _localctx;
-                _prevctx = _localctx;
-                setState(12);
-                match(NOT);
-                setState(13);
-                expression(3);
-                }
-                break;
-            default:
-                throw new NoViableAltException(this);
-            }
-            _ctx.stop = _input.LT(-1);
-            setState(24);
-            _errHandler.sync(this);
-            _alt = getInterpreter().adaptivePredict(_input,2,_ctx);
-            while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
-                if ( _alt==1 ) {
-                    if ( _parseListeners!=null ) triggerExitRuleEvent();
-                    _prevctx = _localctx;
-                    {
-                    setState(22);
-                    _errHandler.sync(this);
-                    switch ( getInterpreter().adaptivePredict(_input,1,_ctx) ) {
-                    case 1:
-                        {
-                        _localctx = new AndExpressionContext(new ExpressionContext(_parentctx, _parentState));
-                        ((AndExpressionContext)_localctx).left = _prevctx;
-                        pushNewRecursionContext(_localctx, _startState, RULE_expression);
-                        setState(16);
-                        if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
-                        setState(17);
-                        ((AndExpressionContext)_localctx).operator = match(AND);
-                        setState(18);
-                        ((AndExpressionContext)_localctx).right = expression(3);
-                        }
-                        break;
-                    case 2:
-                        {
-                        _localctx = new OrExpressionContext(new ExpressionContext(_parentctx, _parentState));
-                        ((OrExpressionContext)_localctx).left = _prevctx;
-                        pushNewRecursionContext(_localctx, _startState, RULE_expression);
-                        setState(19);
-                        if (!(precpred(_ctx, 1))) throw new FailedPredicateException(this, "precpred(_ctx, 1)");
-                        setState(20);
-                        ((OrExpressionContext)_localctx).operator = match(OR);
-                        setState(21);
-                        ((OrExpressionContext)_localctx).right = expression(2);
-                        }
-                        break;
-                    }
-                    }
-                }
-                setState(26);
+                setState(14);
                 _errHandler.sync(this);
-                _alt = getInterpreter().adaptivePredict(_input,2,_ctx);
+                switch (_input.LA(1)) {
+                    case SELECTOR:
+                    case IDENTIFIER:
+                        {
+                            _localctx = new IdentOrSelectExpressionContext(_localctx);
+                            _ctx = _localctx;
+                            _prevctx = _localctx;
+
+                            setState(7);
+                            _la = _input.LA(1);
+                            if (!(_la == SELECTOR || _la == IDENTIFIER)) {
+                                _errHandler.recoverInline(this);
+                            } else {
+                                if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                                _errHandler.reportMatch(this);
+                                consume();
+                            }
+                        }
+                        break;
+                    case LPAREN:
+                        {
+                            _localctx = new ParenExpressionContext(_localctx);
+                            _ctx = _localctx;
+                            _prevctx = _localctx;
+                            setState(8);
+                            match(LPAREN);
+                            setState(9);
+                            ((ParenExpressionContext) _localctx).inner = expression(0);
+                            setState(10);
+                            match(RPAREN);
+                        }
+                        break;
+                    case NOT:
+                        {
+                            _localctx = new NotExpressionContext(_localctx);
+                            _ctx = _localctx;
+                            _prevctx = _localctx;
+                            setState(12);
+                            match(NOT);
+                            setState(13);
+                            expression(3);
+                        }
+                        break;
+                    default:
+                        throw new NoViableAltException(this);
+                }
+                _ctx.stop = _input.LT(-1);
+                setState(24);
+                _errHandler.sync(this);
+                _alt = getInterpreter().adaptivePredict(_input, 2, _ctx);
+                while (_alt != 2 && _alt != org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER) {
+                    if (_alt == 1) {
+                        if (_parseListeners != null) triggerExitRuleEvent();
+                        _prevctx = _localctx;
+                        {
+                            setState(22);
+                            _errHandler.sync(this);
+                            switch (getInterpreter().adaptivePredict(_input, 1, _ctx)) {
+                                case 1:
+                                    {
+                                        _localctx =
+                                                new AndExpressionContext(new ExpressionContext(_parentctx, _parentState));
+                                        ((AndExpressionContext) _localctx).left = _prevctx;
+                                        pushNewRecursionContext(_localctx, _startState, RULE_expression);
+                                        setState(16);
+                                        if (!(precpred(_ctx, 2)))
+                                            throw new FailedPredicateException(this, "precpred(_ctx, 2)");
+                                        setState(17);
+                                        ((AndExpressionContext) _localctx).operator = match(AND);
+                                        setState(18);
+                                        ((AndExpressionContext) _localctx).right = expression(3);
+                                    }
+                                    break;
+                                case 2:
+                                    {
+                                        _localctx =
+                                                new OrExpressionContext(new ExpressionContext(_parentctx, _parentState));
+                                        ((OrExpressionContext) _localctx).left = _prevctx;
+                                        pushNewRecursionContext(_localctx, _startState, RULE_expression);
+                                        setState(19);
+                                        if (!(precpred(_ctx, 1)))
+                                            throw new FailedPredicateException(this, "precpred(_ctx, 1)");
+                                        setState(20);
+                                        ((OrExpressionContext) _localctx).operator = match(OR);
+                                        setState(21);
+                                        ((OrExpressionContext) _localctx).right = expression(2);
+                                    }
+                                    break;
+                            }
+                        }
+                    }
+                    setState(26);
+                    _errHandler.sync(this);
+                    _alt = getInterpreter().adaptivePredict(_input, 2, _ctx);
+                }
             }
-            }
-        }
-        catch (RecognitionException re) {
+        } catch (RecognitionException re) {
             _localctx.exception = re;
             _errHandler.reportError(this, re);
             _errHandler.recover(this, re);
-        }
-        finally {
+        } finally {
             unrollRecursionContexts(_parentctx);
         }
         return _localctx;
@@ -390,45 +506,46 @@ public class ConditionParser extends Parser {
 
     public boolean sempred(RuleContext _localctx, int ruleIndex, int predIndex) {
         switch (ruleIndex) {
-        case 1:
-            return expression_sempred((ExpressionContext)_localctx, predIndex);
+            case 1:
+                return expression_sempred((ExpressionContext) _localctx, predIndex);
         }
         return true;
     }
+
     private boolean expression_sempred(ExpressionContext _localctx, int predIndex) {
         switch (predIndex) {
-        case 0:
-            return precpred(_ctx, 2);
-        case 1:
-            return precpred(_ctx, 1);
+            case 0:
+                return precpred(_ctx, 2);
+            case 1:
+                return precpred(_ctx, 1);
         }
         return true;
     }
 
     public static final String _serializedATN =
-        "\u0004\u0001\b\u001c\u0002\u0000\u0007\u0000\u0002\u0001\u0007\u0001\u0001"+
-        "\u0000\u0001\u0000\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001"+
-        "\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0003\u0001\u000f\b\u0001\u0001"+
-        "\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0005"+
-        "\u0001\u0017\b\u0001\n\u0001\f\u0001\u001a\t\u0001\u0001\u0001\u0000\u0001"+
-        "\u0002\u0002\u0000\u0002\u0000\u0001\u0001\u0000\u0006\u0007\u001d\u0000"+
-        "\u0004\u0001\u0000\u0000\u0000\u0002\u000e\u0001\u0000\u0000\u0000\u0004"+
-        "\u0005\u0003\u0002\u0001\u0000\u0005\u0001\u0001\u0000\u0000\u0000\u0006"+
-        "\u0007\u0006\u0001\uffff\uffff\u0000\u0007\u000f\u0007\u0000\u0000\u0000"+
-        "\b\t\u0005\u0004\u0000\u0000\t\n\u0003\u0002\u0001\u0000\n\u000b\u0005"+
-        "\u0005\u0000\u0000\u000b\u000f\u0001\u0000\u0000\u0000\f\r\u0005\u0003"+
-        "\u0000\u0000\r\u000f\u0003\u0002\u0001\u0003\u000e\u0006\u0001\u0000\u0000"+
-        "\u0000\u000e\b\u0001\u0000\u0000\u0000\u000e\f\u0001\u0000\u0000\u0000"+
-        "\u000f\u0018\u0001\u0000\u0000\u0000\u0010\u0011\n\u0002\u0000\u0000\u0011"+
-        "\u0012\u0005\u0001\u0000\u0000\u0012\u0017\u0003\u0002\u0001\u0003\u0013"+
-        "\u0014\n\u0001\u0000\u0000\u0014\u0015\u0005\u0002\u0000\u0000\u0015\u0017"+
-        "\u0003\u0002\u0001\u0002\u0016\u0010\u0001\u0000\u0000\u0000\u0016\u0013"+
-        "\u0001\u0000\u0000\u0000\u0017\u001a\u0001\u0000\u0000\u0000\u0018\u0016"+
-        "\u0001\u0000\u0000\u0000\u0018\u0019\u0001\u0000\u0000\u0000\u0019\u0003"+
-        "\u0001\u0000\u0000\u0000\u001a\u0018\u0001\u0000\u0000\u0000\u0003\u000e"+
-        "\u0016\u0018";
-    public static final ATN _ATN =
-        new ATNDeserializer().deserialize(_serializedATN.toCharArray());
+            "\u0004\u0001\b\u001c\u0002\u0000\u0007\u0000\u0002\u0001\u0007\u0001\u0001"
+                    + "\u0000\u0001\u0000\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001"
+                    + "\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0003\u0001\u000f\b\u0001\u0001"
+                    + "\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0001\u0005"
+                    + "\u0001\u0017\b\u0001\n\u0001\f\u0001\u001a\t\u0001\u0001\u0001\u0000\u0001"
+                    + "\u0002\u0002\u0000\u0002\u0000\u0001\u0001\u0000\u0006\u0007\u001d\u0000"
+                    + "\u0004\u0001\u0000\u0000\u0000\u0002\u000e\u0001\u0000\u0000\u0000\u0004"
+                    + "\u0005\u0003\u0002\u0001\u0000\u0005\u0001\u0001\u0000\u0000\u0000\u0006"
+                    + "\u0007\u0006\u0001\uffff\uffff\u0000\u0007\u000f\u0007\u0000\u0000\u0000"
+                    + "\b\t\u0005\u0004\u0000\u0000\t\n\u0003\u0002\u0001\u0000\n\u000b\u0005"
+                    + "\u0005\u0000\u0000\u000b\u000f\u0001\u0000\u0000\u0000\f\r\u0005\u0003"
+                    + "\u0000\u0000\r\u000f\u0003\u0002\u0001\u0003\u000e\u0006\u0001\u0000\u0000"
+                    + "\u0000\u000e\b\u0001\u0000\u0000\u0000\u000e\f\u0001\u0000\u0000\u0000"
+                    + "\u000f\u0018\u0001\u0000\u0000\u0000\u0010\u0011\n\u0002\u0000\u0000\u0011"
+                    + "\u0012\u0005\u0001\u0000\u0000\u0012\u0017\u0003\u0002\u0001\u0003\u0013"
+                    + "\u0014\n\u0001\u0000\u0000\u0014\u0015\u0005\u0002\u0000\u0000\u0015\u0017"
+                    + "\u0003\u0002\u0001\u0002\u0016\u0010\u0001\u0000\u0000\u0000\u0016\u0013"
+                    + "\u0001\u0000\u0000\u0000\u0017\u001a\u0001\u0000\u0000\u0000\u0018\u0016"
+                    + "\u0001\u0000\u0000\u0000\u0018\u0019\u0001\u0000\u0000\u0000\u0019\u0003"
+                    + "\u0001\u0000\u0000\u0000\u001a\u0018\u0001\u0000\u0000\u0000\u0003\u000e"
+                    + "\u0016\u0018";
+    public static final ATN _ATN = new ATNDeserializer().deserialize(_serializedATN.toCharArray());
+
     static {
         _decisionToDFA = new DFA[_ATN.getNumberOfDecisions()];
         for (int i = 0; i < _ATN.getNumberOfDecisions(); i++) {

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionVisitor.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/ConditionVisitor.java
@@ -1,52 +1,79 @@
-// Generated from java-escape by ANTLR 4.11.1
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.opensearch.securityanalytics.rules.condition;
+
 import org.antlr.v4.runtime.tree.ParseTreeVisitor;
 
 /**
- * This interface defines a complete generic visitor for a parse tree produced
- * by {@link ConditionParser}.
+ * This interface defines a complete generic visitor for a parse tree produced by {@link
+ * ConditionParser}.
  *
- * @param <T> The return type of the visit operation. Use {@link Void} for
- * operations with no return type.
+ * @param <T> The return type of the visit operation. Use {@link Void} for operations with no return
+ *     type.
  */
 public interface ConditionVisitor<T> extends ParseTreeVisitor<T> {
     /**
      * Visit a parse tree produced by {@link ConditionParser#start}.
+     *
      * @param ctx the parse tree
      * @return the visitor result
      */
     T visitStart(ConditionParser.StartContext ctx);
+
     /**
-     * Visit a parse tree produced by the {@code orExpression}
-     * labeled alternative in {@link ConditionParser#expression}.
+     * Visit a parse tree produced by the {@code orExpression} labeled alternative in {@link
+     * ConditionParser#expression}.
+     *
      * @param ctx the parse tree
      * @return the visitor result
      */
     T visitOrExpression(ConditionParser.OrExpressionContext ctx);
+
     /**
-     * Visit a parse tree produced by the {@code identOrSelectExpression}
-     * labeled alternative in {@link ConditionParser#expression}.
+     * Visit a parse tree produced by the {@code identOrSelectExpression} labeled alternative in
+     * {@link ConditionParser#expression}.
+     *
      * @param ctx the parse tree
      * @return the visitor result
      */
     T visitIdentOrSelectExpression(ConditionParser.IdentOrSelectExpressionContext ctx);
+
     /**
-     * Visit a parse tree produced by the {@code andExpression}
-     * labeled alternative in {@link ConditionParser#expression}.
+     * Visit a parse tree produced by the {@code andExpression} labeled alternative in {@link
+     * ConditionParser#expression}.
+     *
      * @param ctx the parse tree
      * @return the visitor result
      */
     T visitAndExpression(ConditionParser.AndExpressionContext ctx);
+
     /**
-     * Visit a parse tree produced by the {@code notExpression}
-     * labeled alternative in {@link ConditionParser#expression}.
+     * Visit a parse tree produced by the {@code notExpression} labeled alternative in {@link
+     * ConditionParser#expression}.
+     *
      * @param ctx the parse tree
      * @return the visitor result
      */
     T visitNotExpression(ConditionParser.NotExpressionContext ctx);
+
     /**
-     * Visit a parse tree produced by the {@code parenExpression}
-     * labeled alternative in {@link ConditionParser#expression}.
+     * Visit a parse tree produced by the {@code parenExpression} labeled alternative in {@link
+     * ConditionParser#expression}.
+     *
      * @param ctx the parse tree
      * @return the visitor result
      */

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationBaseListener.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationBaseListener.java
@@ -1,4 +1,19 @@
-// Generated from java-escape by ANTLR 4.11.1
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.opensearch.securityanalytics.rules.condition.aggregation;
 
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -6,143 +21,188 @@ import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
 /**
- * This class provides an empty implementation of {@link AggregationListener},
- * which can be extended to create a listener which only needs to handle a subset
- * of the available methods.
+ * This class provides an empty implementation of {@link AggregationListener}, which can be extended
+ * to create a listener which only needs to handle a subset of the available methods.
  */
 @SuppressWarnings("CheckReturnValue")
 public class AggregationBaseListener implements AggregationListener {
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation does nothing.</p>
+     * <p>The default implementation does nothing.
      */
-    @Override public void enterComparisonExpressionWithOperator(AggregationParser.ComparisonExpressionWithOperatorContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void exitComparisonExpressionWithOperator(AggregationParser.ComparisonExpressionWithOperatorContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void enterComparison_operand(AggregationParser.Comparison_operandContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void exitComparison_operand(AggregationParser.Comparison_operandContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void enterComp_operator(AggregationParser.Comp_operatorContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void exitComp_operator(AggregationParser.Comp_operatorContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void enterAgg_operator(AggregationParser.Agg_operatorContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void exitAgg_operator(AggregationParser.Agg_operatorContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void enterGroupby_expr(AggregationParser.Groupby_exprContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void exitGroupby_expr(AggregationParser.Groupby_exprContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void enterAggExpressionParens(AggregationParser.AggExpressionParensContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void exitAggExpressionParens(AggregationParser.AggExpressionParensContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void enterAggExpressionNumericEntity(AggregationParser.AggExpressionNumericEntityContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void exitAggExpressionNumericEntity(AggregationParser.AggExpressionNumericEntityContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void enterNumericConst(AggregationParser.NumericConstContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void exitNumericConst(AggregationParser.NumericConstContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void enterNumericVariable(AggregationParser.NumericVariableContext ctx) { }
-    /**
-     * {@inheritDoc}
-     *
-     * <p>The default implementation does nothing.</p>
-     */
-    @Override public void exitNumericVariable(AggregationParser.NumericVariableContext ctx) { }
+    @Override
+    public void enterComparisonExpressionWithOperator(
+            AggregationParser.ComparisonExpressionWithOperatorContext ctx) {}
 
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation does nothing.</p>
+     * <p>The default implementation does nothing.
      */
-    @Override public void enterEveryRule(ParserRuleContext ctx) { }
+    @Override
+    public void exitComparisonExpressionWithOperator(
+            AggregationParser.ComparisonExpressionWithOperatorContext ctx) {}
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation does nothing.</p>
+     * <p>The default implementation does nothing.
      */
-    @Override public void exitEveryRule(ParserRuleContext ctx) { }
+    @Override
+    public void enterComparison_operand(AggregationParser.Comparison_operandContext ctx) {}
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation does nothing.</p>
+     * <p>The default implementation does nothing.
      */
-    @Override public void visitTerminal(TerminalNode node) { }
+    @Override
+    public void exitComparison_operand(AggregationParser.Comparison_operandContext ctx) {}
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation does nothing.</p>
+     * <p>The default implementation does nothing.
      */
-    @Override public void visitErrorNode(ErrorNode node) { }
+    @Override
+    public void enterComp_operator(AggregationParser.Comp_operatorContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void exitComp_operator(AggregationParser.Comp_operatorContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void enterAgg_operator(AggregationParser.Agg_operatorContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void exitAgg_operator(AggregationParser.Agg_operatorContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void enterGroupby_expr(AggregationParser.Groupby_exprContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void exitGroupby_expr(AggregationParser.Groupby_exprContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void enterAggExpressionParens(AggregationParser.AggExpressionParensContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void exitAggExpressionParens(AggregationParser.AggExpressionParensContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void enterAggExpressionNumericEntity(
+            AggregationParser.AggExpressionNumericEntityContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void exitAggExpressionNumericEntity(
+            AggregationParser.AggExpressionNumericEntityContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void enterNumericConst(AggregationParser.NumericConstContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void exitNumericConst(AggregationParser.NumericConstContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void enterNumericVariable(AggregationParser.NumericVariableContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void exitNumericVariable(AggregationParser.NumericVariableContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void enterEveryRule(ParserRuleContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void exitEveryRule(ParserRuleContext ctx) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void visitTerminal(TerminalNode node) {}
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The default implementation does nothing.
+     */
+    @Override
+    public void visitErrorNode(ErrorNode node) {}
 }

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationBaseVisitor.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationBaseVisitor.java
@@ -1,78 +1,131 @@
-// Generated from java-escape by ANTLR 4.11.1
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.opensearch.securityanalytics.rules.condition.aggregation;
+
 import org.antlr.v4.runtime.tree.AbstractParseTreeVisitor;
 
 /**
- * This class provides an empty implementation of {@link AggregationVisitor},
- * which can be extended to create a visitor which only needs to handle a subset
- * of the available methods.
+ * This class provides an empty implementation of {@link AggregationVisitor}, which can be extended
+ * to create a visitor which only needs to handle a subset of the available methods.
  *
- * @param <T> The return type of the visit operation. Use {@link Void} for
- * operations with no return type.
+ * @param <T> The return type of the visit operation. Use {@link Void} for operations with no return
+ *     type.
  */
 @SuppressWarnings("CheckReturnValue")
-public class AggregationBaseVisitor<T> extends AbstractParseTreeVisitor<T> implements AggregationVisitor<T> {
+public class AggregationBaseVisitor<T> extends AbstractParseTreeVisitor<T>
+        implements AggregationVisitor<T> {
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation returns the result of calling
-     * {@link #visitChildren} on {@code ctx}.</p>
+     * <p>The default implementation returns the result of calling {@link #visitChildren} on {@code
+     * ctx}.
      */
-    @Override public T visitComparisonExpressionWithOperator(AggregationParser.ComparisonExpressionWithOperatorContext ctx) { return visitChildren(ctx); }
+    @Override
+    public T visitComparisonExpressionWithOperator(
+            AggregationParser.ComparisonExpressionWithOperatorContext ctx) {
+        return visitChildren(ctx);
+    }
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation returns the result of calling
-     * {@link #visitChildren} on {@code ctx}.</p>
+     * <p>The default implementation returns the result of calling {@link #visitChildren} on {@code
+     * ctx}.
      */
-    @Override public T visitComparison_operand(AggregationParser.Comparison_operandContext ctx) { return visitChildren(ctx); }
+    @Override
+    public T visitComparison_operand(AggregationParser.Comparison_operandContext ctx) {
+        return visitChildren(ctx);
+    }
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation returns the result of calling
-     * {@link #visitChildren} on {@code ctx}.</p>
+     * <p>The default implementation returns the result of calling {@link #visitChildren} on {@code
+     * ctx}.
      */
-    @Override public T visitComp_operator(AggregationParser.Comp_operatorContext ctx) { return visitChildren(ctx); }
+    @Override
+    public T visitComp_operator(AggregationParser.Comp_operatorContext ctx) {
+        return visitChildren(ctx);
+    }
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation returns the result of calling
-     * {@link #visitChildren} on {@code ctx}.</p>
+     * <p>The default implementation returns the result of calling {@link #visitChildren} on {@code
+     * ctx}.
      */
-    @Override public T visitAgg_operator(AggregationParser.Agg_operatorContext ctx) { return visitChildren(ctx); }
+    @Override
+    public T visitAgg_operator(AggregationParser.Agg_operatorContext ctx) {
+        return visitChildren(ctx);
+    }
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation returns the result of calling
-     * {@link #visitChildren} on {@code ctx}.</p>
+     * <p>The default implementation returns the result of calling {@link #visitChildren} on {@code
+     * ctx}.
      */
-    @Override public T visitGroupby_expr(AggregationParser.Groupby_exprContext ctx) { return visitChildren(ctx); }
+    @Override
+    public T visitGroupby_expr(AggregationParser.Groupby_exprContext ctx) {
+        return visitChildren(ctx);
+    }
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation returns the result of calling
-     * {@link #visitChildren} on {@code ctx}.</p>
+     * <p>The default implementation returns the result of calling {@link #visitChildren} on {@code
+     * ctx}.
      */
-    @Override public T visitAggExpressionParens(AggregationParser.AggExpressionParensContext ctx) { return visitChildren(ctx); }
+    @Override
+    public T visitAggExpressionParens(AggregationParser.AggExpressionParensContext ctx) {
+        return visitChildren(ctx);
+    }
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation returns the result of calling
-     * {@link #visitChildren} on {@code ctx}.</p>
+     * <p>The default implementation returns the result of calling {@link #visitChildren} on {@code
+     * ctx}.
      */
-    @Override public T visitAggExpressionNumericEntity(AggregationParser.AggExpressionNumericEntityContext ctx) { return visitChildren(ctx); }
+    @Override
+    public T visitAggExpressionNumericEntity(
+            AggregationParser.AggExpressionNumericEntityContext ctx) {
+        return visitChildren(ctx);
+    }
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation returns the result of calling
-     * {@link #visitChildren} on {@code ctx}.</p>
+     * <p>The default implementation returns the result of calling {@link #visitChildren} on {@code
+     * ctx}.
      */
-    @Override public T visitNumericConst(AggregationParser.NumericConstContext ctx) { return visitChildren(ctx); }
+    @Override
+    public T visitNumericConst(AggregationParser.NumericConstContext ctx) {
+        return visitChildren(ctx);
+    }
+
     /**
      * {@inheritDoc}
      *
-     * <p>The default implementation returns the result of calling
-     * {@link #visitChildren} on {@code ctx}.</p>
+     * <p>The default implementation returns the result of calling {@link #visitChildren} on {@code
+     * ctx}.
      */
-    @Override public T visitNumericVariable(AggregationParser.NumericVariableContext ctx) { return visitChildren(ctx); }
+    @Override
+    public T visitNumericVariable(AggregationParser.NumericVariableContext ctx) {
+        return visitChildren(ctx);
+    }
 }

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationLexer.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationLexer.java
@@ -1,61 +1,126 @@
-// Generated from java-escape by ANTLR 4.11.1
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.opensearch.securityanalytics.rules.condition.aggregation;
-import org.antlr.v4.runtime.Lexer;
-import org.antlr.v4.runtime.CharStream;
-import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.TokenStream;
+
 import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.Lexer;
 import org.antlr.v4.runtime.atn.*;
 import org.antlr.v4.runtime.dfa.DFA;
 import org.antlr.v4.runtime.misc.*;
 
-@SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast", "CheckReturnValue"})
+@SuppressWarnings({
+    "all",
+    "warnings",
+    "unchecked",
+    "unused",
+    "cast",
+    "CheckReturnValue",
+    "this-escape"
+})
 public class AggregationLexer extends Lexer {
-    static { RuntimeMetaData.checkVersion("4.11.1", RuntimeMetaData.VERSION); }
+    static {
+        RuntimeMetaData.checkVersion("4.13.1", RuntimeMetaData.VERSION);
+    }
 
     protected static final DFA[] _decisionToDFA;
-    protected static final PredictionContextCache _sharedContextCache =
-        new PredictionContextCache();
-    public static final int
-        GT=1, GE=2, LT=3, LE=4, EQ=5, COUNT=6, SUM=7, MIN=8, MAX=9, AVG=10, BY=11,
-        LPAREN=12, RPAREN=13, DECIMAL=14, IDENTIFIER=15, WS=16;
-    public static String[] channelNames = {
-        "DEFAULT_TOKEN_CHANNEL", "HIDDEN"
-    };
+    protected static final PredictionContextCache _sharedContextCache = new PredictionContextCache();
+    public static final int GT = 1,
+            GE = 2,
+            LT = 3,
+            LE = 4,
+            EQ = 5,
+            COUNT = 6,
+            SUM = 7,
+            MIN = 8,
+            MAX = 9,
+            AVG = 10,
+            BY = 11,
+            LPAREN = 12,
+            RPAREN = 13,
+            DECIMAL = 14,
+            IDENTIFIER = 15,
+            WS = 16;
+    public static String[] channelNames = {"DEFAULT_TOKEN_CHANNEL", "HIDDEN"};
 
-    public static String[] modeNames = {
-        "DEFAULT_MODE"
-    };
+    public static String[] modeNames = {"DEFAULT_MODE"};
 
     private static String[] makeRuleNames() {
         return new String[] {
-            "GT", "GE", "LT", "LE", "EQ", "COUNT", "SUM", "MIN", "MAX", "AVG", "BY",
-            "LPAREN", "RPAREN", "DECIMAL", "IDENTIFIER", "WS"
+            "GT",
+            "GE",
+            "LT",
+            "LE",
+            "EQ",
+            "COUNT",
+            "SUM",
+            "MIN",
+            "MAX",
+            "AVG",
+            "BY",
+            "LPAREN",
+            "RPAREN",
+            "DECIMAL",
+            "IDENTIFIER",
+            "WS"
         };
     }
+
     public static final String[] ruleNames = makeRuleNames();
 
     private static String[] makeLiteralNames() {
         return new String[] {
-            null, "'>'", "'>='", "'<'", "'<='", "'=='", "'count'", "'sum'", "'min'",
-            "'max'", "'avg'", "'by'", "'('", "')'"
+            null, "'>'", "'>='", "'<'", "'<='", "'=='", "'count'", "'sum'", "'min'", "'max'", "'avg'",
+            "'by'", "'('", "')'"
         };
     }
+
     private static final String[] _LITERAL_NAMES = makeLiteralNames();
+
     private static String[] makeSymbolicNames() {
         return new String[] {
-            null, "GT", "GE", "LT", "LE", "EQ", "COUNT", "SUM", "MIN", "MAX", "AVG",
-            "BY", "LPAREN", "RPAREN", "DECIMAL", "IDENTIFIER", "WS"
+            null,
+            "GT",
+            "GE",
+            "LT",
+            "LE",
+            "EQ",
+            "COUNT",
+            "SUM",
+            "MIN",
+            "MAX",
+            "AVG",
+            "BY",
+            "LPAREN",
+            "RPAREN",
+            "DECIMAL",
+            "IDENTIFIER",
+            "WS"
         };
     }
+
     private static final String[] _SYMBOLIC_NAMES = makeSymbolicNames();
     public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
 
     /**
      * @deprecated Use {@link #VOCABULARY} instead.
      */
-    @Deprecated
-    public static final String[] tokenNames;
+    @Deprecated public static final String[] tokenNames;
+
     static {
         tokenNames = new String[_SYMBOLIC_NAMES.length];
         for (int i = 0; i < tokenNames.length; i++) {
@@ -77,100 +142,110 @@ public class AggregationLexer extends Lexer {
     }
 
     @Override
-
     public Vocabulary getVocabulary() {
         return VOCABULARY;
     }
 
-
     public AggregationLexer(CharStream input) {
         super(input);
-        _interp = new LexerATNSimulator(this,_ATN,_decisionToDFA,_sharedContextCache);
+        _interp = new LexerATNSimulator(this, _ATN, _decisionToDFA, _sharedContextCache);
     }
 
     @Override
-    public String getGrammarFileName() { return "Aggregation.g4"; }
+    public String getGrammarFileName() {
+        return "Aggregation.g4";
+    }
 
     @Override
-    public String[] getRuleNames() { return ruleNames; }
+    public String[] getRuleNames() {
+        return ruleNames;
+    }
 
     @Override
-    public String getSerializedATN() { return _serializedATN; }
+    public String getSerializedATN() {
+        return _serializedATN;
+    }
 
     @Override
-    public String[] getChannelNames() { return channelNames; }
+    public String[] getChannelNames() {
+        return channelNames;
+    }
 
     @Override
-    public String[] getModeNames() { return modeNames; }
+    public String[] getModeNames() {
+        return modeNames;
+    }
 
     @Override
-    public ATN getATN() { return _ATN; }
+    public ATN getATN() {
+        return _ATN;
+    }
 
     public static final String _serializedATN =
-        "\u0004\u0000\u0010i\u0006\uffff\uffff\u0002\u0000\u0007\u0000\u0002\u0001"+
-        "\u0007\u0001\u0002\u0002\u0007\u0002\u0002\u0003\u0007\u0003\u0002\u0004"+
-        "\u0007\u0004\u0002\u0005\u0007\u0005\u0002\u0006\u0007\u0006\u0002\u0007"+
-        "\u0007\u0007\u0002\b\u0007\b\u0002\t\u0007\t\u0002\n\u0007\n\u0002\u000b"+
-        "\u0007\u000b\u0002\f\u0007\f\u0002\r\u0007\r\u0002\u000e\u0007\u000e\u0002"+
-        "\u000f\u0007\u000f\u0001\u0000\u0001\u0000\u0001\u0001\u0001\u0001\u0001"+
-        "\u0001\u0001\u0002\u0001\u0002\u0001\u0003\u0001\u0003\u0001\u0003\u0001"+
-        "\u0004\u0001\u0004\u0001\u0004\u0001\u0005\u0001\u0005\u0001\u0005\u0001"+
-        "\u0005\u0001\u0005\u0001\u0005\u0001\u0006\u0001\u0006\u0001\u0006\u0001"+
-        "\u0006\u0001\u0007\u0001\u0007\u0001\u0007\u0001\u0007\u0001\b\u0001\b"+
-        "\u0001\b\u0001\b\u0001\t\u0001\t\u0001\t\u0001\t\u0001\n\u0001\n\u0001"+
-        "\n\u0001\u000b\u0001\u000b\u0001\f\u0001\f\u0001\r\u0003\rM\b\r\u0001"+
-        "\r\u0004\rP\b\r\u000b\r\f\rQ\u0001\r\u0001\r\u0004\rV\b\r\u000b\r\f\r"+
-        "W\u0003\rZ\b\r\u0001\u000e\u0001\u000e\u0005\u000e^\b\u000e\n\u000e\f"+
-        "\u000ea\t\u000e\u0001\u000f\u0004\u000fd\b\u000f\u000b\u000f\f\u000fe"+
-        "\u0001\u000f\u0001\u000f\u0000\u0000\u0010\u0001\u0001\u0003\u0002\u0005"+
-        "\u0003\u0007\u0004\t\u0005\u000b\u0006\r\u0007\u000f\b\u0011\t\u0013\n"+
-        "\u0015\u000b\u0017\f\u0019\r\u001b\u000e\u001d\u000f\u001f\u0010\u0001"+
-        "\u0000\u0004\u0001\u000009\u0005\u0000**..AZ__az\u0005\u0000..09AZ__a"+
-        "z\u0003\u0000\t\n\f\r  n\u0000\u0001\u0001\u0000\u0000\u0000\u0000\u0003"+
-        "\u0001\u0000\u0000\u0000\u0000\u0005\u0001\u0000\u0000\u0000\u0000\u0007"+
-        "\u0001\u0000\u0000\u0000\u0000\t\u0001\u0000\u0000\u0000\u0000\u000b\u0001"+
-        "\u0000\u0000\u0000\u0000\r\u0001\u0000\u0000\u0000\u0000\u000f\u0001\u0000"+
-        "\u0000\u0000\u0000\u0011\u0001\u0000\u0000\u0000\u0000\u0013\u0001\u0000"+
-        "\u0000\u0000\u0000\u0015\u0001\u0000\u0000\u0000\u0000\u0017\u0001\u0000"+
-        "\u0000\u0000\u0000\u0019\u0001\u0000\u0000\u0000\u0000\u001b\u0001\u0000"+
-        "\u0000\u0000\u0000\u001d\u0001\u0000\u0000\u0000\u0000\u001f\u0001\u0000"+
-        "\u0000\u0000\u0001!\u0001\u0000\u0000\u0000\u0003#\u0001\u0000\u0000\u0000"+
-        "\u0005&\u0001\u0000\u0000\u0000\u0007(\u0001\u0000\u0000\u0000\t+\u0001"+
-        "\u0000\u0000\u0000\u000b.\u0001\u0000\u0000\u0000\r4\u0001\u0000\u0000"+
-        "\u0000\u000f8\u0001\u0000\u0000\u0000\u0011<\u0001\u0000\u0000\u0000\u0013"+
-        "@\u0001\u0000\u0000\u0000\u0015D\u0001\u0000\u0000\u0000\u0017G\u0001"+
-        "\u0000\u0000\u0000\u0019I\u0001\u0000\u0000\u0000\u001bL\u0001\u0000\u0000"+
-        "\u0000\u001d[\u0001\u0000\u0000\u0000\u001fc\u0001\u0000\u0000\u0000!"+
-        "\"\u0005>\u0000\u0000\"\u0002\u0001\u0000\u0000\u0000#$\u0005>\u0000\u0000"+
-        "$%\u0005=\u0000\u0000%\u0004\u0001\u0000\u0000\u0000&\'\u0005<\u0000\u0000"+
-        "\'\u0006\u0001\u0000\u0000\u0000()\u0005<\u0000\u0000)*\u0005=\u0000\u0000"+
-        "*\b\u0001\u0000\u0000\u0000+,\u0005=\u0000\u0000,-\u0005=\u0000\u0000"+
-        "-\n\u0001\u0000\u0000\u0000./\u0005c\u0000\u0000/0\u0005o\u0000\u0000"+
-        "01\u0005u\u0000\u000012\u0005n\u0000\u000023\u0005t\u0000\u00003\f\u0001"+
-        "\u0000\u0000\u000045\u0005s\u0000\u000056\u0005u\u0000\u000067\u0005m"+
-        "\u0000\u00007\u000e\u0001\u0000\u0000\u000089\u0005m\u0000\u00009:\u0005"+
-        "i\u0000\u0000:;\u0005n\u0000\u0000;\u0010\u0001\u0000\u0000\u0000<=\u0005"+
-        "m\u0000\u0000=>\u0005a\u0000\u0000>?\u0005x\u0000\u0000?\u0012\u0001\u0000"+
-        "\u0000\u0000@A\u0005a\u0000\u0000AB\u0005v\u0000\u0000BC\u0005g\u0000"+
-        "\u0000C\u0014\u0001\u0000\u0000\u0000DE\u0005b\u0000\u0000EF\u0005y\u0000"+
-        "\u0000F\u0016\u0001\u0000\u0000\u0000GH\u0005(\u0000\u0000H\u0018\u0001"+
-        "\u0000\u0000\u0000IJ\u0005)\u0000\u0000J\u001a\u0001\u0000\u0000\u0000"+
-        "KM\u0005-\u0000\u0000LK\u0001\u0000\u0000\u0000LM\u0001\u0000\u0000\u0000"+
-        "MO\u0001\u0000\u0000\u0000NP\u0007\u0000\u0000\u0000ON\u0001\u0000\u0000"+
-        "\u0000PQ\u0001\u0000\u0000\u0000QO\u0001\u0000\u0000\u0000QR\u0001\u0000"+
-        "\u0000\u0000RY\u0001\u0000\u0000\u0000SU\u0005.\u0000\u0000TV\u0007\u0000"+
-        "\u0000\u0000UT\u0001\u0000\u0000\u0000VW\u0001\u0000\u0000\u0000WU\u0001"+
-        "\u0000\u0000\u0000WX\u0001\u0000\u0000\u0000XZ\u0001\u0000\u0000\u0000"+
-        "YS\u0001\u0000\u0000\u0000YZ\u0001\u0000\u0000\u0000Z\u001c\u0001\u0000"+
-        "\u0000\u0000[_\u0007\u0001\u0000\u0000\\^\u0007\u0002\u0000\u0000]\\\u0001"+
-        "\u0000\u0000\u0000^a\u0001\u0000\u0000\u0000_]\u0001\u0000\u0000\u0000"+
-        "_`\u0001\u0000\u0000\u0000`\u001e\u0001\u0000\u0000\u0000a_\u0001\u0000"+
-        "\u0000\u0000bd\u0007\u0003\u0000\u0000cb\u0001\u0000\u0000\u0000de\u0001"+
-        "\u0000\u0000\u0000ec\u0001\u0000\u0000\u0000ef\u0001\u0000\u0000\u0000"+
-        "fg\u0001\u0000\u0000\u0000gh\u0006\u000f\u0000\u0000h \u0001\u0000\u0000"+
-        "\u0000\u0007\u0000LQWY_e\u0001\u0006\u0000\u0000";
-    public static final ATN _ATN =
-        new ATNDeserializer().deserialize(_serializedATN.toCharArray());
+            "\u0004\u0000\u0010i\u0006\uffff\uffff\u0002\u0000\u0007\u0000\u0002\u0001"
+                    + "\u0007\u0001\u0002\u0002\u0007\u0002\u0002\u0003\u0007\u0003\u0002\u0004"
+                    + "\u0007\u0004\u0002\u0005\u0007\u0005\u0002\u0006\u0007\u0006\u0002\u0007"
+                    + "\u0007\u0007\u0002\b\u0007\b\u0002\t\u0007\t\u0002\n\u0007\n\u0002\u000b"
+                    + "\u0007\u000b\u0002\f\u0007\f\u0002\r\u0007\r\u0002\u000e\u0007\u000e\u0002"
+                    + "\u000f\u0007\u000f\u0001\u0000\u0001\u0000\u0001\u0001\u0001\u0001\u0001"
+                    + "\u0001\u0001\u0002\u0001\u0002\u0001\u0003\u0001\u0003\u0001\u0003\u0001"
+                    + "\u0004\u0001\u0004\u0001\u0004\u0001\u0005\u0001\u0005\u0001\u0005\u0001"
+                    + "\u0005\u0001\u0005\u0001\u0005\u0001\u0006\u0001\u0006\u0001\u0006\u0001"
+                    + "\u0006\u0001\u0007\u0001\u0007\u0001\u0007\u0001\u0007\u0001\b\u0001\b"
+                    + "\u0001\b\u0001\b\u0001\t\u0001\t\u0001\t\u0001\t\u0001\n\u0001\n\u0001"
+                    + "\n\u0001\u000b\u0001\u000b\u0001\f\u0001\f\u0001\r\u0003\rM\b\r\u0001"
+                    + "\r\u0004\rP\b\r\u000b\r\f\rQ\u0001\r\u0001\r\u0004\rV\b\r\u000b\r\f\r"
+                    + "W\u0003\rZ\b\r\u0001\u000e\u0001\u000e\u0005\u000e^\b\u000e\n\u000e\f"
+                    + "\u000ea\t\u000e\u0001\u000f\u0004\u000fd\b\u000f\u000b\u000f\f\u000fe"
+                    + "\u0001\u000f\u0001\u000f\u0000\u0000\u0010\u0001\u0001\u0003\u0002\u0005"
+                    + "\u0003\u0007\u0004\t\u0005\u000b\u0006\r\u0007\u000f\b\u0011\t\u0013\n"
+                    + "\u0015\u000b\u0017\f\u0019\r\u001b\u000e\u001d\u000f\u001f\u0010\u0001"
+                    + "\u0000\u0004\u0001\u000009\u0005\u0000**..AZ__az\u0005\u0000..09AZ__a"
+                    + "z\u0003\u0000\t\n\f\r  n\u0000\u0001\u0001\u0000\u0000\u0000\u0000\u0003"
+                    + "\u0001\u0000\u0000\u0000\u0000\u0005\u0001\u0000\u0000\u0000\u0000\u0007"
+                    + "\u0001\u0000\u0000\u0000\u0000\t\u0001\u0000\u0000\u0000\u0000\u000b\u0001"
+                    + "\u0000\u0000\u0000\u0000\r\u0001\u0000\u0000\u0000\u0000\u000f\u0001\u0000"
+                    + "\u0000\u0000\u0000\u0011\u0001\u0000\u0000\u0000\u0000\u0013\u0001\u0000"
+                    + "\u0000\u0000\u0000\u0015\u0001\u0000\u0000\u0000\u0000\u0017\u0001\u0000"
+                    + "\u0000\u0000\u0000\u0019\u0001\u0000\u0000\u0000\u0000\u001b\u0001\u0000"
+                    + "\u0000\u0000\u0000\u001d\u0001\u0000\u0000\u0000\u0000\u001f\u0001\u0000"
+                    + "\u0000\u0000\u0001!\u0001\u0000\u0000\u0000\u0003#\u0001\u0000\u0000\u0000"
+                    + "\u0005&\u0001\u0000\u0000\u0000\u0007(\u0001\u0000\u0000\u0000\t+\u0001"
+                    + "\u0000\u0000\u0000\u000b.\u0001\u0000\u0000\u0000\r4\u0001\u0000\u0000"
+                    + "\u0000\u000f8\u0001\u0000\u0000\u0000\u0011<\u0001\u0000\u0000\u0000\u0013"
+                    + "@\u0001\u0000\u0000\u0000\u0015D\u0001\u0000\u0000\u0000\u0017G\u0001"
+                    + "\u0000\u0000\u0000\u0019I\u0001\u0000\u0000\u0000\u001bL\u0001\u0000\u0000"
+                    + "\u0000\u001d[\u0001\u0000\u0000\u0000\u001fc\u0001\u0000\u0000\u0000!"
+                    + "\"\u0005>\u0000\u0000\"\u0002\u0001\u0000\u0000\u0000#$\u0005>\u0000\u0000"
+                    + "$%\u0005=\u0000\u0000%\u0004\u0001\u0000\u0000\u0000&\'\u0005<\u0000\u0000"
+                    + "\'\u0006\u0001\u0000\u0000\u0000()\u0005<\u0000\u0000)*\u0005=\u0000\u0000"
+                    + "*\b\u0001\u0000\u0000\u0000+,\u0005=\u0000\u0000,-\u0005=\u0000\u0000"
+                    + "-\n\u0001\u0000\u0000\u0000./\u0005c\u0000\u0000/0\u0005o\u0000\u0000"
+                    + "01\u0005u\u0000\u000012\u0005n\u0000\u000023\u0005t\u0000\u00003\f\u0001"
+                    + "\u0000\u0000\u000045\u0005s\u0000\u000056\u0005u\u0000\u000067\u0005m"
+                    + "\u0000\u00007\u000e\u0001\u0000\u0000\u000089\u0005m\u0000\u00009:\u0005"
+                    + "i\u0000\u0000:;\u0005n\u0000\u0000;\u0010\u0001\u0000\u0000\u0000<=\u0005"
+                    + "m\u0000\u0000=>\u0005a\u0000\u0000>?\u0005x\u0000\u0000?\u0012\u0001\u0000"
+                    + "\u0000\u0000@A\u0005a\u0000\u0000AB\u0005v\u0000\u0000BC\u0005g\u0000"
+                    + "\u0000C\u0014\u0001\u0000\u0000\u0000DE\u0005b\u0000\u0000EF\u0005y\u0000"
+                    + "\u0000F\u0016\u0001\u0000\u0000\u0000GH\u0005(\u0000\u0000H\u0018\u0001"
+                    + "\u0000\u0000\u0000IJ\u0005)\u0000\u0000J\u001a\u0001\u0000\u0000\u0000"
+                    + "KM\u0005-\u0000\u0000LK\u0001\u0000\u0000\u0000LM\u0001\u0000\u0000\u0000"
+                    + "MO\u0001\u0000\u0000\u0000NP\u0007\u0000\u0000\u0000ON\u0001\u0000\u0000"
+                    + "\u0000PQ\u0001\u0000\u0000\u0000QO\u0001\u0000\u0000\u0000QR\u0001\u0000"
+                    + "\u0000\u0000RY\u0001\u0000\u0000\u0000SU\u0005.\u0000\u0000TV\u0007\u0000"
+                    + "\u0000\u0000UT\u0001\u0000\u0000\u0000VW\u0001\u0000\u0000\u0000WU\u0001"
+                    + "\u0000\u0000\u0000WX\u0001\u0000\u0000\u0000XZ\u0001\u0000\u0000\u0000"
+                    + "YS\u0001\u0000\u0000\u0000YZ\u0001\u0000\u0000\u0000Z\u001c\u0001\u0000"
+                    + "\u0000\u0000[_\u0007\u0001\u0000\u0000\\^\u0007\u0002\u0000\u0000]\\\u0001"
+                    + "\u0000\u0000\u0000^a\u0001\u0000\u0000\u0000_]\u0001\u0000\u0000\u0000"
+                    + "_`\u0001\u0000\u0000\u0000`\u001e\u0001\u0000\u0000\u0000a_\u0001\u0000"
+                    + "\u0000\u0000bd\u0007\u0003\u0000\u0000cb\u0001\u0000\u0000\u0000de\u0001"
+                    + "\u0000\u0000\u0000ec\u0001\u0000\u0000\u0000ef\u0001\u0000\u0000\u0000"
+                    + "fg\u0001\u0000\u0000\u0000gh\u0006\u000f\u0000\u0000h \u0001\u0000\u0000"
+                    + "\u0000\u0007\u0000LQWY_e\u0001\u0006\u0000\u0000";
+    public static final ATN _ATN = new ATNDeserializer().deserialize(_serializedATN.toCharArray());
+
     static {
         _decisionToDFA = new DFA[_ATN.getNumberOfDecisions()];
         for (int i = 0; i < _ATN.getNumberOfDecisions(); i++) {

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationListener.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationListener.java
@@ -1,109 +1,162 @@
-// Generated from java-escape by ANTLR 4.11.1
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.opensearch.securityanalytics.rules.condition.aggregation;
+
 import org.antlr.v4.runtime.tree.ParseTreeListener;
 
 /**
- * This interface defines a complete listener for a parse tree produced by
- * {@link AggregationParser}.
+ * This interface defines a complete listener for a parse tree produced by {@link
+ * AggregationParser}.
  */
 public interface AggregationListener extends ParseTreeListener {
     /**
-     * Enter a parse tree produced by the {@code ComparisonExpressionWithOperator}
-     * labeled alternative in {@link AggregationParser#comparison_expr}.
+     * Enter a parse tree produced by the {@code ComparisonExpressionWithOperator} labeled alternative
+     * in {@link AggregationParser#comparison_expr}.
+     *
      * @param ctx the parse tree
      */
-    void enterComparisonExpressionWithOperator(AggregationParser.ComparisonExpressionWithOperatorContext ctx);
+    void enterComparisonExpressionWithOperator(
+            AggregationParser.ComparisonExpressionWithOperatorContext ctx);
+
     /**
-     * Exit a parse tree produced by the {@code ComparisonExpressionWithOperator}
-     * labeled alternative in {@link AggregationParser#comparison_expr}.
+     * Exit a parse tree produced by the {@code ComparisonExpressionWithOperator} labeled alternative
+     * in {@link AggregationParser#comparison_expr}.
+     *
      * @param ctx the parse tree
      */
-    void exitComparisonExpressionWithOperator(AggregationParser.ComparisonExpressionWithOperatorContext ctx);
+    void exitComparisonExpressionWithOperator(
+            AggregationParser.ComparisonExpressionWithOperatorContext ctx);
+
     /**
      * Enter a parse tree produced by {@link AggregationParser#comparison_operand}.
+     *
      * @param ctx the parse tree
      */
     void enterComparison_operand(AggregationParser.Comparison_operandContext ctx);
+
     /**
      * Exit a parse tree produced by {@link AggregationParser#comparison_operand}.
+     *
      * @param ctx the parse tree
      */
     void exitComparison_operand(AggregationParser.Comparison_operandContext ctx);
+
     /**
      * Enter a parse tree produced by {@link AggregationParser#comp_operator}.
+     *
      * @param ctx the parse tree
      */
     void enterComp_operator(AggregationParser.Comp_operatorContext ctx);
+
     /**
      * Exit a parse tree produced by {@link AggregationParser#comp_operator}.
+     *
      * @param ctx the parse tree
      */
     void exitComp_operator(AggregationParser.Comp_operatorContext ctx);
+
     /**
      * Enter a parse tree produced by {@link AggregationParser#agg_operator}.
+     *
      * @param ctx the parse tree
      */
     void enterAgg_operator(AggregationParser.Agg_operatorContext ctx);
+
     /**
      * Exit a parse tree produced by {@link AggregationParser#agg_operator}.
+     *
      * @param ctx the parse tree
      */
     void exitAgg_operator(AggregationParser.Agg_operatorContext ctx);
+
     /**
      * Enter a parse tree produced by {@link AggregationParser#groupby_expr}.
+     *
      * @param ctx the parse tree
      */
     void enterGroupby_expr(AggregationParser.Groupby_exprContext ctx);
+
     /**
      * Exit a parse tree produced by {@link AggregationParser#groupby_expr}.
+     *
      * @param ctx the parse tree
      */
     void exitGroupby_expr(AggregationParser.Groupby_exprContext ctx);
+
     /**
-     * Enter a parse tree produced by the {@code AggExpressionParens}
-     * labeled alternative in {@link AggregationParser#agg_expr}.
+     * Enter a parse tree produced by the {@code AggExpressionParens} labeled alternative in {@link
+     * AggregationParser#agg_expr}.
+     *
      * @param ctx the parse tree
      */
     void enterAggExpressionParens(AggregationParser.AggExpressionParensContext ctx);
+
     /**
-     * Exit a parse tree produced by the {@code AggExpressionParens}
-     * labeled alternative in {@link AggregationParser#agg_expr}.
+     * Exit a parse tree produced by the {@code AggExpressionParens} labeled alternative in {@link
+     * AggregationParser#agg_expr}.
+     *
      * @param ctx the parse tree
      */
     void exitAggExpressionParens(AggregationParser.AggExpressionParensContext ctx);
+
     /**
-     * Enter a parse tree produced by the {@code AggExpressionNumericEntity}
-     * labeled alternative in {@link AggregationParser#agg_expr}.
+     * Enter a parse tree produced by the {@code AggExpressionNumericEntity} labeled alternative in
+     * {@link AggregationParser#agg_expr}.
+     *
      * @param ctx the parse tree
      */
     void enterAggExpressionNumericEntity(AggregationParser.AggExpressionNumericEntityContext ctx);
+
     /**
-     * Exit a parse tree produced by the {@code AggExpressionNumericEntity}
-     * labeled alternative in {@link AggregationParser#agg_expr}.
+     * Exit a parse tree produced by the {@code AggExpressionNumericEntity} labeled alternative in
+     * {@link AggregationParser#agg_expr}.
+     *
      * @param ctx the parse tree
      */
     void exitAggExpressionNumericEntity(AggregationParser.AggExpressionNumericEntityContext ctx);
+
     /**
-     * Enter a parse tree produced by the {@code NumericConst}
-     * labeled alternative in {@link AggregationParser#numeric_entity}.
+     * Enter a parse tree produced by the {@code NumericConst} labeled alternative in {@link
+     * AggregationParser#numeric_entity}.
+     *
      * @param ctx the parse tree
      */
     void enterNumericConst(AggregationParser.NumericConstContext ctx);
+
     /**
-     * Exit a parse tree produced by the {@code NumericConst}
-     * labeled alternative in {@link AggregationParser#numeric_entity}.
+     * Exit a parse tree produced by the {@code NumericConst} labeled alternative in {@link
+     * AggregationParser#numeric_entity}.
+     *
      * @param ctx the parse tree
      */
     void exitNumericConst(AggregationParser.NumericConstContext ctx);
+
     /**
-     * Enter a parse tree produced by the {@code NumericVariable}
-     * labeled alternative in {@link AggregationParser#numeric_entity}.
+     * Enter a parse tree produced by the {@code NumericVariable} labeled alternative in {@link
+     * AggregationParser#numeric_entity}.
+     *
      * @param ctx the parse tree
      */
     void enterNumericVariable(AggregationParser.NumericVariableContext ctx);
+
     /**
-     * Exit a parse tree produced by the {@code NumericVariable}
-     * labeled alternative in {@link AggregationParser#numeric_entity}.
+     * Exit a parse tree produced by the {@code NumericVariable} labeled alternative in {@link
+     * AggregationParser#numeric_entity}.
+     *
      * @param ctx the parse tree
      */
     void exitNumericVariable(AggregationParser.NumericVariableContext ctx);

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationParser.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationParser.java
@@ -1,56 +1,114 @@
-// Generated from java-escape by ANTLR 4.11.1
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.opensearch.securityanalytics.rules.condition.aggregation;
+
+import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.atn.*;
 import org.antlr.v4.runtime.dfa.DFA;
-import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.misc.*;
 import org.antlr.v4.runtime.tree.*;
+
 import java.util.List;
-import java.util.Iterator;
-import java.util.ArrayList;
 
 @SuppressWarnings({"all", "warnings", "unchecked", "unused", "cast", "CheckReturnValue"})
 public class AggregationParser extends Parser {
-    static { RuntimeMetaData.checkVersion("4.11.1", RuntimeMetaData.VERSION); }
+    static {
+        RuntimeMetaData.checkVersion("4.13.1", RuntimeMetaData.VERSION);
+    }
 
     protected static final DFA[] _decisionToDFA;
-    protected static final PredictionContextCache _sharedContextCache =
-        new PredictionContextCache();
-    public static final int
-        GT=1, GE=2, LT=3, LE=4, EQ=5, COUNT=6, SUM=7, MIN=8, MAX=9, AVG=10, BY=11,
-        LPAREN=12, RPAREN=13, DECIMAL=14, IDENTIFIER=15, WS=16;
-    public static final int
-        RULE_comparison_expr = 0, RULE_comparison_operand = 1, RULE_comp_operator = 2,
-        RULE_agg_operator = 3, RULE_groupby_expr = 4, RULE_agg_expr = 5, RULE_numeric_entity = 6;
+    protected static final PredictionContextCache _sharedContextCache = new PredictionContextCache();
+    public static final int GT = 1,
+            GE = 2,
+            LT = 3,
+            LE = 4,
+            EQ = 5,
+            COUNT = 6,
+            SUM = 7,
+            MIN = 8,
+            MAX = 9,
+            AVG = 10,
+            BY = 11,
+            LPAREN = 12,
+            RPAREN = 13,
+            DECIMAL = 14,
+            IDENTIFIER = 15,
+            WS = 16;
+    public static final int RULE_comparison_expr = 0,
+            RULE_comparison_operand = 1,
+            RULE_comp_operator = 2,
+            RULE_agg_operator = 3,
+            RULE_groupby_expr = 4,
+            RULE_agg_expr = 5,
+            RULE_numeric_entity = 6;
+
     private static String[] makeRuleNames() {
         return new String[] {
-            "comparison_expr", "comparison_operand", "comp_operator", "agg_operator",
-            "groupby_expr", "agg_expr", "numeric_entity"
+            "comparison_expr",
+            "comparison_operand",
+            "comp_operator",
+            "agg_operator",
+            "groupby_expr",
+            "agg_expr",
+            "numeric_entity"
         };
     }
+
     public static final String[] ruleNames = makeRuleNames();
 
     private static String[] makeLiteralNames() {
         return new String[] {
-            null, "'>'", "'>='", "'<'", "'<='", "'=='", "'count'", "'sum'", "'min'",
-            "'max'", "'avg'", "'by'", "'('", "')'"
+            null, "'>'", "'>='", "'<'", "'<='", "'=='", "'count'", "'sum'", "'min'", "'max'", "'avg'",
+            "'by'", "'('", "')'"
         };
     }
+
     private static final String[] _LITERAL_NAMES = makeLiteralNames();
+
     private static String[] makeSymbolicNames() {
         return new String[] {
-            null, "GT", "GE", "LT", "LE", "EQ", "COUNT", "SUM", "MIN", "MAX", "AVG",
-            "BY", "LPAREN", "RPAREN", "DECIMAL", "IDENTIFIER", "WS"
+            null,
+            "GT",
+            "GE",
+            "LT",
+            "LE",
+            "EQ",
+            "COUNT",
+            "SUM",
+            "MIN",
+            "MAX",
+            "AVG",
+            "BY",
+            "LPAREN",
+            "RPAREN",
+            "DECIMAL",
+            "IDENTIFIER",
+            "WS"
         };
     }
+
     private static final String[] _SYMBOLIC_NAMES = makeSymbolicNames();
     public static final Vocabulary VOCABULARY = new VocabularyImpl(_LITERAL_NAMES, _SYMBOLIC_NAMES);
 
     /**
      * @deprecated Use {@link #VOCABULARY} instead.
      */
-    @Deprecated
-    public static final String[] tokenNames;
+    @Deprecated public static final String[] tokenNames;
+
     static {
         tokenNames = new String[_SYMBOLIC_NAMES.length];
         for (int i = 0; i < tokenNames.length; i++) {
@@ -72,26 +130,33 @@ public class AggregationParser extends Parser {
     }
 
     @Override
-
     public Vocabulary getVocabulary() {
         return VOCABULARY;
     }
 
     @Override
-    public String getGrammarFileName() { return "java-escape"; }
+    public String getGrammarFileName() {
+        return "Aggregation.g4";
+    }
 
     @Override
-    public String[] getRuleNames() { return ruleNames; }
+    public String[] getRuleNames() {
+        return ruleNames;
+    }
 
     @Override
-    public String getSerializedATN() { return _serializedATN; }
+    public String getSerializedATN() {
+        return _serializedATN;
+    }
 
     @Override
-    public ATN getATN() { return _ATN; }
+    public ATN getATN() {
+        return _ATN;
+    }
 
     public AggregationParser(TokenStream input) {
         super(input);
-        _interp = new ParserATNSimulator(this,_ATN,_decisionToDFA,_sharedContextCache);
+        _interp = new ParserATNSimulator(this, _ATN, _decisionToDFA, _sharedContextCache);
     }
 
     @SuppressWarnings("CheckReturnValue")
@@ -99,36 +164,54 @@ public class AggregationParser extends Parser {
         public Comparison_exprContext(ParserRuleContext parent, int invokingState) {
             super(parent, invokingState);
         }
-        @Override public int getRuleIndex() { return RULE_comparison_expr; }
 
-        public Comparison_exprContext() { }
+        @Override
+        public int getRuleIndex() {
+            return RULE_comparison_expr;
+        }
+
+        public Comparison_exprContext() {}
+
         public void copyFrom(Comparison_exprContext ctx) {
             super.copyFrom(ctx);
         }
     }
+
     @SuppressWarnings("CheckReturnValue")
     public static class ComparisonExpressionWithOperatorContext extends Comparison_exprContext {
         public List<Comparison_operandContext> comparison_operand() {
             return getRuleContexts(Comparison_operandContext.class);
         }
+
         public Comparison_operandContext comparison_operand(int i) {
-            return getRuleContext(Comparison_operandContext.class,i);
+            return getRuleContext(Comparison_operandContext.class, i);
         }
+
         public Comp_operatorContext comp_operator() {
-            return getRuleContext(Comp_operatorContext.class,0);
+            return getRuleContext(Comp_operatorContext.class, 0);
         }
-        public ComparisonExpressionWithOperatorContext(Comparison_exprContext ctx) { copyFrom(ctx); }
+
+        public ComparisonExpressionWithOperatorContext(Comparison_exprContext ctx) {
+            copyFrom(ctx);
+        }
+
         @Override
         public void enterRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).enterComparisonExpressionWithOperator(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).enterComparisonExpressionWithOperator(this);
         }
+
         @Override
         public void exitRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).exitComparisonExpressionWithOperator(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).exitComparisonExpressionWithOperator(this);
         }
+
         @Override
         public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-            if ( visitor instanceof AggregationVisitor ) return ((AggregationVisitor<? extends T>)visitor).visitComparisonExpressionWithOperator(this);
+            if (visitor instanceof AggregationVisitor)
+                return ((AggregationVisitor<? extends T>) visitor)
+                        .visitComparisonExpressionWithOperator(this);
             else return visitor.visitChildren(this);
         }
     }
@@ -140,20 +223,18 @@ public class AggregationParser extends Parser {
             _localctx = new ComparisonExpressionWithOperatorContext(_localctx);
             enterOuterAlt(_localctx, 1);
             {
-            setState(14);
-            comparison_operand();
-            setState(15);
-            comp_operator();
-            setState(16);
-            comparison_operand();
+                setState(14);
+                comparison_operand();
+                setState(15);
+                comp_operator();
+                setState(16);
+                comparison_operand();
             }
-        }
-        catch (RecognitionException re) {
+        } catch (RecognitionException re) {
             _localctx.exception = re;
             _errHandler.reportError(this, re);
             _errHandler.recover(this, re);
-        }
-        finally {
+        } finally {
             exitRule();
         }
         return _localctx;
@@ -162,23 +243,34 @@ public class AggregationParser extends Parser {
     @SuppressWarnings("CheckReturnValue")
     public static class Comparison_operandContext extends ParserRuleContext {
         public Agg_exprContext agg_expr() {
-            return getRuleContext(Agg_exprContext.class,0);
+            return getRuleContext(Agg_exprContext.class, 0);
         }
+
         public Comparison_operandContext(ParserRuleContext parent, int invokingState) {
             super(parent, invokingState);
         }
-        @Override public int getRuleIndex() { return RULE_comparison_operand; }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_comparison_operand;
+        }
+
         @Override
         public void enterRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).enterComparison_operand(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).enterComparison_operand(this);
         }
+
         @Override
         public void exitRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).exitComparison_operand(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).exitComparison_operand(this);
         }
+
         @Override
         public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-            if ( visitor instanceof AggregationVisitor ) return ((AggregationVisitor<? extends T>)visitor).visitComparison_operand(this);
+            if (visitor instanceof AggregationVisitor)
+                return ((AggregationVisitor<? extends T>) visitor).visitComparison_operand(this);
             else return visitor.visitChildren(this);
         }
     }
@@ -189,16 +281,14 @@ public class AggregationParser extends Parser {
         try {
             enterOuterAlt(_localctx, 1);
             {
-            setState(18);
-            agg_expr();
+                setState(18);
+                agg_expr();
             }
-        }
-        catch (RecognitionException re) {
+        } catch (RecognitionException re) {
             _localctx.exception = re;
             _errHandler.reportError(this, re);
             _errHandler.recover(this, re);
-        }
-        finally {
+        } finally {
             exitRule();
         }
         return _localctx;
@@ -206,26 +296,51 @@ public class AggregationParser extends Parser {
 
     @SuppressWarnings("CheckReturnValue")
     public static class Comp_operatorContext extends ParserRuleContext {
-        public TerminalNode GT() { return getToken(AggregationParser.GT, 0); }
-        public TerminalNode GE() { return getToken(AggregationParser.GE, 0); }
-        public TerminalNode LT() { return getToken(AggregationParser.LT, 0); }
-        public TerminalNode LE() { return getToken(AggregationParser.LE, 0); }
-        public TerminalNode EQ() { return getToken(AggregationParser.EQ, 0); }
+        public TerminalNode GT() {
+            return getToken(AggregationParser.GT, 0);
+        }
+
+        public TerminalNode GE() {
+            return getToken(AggregationParser.GE, 0);
+        }
+
+        public TerminalNode LT() {
+            return getToken(AggregationParser.LT, 0);
+        }
+
+        public TerminalNode LE() {
+            return getToken(AggregationParser.LE, 0);
+        }
+
+        public TerminalNode EQ() {
+            return getToken(AggregationParser.EQ, 0);
+        }
+
         public Comp_operatorContext(ParserRuleContext parent, int invokingState) {
             super(parent, invokingState);
         }
-        @Override public int getRuleIndex() { return RULE_comp_operator; }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_comp_operator;
+        }
+
         @Override
         public void enterRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).enterComp_operator(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).enterComp_operator(this);
         }
+
         @Override
         public void exitRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).exitComp_operator(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).exitComp_operator(this);
         }
+
         @Override
         public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-            if ( visitor instanceof AggregationVisitor ) return ((AggregationVisitor<? extends T>)visitor).visitComp_operator(this);
+            if (visitor instanceof AggregationVisitor)
+                return ((AggregationVisitor<? extends T>) visitor).visitComp_operator(this);
             else return visitor.visitChildren(this);
         }
     }
@@ -237,24 +352,21 @@ public class AggregationParser extends Parser {
         try {
             enterOuterAlt(_localctx, 1);
             {
-            setState(20);
-            _la = _input.LA(1);
-            if ( !(((_la) & ~0x3f) == 0 && ((1L << _la) & 62L) != 0) ) {
-            _errHandler.recoverInline(this);
+                setState(20);
+                _la = _input.LA(1);
+                if (!((((_la) & ~0x3f) == 0 && ((1L << _la) & 62L) != 0))) {
+                    _errHandler.recoverInline(this);
+                } else {
+                    if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                    _errHandler.reportMatch(this);
+                    consume();
+                }
             }
-            else {
-                if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
-                _errHandler.reportMatch(this);
-                consume();
-            }
-            }
-        }
-        catch (RecognitionException re) {
+        } catch (RecognitionException re) {
             _localctx.exception = re;
             _errHandler.reportError(this, re);
             _errHandler.recover(this, re);
-        }
-        finally {
+        } finally {
             exitRule();
         }
         return _localctx;
@@ -262,26 +374,51 @@ public class AggregationParser extends Parser {
 
     @SuppressWarnings("CheckReturnValue")
     public static class Agg_operatorContext extends ParserRuleContext {
-        public TerminalNode COUNT() { return getToken(AggregationParser.COUNT, 0); }
-        public TerminalNode SUM() { return getToken(AggregationParser.SUM, 0); }
-        public TerminalNode MIN() { return getToken(AggregationParser.MIN, 0); }
-        public TerminalNode MAX() { return getToken(AggregationParser.MAX, 0); }
-        public TerminalNode AVG() { return getToken(AggregationParser.AVG, 0); }
+        public TerminalNode COUNT() {
+            return getToken(AggregationParser.COUNT, 0);
+        }
+
+        public TerminalNode SUM() {
+            return getToken(AggregationParser.SUM, 0);
+        }
+
+        public TerminalNode MIN() {
+            return getToken(AggregationParser.MIN, 0);
+        }
+
+        public TerminalNode MAX() {
+            return getToken(AggregationParser.MAX, 0);
+        }
+
+        public TerminalNode AVG() {
+            return getToken(AggregationParser.AVG, 0);
+        }
+
         public Agg_operatorContext(ParserRuleContext parent, int invokingState) {
             super(parent, invokingState);
         }
-        @Override public int getRuleIndex() { return RULE_agg_operator; }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_agg_operator;
+        }
+
         @Override
         public void enterRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).enterAgg_operator(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).enterAgg_operator(this);
         }
+
         @Override
         public void exitRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).exitAgg_operator(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).exitAgg_operator(this);
         }
+
         @Override
         public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-            if ( visitor instanceof AggregationVisitor ) return ((AggregationVisitor<? extends T>)visitor).visitAgg_operator(this);
+            if (visitor instanceof AggregationVisitor)
+                return ((AggregationVisitor<? extends T>) visitor).visitAgg_operator(this);
             else return visitor.visitChildren(this);
         }
     }
@@ -293,24 +430,21 @@ public class AggregationParser extends Parser {
         try {
             enterOuterAlt(_localctx, 1);
             {
-            setState(22);
-            _la = _input.LA(1);
-            if ( !(((_la) & ~0x3f) == 0 && ((1L << _la) & 1984L) != 0) ) {
-            _errHandler.recoverInline(this);
+                setState(22);
+                _la = _input.LA(1);
+                if (!((((_la) & ~0x3f) == 0 && ((1L << _la) & 1984L) != 0))) {
+                    _errHandler.recoverInline(this);
+                } else {
+                    if (_input.LA(1) == Token.EOF) matchedEOF = true;
+                    _errHandler.reportMatch(this);
+                    consume();
+                }
             }
-            else {
-                if ( _input.LA(1)==Token.EOF ) matchedEOF = true;
-                _errHandler.reportMatch(this);
-                consume();
-            }
-            }
-        }
-        catch (RecognitionException re) {
+        } catch (RecognitionException re) {
             _localctx.exception = re;
             _errHandler.reportError(this, re);
             _errHandler.recover(this, re);
-        }
-        finally {
+        } finally {
             exitRule();
         }
         return _localctx;
@@ -318,22 +452,35 @@ public class AggregationParser extends Parser {
 
     @SuppressWarnings("CheckReturnValue")
     public static class Groupby_exprContext extends ParserRuleContext {
-        public TerminalNode IDENTIFIER() { return getToken(AggregationParser.IDENTIFIER, 0); }
+        public TerminalNode IDENTIFIER() {
+            return getToken(AggregationParser.IDENTIFIER, 0);
+        }
+
         public Groupby_exprContext(ParserRuleContext parent, int invokingState) {
             super(parent, invokingState);
         }
-        @Override public int getRuleIndex() { return RULE_groupby_expr; }
+
+        @Override
+        public int getRuleIndex() {
+            return RULE_groupby_expr;
+        }
+
         @Override
         public void enterRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).enterGroupby_expr(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).enterGroupby_expr(this);
         }
+
         @Override
         public void exitRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).exitGroupby_expr(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).exitGroupby_expr(this);
         }
+
         @Override
         public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-            if ( visitor instanceof AggregationVisitor ) return ((AggregationVisitor<? extends T>)visitor).visitGroupby_expr(this);
+            if (visitor instanceof AggregationVisitor)
+                return ((AggregationVisitor<? extends T>) visitor).visitGroupby_expr(this);
             else return visitor.visitChildren(this);
         }
     }
@@ -344,16 +491,14 @@ public class AggregationParser extends Parser {
         try {
             enterOuterAlt(_localctx, 1);
             {
-            setState(24);
-            match(IDENTIFIER);
+                setState(24);
+                match(IDENTIFIER);
             }
-        }
-        catch (RecognitionException re) {
+        } catch (RecognitionException re) {
             _localctx.exception = re;
             _errHandler.reportError(this, re);
             _errHandler.recover(this, re);
-        }
-        finally {
+        } finally {
             exitRule();
         }
         return _localctx;
@@ -364,59 +509,95 @@ public class AggregationParser extends Parser {
         public Agg_exprContext(ParserRuleContext parent, int invokingState) {
             super(parent, invokingState);
         }
-        @Override public int getRuleIndex() { return RULE_agg_expr; }
 
-        public Agg_exprContext() { }
+        @Override
+        public int getRuleIndex() {
+            return RULE_agg_expr;
+        }
+
+        public Agg_exprContext() {}
+
         public void copyFrom(Agg_exprContext ctx) {
             super.copyFrom(ctx);
         }
     }
+
     @SuppressWarnings("CheckReturnValue")
     public static class AggExpressionNumericEntityContext extends Agg_exprContext {
         public Numeric_entityContext numeric_entity() {
-            return getRuleContext(Numeric_entityContext.class,0);
+            return getRuleContext(Numeric_entityContext.class, 0);
         }
-        public AggExpressionNumericEntityContext(Agg_exprContext ctx) { copyFrom(ctx); }
+
+        public AggExpressionNumericEntityContext(Agg_exprContext ctx) {
+            copyFrom(ctx);
+        }
+
         @Override
         public void enterRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).enterAggExpressionNumericEntity(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).enterAggExpressionNumericEntity(this);
         }
+
         @Override
         public void exitRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).exitAggExpressionNumericEntity(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).exitAggExpressionNumericEntity(this);
         }
+
         @Override
         public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-            if ( visitor instanceof AggregationVisitor ) return ((AggregationVisitor<? extends T>)visitor).visitAggExpressionNumericEntity(this);
+            if (visitor instanceof AggregationVisitor)
+                return ((AggregationVisitor<? extends T>) visitor).visitAggExpressionNumericEntity(this);
             else return visitor.visitChildren(this);
         }
     }
+
     @SuppressWarnings("CheckReturnValue")
     public static class AggExpressionParensContext extends Agg_exprContext {
         public Agg_operatorContext agg_operator() {
-            return getRuleContext(Agg_operatorContext.class,0);
+            return getRuleContext(Agg_operatorContext.class, 0);
         }
-        public TerminalNode LPAREN() { return getToken(AggregationParser.LPAREN, 0); }
+
+        public TerminalNode LPAREN() {
+            return getToken(AggregationParser.LPAREN, 0);
+        }
+
         public Agg_exprContext agg_expr() {
-            return getRuleContext(Agg_exprContext.class,0);
+            return getRuleContext(Agg_exprContext.class, 0);
         }
-        public TerminalNode RPAREN() { return getToken(AggregationParser.RPAREN, 0); }
-        public TerminalNode BY() { return getToken(AggregationParser.BY, 0); }
+
+        public TerminalNode RPAREN() {
+            return getToken(AggregationParser.RPAREN, 0);
+        }
+
+        public TerminalNode BY() {
+            return getToken(AggregationParser.BY, 0);
+        }
+
         public Groupby_exprContext groupby_expr() {
-            return getRuleContext(Groupby_exprContext.class,0);
+            return getRuleContext(Groupby_exprContext.class, 0);
         }
-        public AggExpressionParensContext(Agg_exprContext ctx) { copyFrom(ctx); }
+
+        public AggExpressionParensContext(Agg_exprContext ctx) {
+            copyFrom(ctx);
+        }
+
         @Override
         public void enterRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).enterAggExpressionParens(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).enterAggExpressionParens(this);
         }
+
         @Override
         public void exitRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).exitAggExpressionParens(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).exitAggExpressionParens(this);
         }
+
         @Override
         public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-            if ( visitor instanceof AggregationVisitor ) return ((AggregationVisitor<? extends T>)visitor).visitAggExpressionParens(this);
+            if (visitor instanceof AggregationVisitor)
+                return ((AggregationVisitor<? extends T>) visitor).visitAggExpressionParens(this);
             else return visitor.visitChildren(this);
         }
     }
@@ -429,63 +610,60 @@ public class AggregationParser extends Parser {
             setState(37);
             _errHandler.sync(this);
             switch (_input.LA(1)) {
-            case COUNT:
-            case SUM:
-            case MIN:
-            case MAX:
-            case AVG:
-                _localctx = new AggExpressionParensContext(_localctx);
-                enterOuterAlt(_localctx, 1);
-                {
-                setState(26);
-                agg_operator();
-                setState(27);
-                match(LPAREN);
-                setState(28);
-                agg_expr();
-                setState(29);
-                match(RPAREN);
-                setState(31);
-                _errHandler.sync(this);
-                _la = _input.LA(1);
-                if (_la==BY) {
+                case COUNT:
+                case SUM:
+                case MIN:
+                case MAX:
+                case AVG:
+                    _localctx = new AggExpressionParensContext(_localctx);
+                    enterOuterAlt(_localctx, 1);
                     {
-                    setState(30);
-                    match(BY);
-                    }
-                }
+                        setState(26);
+                        agg_operator();
+                        setState(27);
+                        match(LPAREN);
+                        setState(28);
+                        agg_expr();
+                        setState(29);
+                        match(RPAREN);
+                        setState(31);
+                        _errHandler.sync(this);
+                        _la = _input.LA(1);
+                        if (_la == BY) {
+                            {
+                                setState(30);
+                                match(BY);
+                            }
+                        }
 
-                setState(34);
-                _errHandler.sync(this);
-                _la = _input.LA(1);
-                if (_la==IDENTIFIER) {
+                        setState(34);
+                        _errHandler.sync(this);
+                        _la = _input.LA(1);
+                        if (_la == IDENTIFIER) {
+                            {
+                                setState(33);
+                                groupby_expr();
+                            }
+                        }
+                    }
+                    break;
+                case DECIMAL:
+                case IDENTIFIER:
+                    _localctx = new AggExpressionNumericEntityContext(_localctx);
+                    enterOuterAlt(_localctx, 2);
                     {
-                    setState(33);
-                    groupby_expr();
+                        setState(36);
+                        numeric_entity();
                     }
-                }
-
-                }
-                break;
-            case DECIMAL:
-            case IDENTIFIER:
-                _localctx = new AggExpressionNumericEntityContext(_localctx);
-                enterOuterAlt(_localctx, 2);
-                {
-                setState(36);
-                numeric_entity();
-                }
-                break;
-            default:
-                throw new NoViableAltException(this);
+                    break;
+                default:
+                    throw new NoViableAltException(this);
             }
-        }
-        catch (RecognitionException re) {
+        } catch (RecognitionException re) {
             _localctx.exception = re;
             _errHandler.reportError(this, re);
             _errHandler.recover(this, re);
-        }
-        finally {
+        } finally {
             exitRule();
         }
         return _localctx;
@@ -496,46 +674,75 @@ public class AggregationParser extends Parser {
         public Numeric_entityContext(ParserRuleContext parent, int invokingState) {
             super(parent, invokingState);
         }
-        @Override public int getRuleIndex() { return RULE_numeric_entity; }
 
-        public Numeric_entityContext() { }
+        @Override
+        public int getRuleIndex() {
+            return RULE_numeric_entity;
+        }
+
+        public Numeric_entityContext() {}
+
         public void copyFrom(Numeric_entityContext ctx) {
             super.copyFrom(ctx);
         }
     }
+
     @SuppressWarnings("CheckReturnValue")
     public static class NumericConstContext extends Numeric_entityContext {
-        public TerminalNode DECIMAL() { return getToken(AggregationParser.DECIMAL, 0); }
-        public NumericConstContext(Numeric_entityContext ctx) { copyFrom(ctx); }
+        public TerminalNode DECIMAL() {
+            return getToken(AggregationParser.DECIMAL, 0);
+        }
+
+        public NumericConstContext(Numeric_entityContext ctx) {
+            copyFrom(ctx);
+        }
+
         @Override
         public void enterRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).enterNumericConst(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).enterNumericConst(this);
         }
+
         @Override
         public void exitRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).exitNumericConst(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).exitNumericConst(this);
         }
+
         @Override
         public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-            if ( visitor instanceof AggregationVisitor ) return ((AggregationVisitor<? extends T>)visitor).visitNumericConst(this);
+            if (visitor instanceof AggregationVisitor)
+                return ((AggregationVisitor<? extends T>) visitor).visitNumericConst(this);
             else return visitor.visitChildren(this);
         }
     }
+
     @SuppressWarnings("CheckReturnValue")
     public static class NumericVariableContext extends Numeric_entityContext {
-        public TerminalNode IDENTIFIER() { return getToken(AggregationParser.IDENTIFIER, 0); }
-        public NumericVariableContext(Numeric_entityContext ctx) { copyFrom(ctx); }
+        public TerminalNode IDENTIFIER() {
+            return getToken(AggregationParser.IDENTIFIER, 0);
+        }
+
+        public NumericVariableContext(Numeric_entityContext ctx) {
+            copyFrom(ctx);
+        }
+
         @Override
         public void enterRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).enterNumericVariable(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).enterNumericVariable(this);
         }
+
         @Override
         public void exitRule(ParseTreeListener listener) {
-            if ( listener instanceof AggregationListener ) ((AggregationListener)listener).exitNumericVariable(this);
+            if (listener instanceof AggregationListener)
+                ((AggregationListener) listener).exitNumericVariable(this);
         }
+
         @Override
         public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-            if ( visitor instanceof AggregationVisitor ) return ((AggregationVisitor<? extends T>)visitor).visitNumericVariable(this);
+            if (visitor instanceof AggregationVisitor)
+                return ((AggregationVisitor<? extends T>) visitor).visitNumericVariable(this);
             else return visitor.visitChildren(this);
         }
     }
@@ -547,67 +754,65 @@ public class AggregationParser extends Parser {
             setState(41);
             _errHandler.sync(this);
             switch (_input.LA(1)) {
-            case DECIMAL:
-                _localctx = new NumericConstContext(_localctx);
-                enterOuterAlt(_localctx, 1);
-                {
-                setState(39);
-                match(DECIMAL);
-                }
-                break;
-            case IDENTIFIER:
-                _localctx = new NumericVariableContext(_localctx);
-                enterOuterAlt(_localctx, 2);
-                {
-                setState(40);
-                match(IDENTIFIER);
-                }
-                break;
-            default:
-                throw new NoViableAltException(this);
+                case DECIMAL:
+                    _localctx = new NumericConstContext(_localctx);
+                    enterOuterAlt(_localctx, 1);
+                    {
+                        setState(39);
+                        match(DECIMAL);
+                    }
+                    break;
+                case IDENTIFIER:
+                    _localctx = new NumericVariableContext(_localctx);
+                    enterOuterAlt(_localctx, 2);
+                    {
+                        setState(40);
+                        match(IDENTIFIER);
+                    }
+                    break;
+                default:
+                    throw new NoViableAltException(this);
             }
-        }
-        catch (RecognitionException re) {
+        } catch (RecognitionException re) {
             _localctx.exception = re;
             _errHandler.reportError(this, re);
             _errHandler.recover(this, re);
-        }
-        finally {
+        } finally {
             exitRule();
         }
         return _localctx;
     }
 
     public static final String _serializedATN =
-        "\u0004\u0001\u0010,\u0002\u0000\u0007\u0000\u0002\u0001\u0007\u0001\u0002"+
-        "\u0002\u0007\u0002\u0002\u0003\u0007\u0003\u0002\u0004\u0007\u0004\u0002"+
-        "\u0005\u0007\u0005\u0002\u0006\u0007\u0006\u0001\u0000\u0001\u0000\u0001"+
-        "\u0000\u0001\u0000\u0001\u0001\u0001\u0001\u0001\u0002\u0001\u0002\u0001"+
-        "\u0003\u0001\u0003\u0001\u0004\u0001\u0004\u0001\u0005\u0001\u0005\u0001"+
-        "\u0005\u0001\u0005\u0001\u0005\u0003\u0005 \b\u0005\u0001\u0005\u0003"+
-        "\u0005#\b\u0005\u0001\u0005\u0003\u0005&\b\u0005\u0001\u0006\u0001\u0006"+
-        "\u0003\u0006*\b\u0006\u0001\u0006\u0000\u0000\u0007\u0000\u0002\u0004"+
-        "\u0006\b\n\f\u0000\u0002\u0001\u0000\u0001\u0005\u0001\u0000\u0006\n("+
-        "\u0000\u000e\u0001\u0000\u0000\u0000\u0002\u0012\u0001\u0000\u0000\u0000"+
-        "\u0004\u0014\u0001\u0000\u0000\u0000\u0006\u0016\u0001\u0000\u0000\u0000"+
-        "\b\u0018\u0001\u0000\u0000\u0000\n%\u0001\u0000\u0000\u0000\f)\u0001\u0000"+
-        "\u0000\u0000\u000e\u000f\u0003\u0002\u0001\u0000\u000f\u0010\u0003\u0004"+
-        "\u0002\u0000\u0010\u0011\u0003\u0002\u0001\u0000\u0011\u0001\u0001\u0000"+
-        "\u0000\u0000\u0012\u0013\u0003\n\u0005\u0000\u0013\u0003\u0001\u0000\u0000"+
-        "\u0000\u0014\u0015\u0007\u0000\u0000\u0000\u0015\u0005\u0001\u0000\u0000"+
-        "\u0000\u0016\u0017\u0007\u0001\u0000\u0000\u0017\u0007\u0001\u0000\u0000"+
-        "\u0000\u0018\u0019\u0005\u000f\u0000\u0000\u0019\t\u0001\u0000\u0000\u0000"+
-        "\u001a\u001b\u0003\u0006\u0003\u0000\u001b\u001c\u0005\f\u0000\u0000\u001c"+
-        "\u001d\u0003\n\u0005\u0000\u001d\u001f\u0005\r\u0000\u0000\u001e \u0005"+
-        "\u000b\u0000\u0000\u001f\u001e\u0001\u0000\u0000\u0000\u001f \u0001\u0000"+
-        "\u0000\u0000 \"\u0001\u0000\u0000\u0000!#\u0003\b\u0004\u0000\"!\u0001"+
-        "\u0000\u0000\u0000\"#\u0001\u0000\u0000\u0000#&\u0001\u0000\u0000\u0000"+
-        "$&\u0003\f\u0006\u0000%\u001a\u0001\u0000\u0000\u0000%$\u0001\u0000\u0000"+
-        "\u0000&\u000b\u0001\u0000\u0000\u0000\'*\u0005\u000e\u0000\u0000(*\u0005"+
-        "\u000f\u0000\u0000)\'\u0001\u0000\u0000\u0000)(\u0001\u0000\u0000\u0000"+
-        "*\r\u0001\u0000\u0000\u0000\u0004\u001f\"%)";
-    public static final ATN _ATN =
-        new ATNDeserializer().deserialize(_serializedATN.toCharArray());
+            "\u0004\u0001\u0010,\u0002\u0000\u0007\u0000\u0002\u0001\u0007\u0001\u0002"
+                    + "\u0002\u0007\u0002\u0002\u0003\u0007\u0003\u0002\u0004\u0007\u0004\u0002"
+                    + "\u0005\u0007\u0005\u0002\u0006\u0007\u0006\u0001\u0000\u0001\u0000\u0001"
+                    + "\u0000\u0001\u0000\u0001\u0001\u0001\u0001\u0001\u0002\u0001\u0002\u0001"
+                    + "\u0003\u0001\u0003\u0001\u0004\u0001\u0004\u0001\u0005\u0001\u0005\u0001"
+                    + "\u0005\u0001\u0005\u0001\u0005\u0003\u0005 \b\u0005\u0001\u0005\u0003"
+                    + "\u0005#\b\u0005\u0001\u0005\u0003\u0005&\b\u0005\u0001\u0006\u0001\u0006"
+                    + "\u0003\u0006*\b\u0006\u0001\u0006\u0000\u0000\u0007\u0000\u0002\u0004"
+                    + "\u0006\b\n\f\u0000\u0002\u0001\u0000\u0001\u0005\u0001\u0000\u0006\n("
+                    + "\u0000\u000e\u0001\u0000\u0000\u0000\u0002\u0012\u0001\u0000\u0000\u0000"
+                    + "\u0004\u0014\u0001\u0000\u0000\u0000\u0006\u0016\u0001\u0000\u0000\u0000"
+                    + "\b\u0018\u0001\u0000\u0000\u0000\n%\u0001\u0000\u0000\u0000\f)\u0001\u0000"
+                    + "\u0000\u0000\u000e\u000f\u0003\u0002\u0001\u0000\u000f\u0010\u0003\u0004"
+                    + "\u0002\u0000\u0010\u0011\u0003\u0002\u0001\u0000\u0011\u0001\u0001\u0000"
+                    + "\u0000\u0000\u0012\u0013\u0003\n\u0005\u0000\u0013\u0003\u0001\u0000\u0000"
+                    + "\u0000\u0014\u0015\u0007\u0000\u0000\u0000\u0015\u0005\u0001\u0000\u0000"
+                    + "\u0000\u0016\u0017\u0007\u0001\u0000\u0000\u0017\u0007\u0001\u0000\u0000"
+                    + "\u0000\u0018\u0019\u0005\u000f\u0000\u0000\u0019\t\u0001\u0000\u0000\u0000"
+                    + "\u001a\u001b\u0003\u0006\u0003\u0000\u001b\u001c\u0005\f\u0000\u0000\u001c"
+                    + "\u001d\u0003\n\u0005\u0000\u001d\u001f\u0005\r\u0000\u0000\u001e \u0005"
+                    + "\u000b\u0000\u0000\u001f\u001e\u0001\u0000\u0000\u0000\u001f \u0001\u0000"
+                    + "\u0000\u0000 \"\u0001\u0000\u0000\u0000!#\u0003\b\u0004\u0000\"!\u0001"
+                    + "\u0000\u0000\u0000\"#\u0001\u0000\u0000\u0000#&\u0001\u0000\u0000\u0000"
+                    + "$&\u0003\f\u0006\u0000%\u001a\u0001\u0000\u0000\u0000%$\u0001\u0000\u0000"
+                    + "\u0000&\u000b\u0001\u0000\u0000\u0000\'*\u0005\u000e\u0000\u0000(*\u0005"
+                    + "\u000f\u0000\u0000)\'\u0001\u0000\u0000\u0000)(\u0001\u0000\u0000\u0000"
+                    + "*\r\u0001\u0000\u0000\u0000\u0004\u001f\"%)";
+    public static final ATN _ATN = new ATNDeserializer().deserialize(_serializedATN.toCharArray());
+
     static {
         _decisionToDFA = new DFA[_ATN.getNumberOfDecisions()];
         for (int i = 0; i < _ATN.getNumberOfDecisions(); i++) {

--- a/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationVisitor.java
+++ b/src/main/generated/org/opensearch/securityanalytics/rules/condition/aggregation/AggregationVisitor.java
@@ -1,70 +1,104 @@
-// Generated from java-escape by ANTLR 4.11.1
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.opensearch.securityanalytics.rules.condition.aggregation;
+
 import org.antlr.v4.runtime.tree.ParseTreeVisitor;
 
 /**
- * This interface defines a complete generic visitor for a parse tree produced
- * by {@link AggregationParser}.
+ * This interface defines a complete generic visitor for a parse tree produced by {@link
+ * AggregationParser}.
  *
- * @param <T> The return type of the visit operation. Use {@link Void} for
- * operations with no return type.
+ * @param <T> The return type of the visit operation. Use {@link Void} for operations with no return
+ *     type.
  */
 public interface AggregationVisitor<T> extends ParseTreeVisitor<T> {
     /**
-     * Visit a parse tree produced by the {@code ComparisonExpressionWithOperator}
-     * labeled alternative in {@link AggregationParser#comparison_expr}.
+     * Visit a parse tree produced by the {@code ComparisonExpressionWithOperator} labeled alternative
+     * in {@link AggregationParser#comparison_expr}.
+     *
      * @param ctx the parse tree
      * @return the visitor result
      */
-    T visitComparisonExpressionWithOperator(AggregationParser.ComparisonExpressionWithOperatorContext ctx);
+    T visitComparisonExpressionWithOperator(
+            AggregationParser.ComparisonExpressionWithOperatorContext ctx);
+
     /**
      * Visit a parse tree produced by {@link AggregationParser#comparison_operand}.
+     *
      * @param ctx the parse tree
      * @return the visitor result
      */
     T visitComparison_operand(AggregationParser.Comparison_operandContext ctx);
+
     /**
      * Visit a parse tree produced by {@link AggregationParser#comp_operator}.
+     *
      * @param ctx the parse tree
      * @return the visitor result
      */
     T visitComp_operator(AggregationParser.Comp_operatorContext ctx);
+
     /**
      * Visit a parse tree produced by {@link AggregationParser#agg_operator}.
+     *
      * @param ctx the parse tree
      * @return the visitor result
      */
     T visitAgg_operator(AggregationParser.Agg_operatorContext ctx);
+
     /**
      * Visit a parse tree produced by {@link AggregationParser#groupby_expr}.
+     *
      * @param ctx the parse tree
      * @return the visitor result
      */
     T visitGroupby_expr(AggregationParser.Groupby_exprContext ctx);
+
     /**
-     * Visit a parse tree produced by the {@code AggExpressionParens}
-     * labeled alternative in {@link AggregationParser#agg_expr}.
+     * Visit a parse tree produced by the {@code AggExpressionParens} labeled alternative in {@link
+     * AggregationParser#agg_expr}.
+     *
      * @param ctx the parse tree
      * @return the visitor result
      */
     T visitAggExpressionParens(AggregationParser.AggExpressionParensContext ctx);
+
     /**
-     * Visit a parse tree produced by the {@code AggExpressionNumericEntity}
-     * labeled alternative in {@link AggregationParser#agg_expr}.
+     * Visit a parse tree produced by the {@code AggExpressionNumericEntity} labeled alternative in
+     * {@link AggregationParser#agg_expr}.
+     *
      * @param ctx the parse tree
      * @return the visitor result
      */
     T visitAggExpressionNumericEntity(AggregationParser.AggExpressionNumericEntityContext ctx);
+
     /**
-     * Visit a parse tree produced by the {@code NumericConst}
-     * labeled alternative in {@link AggregationParser#numeric_entity}.
+     * Visit a parse tree produced by the {@code NumericConst} labeled alternative in {@link
+     * AggregationParser#numeric_entity}.
+     *
      * @param ctx the parse tree
      * @return the visitor result
      */
     T visitNumericConst(AggregationParser.NumericConstContext ctx);
+
     /**
-     * Visit a parse tree produced by the {@code NumericVariable}
-     * labeled alternative in {@link AggregationParser#numeric_entity}.
+     * Visit a parse tree produced by the {@code NumericVariable} labeled alternative in {@link
+     * AggregationParser#numeric_entity}.
+     *
      * @param ctx the parse tree
      * @return the visitor result
      */


### PR DESCRIPTION
### Description
This PR aligns ANTLR dependencies and generated parsers to 4.13.1, eliminating startup ANTLR version mismatch warnings.

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1583

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
