### PR TITLE
Fix error with internal caller mechanism

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/action/DeleteDetectorRequest.java
+++ b/src/main/java/org/opensearch/securityanalytics/action/DeleteDetectorRequest.java
@@ -1,6 +1,18 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 package org.opensearch.securityanalytics.action;
 
@@ -17,15 +29,26 @@ public class DeleteDetectorRequest extends ActionRequest {
     private String detectorId;
     private WriteRequest.RefreshPolicy refreshPolicy;
 
+    /**
+     * When true the request originates from an internal plugin (e.g. Content Manager) and should
+     * bypass the standard-detector deletion restriction.
+     */
+    private final boolean internalCaller;
+
     public DeleteDetectorRequest(String detectorId, WriteRequest.RefreshPolicy refreshPolicy) {
+        this(detectorId, refreshPolicy, false);
+    }
+
+    public DeleteDetectorRequest(
+            String detectorId, WriteRequest.RefreshPolicy refreshPolicy, boolean internalCaller) {
         super();
         this.detectorId = detectorId;
         this.refreshPolicy = refreshPolicy;
+        this.internalCaller = internalCaller;
     }
 
     public DeleteDetectorRequest(StreamInput sin) throws IOException {
-        this(sin.readString(),
-             WriteRequest.RefreshPolicy.readFrom(sin));
+        this(sin.readString(), WriteRequest.RefreshPolicy.readFrom(sin), sin.readBoolean());
     }
 
     @Override
@@ -37,6 +60,7 @@ public class DeleteDetectorRequest extends ActionRequest {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(detectorId);
         refreshPolicy.writeTo(out);
+        out.writeBoolean(internalCaller);
     }
 
     public String getDetectorId() {
@@ -45,5 +69,9 @@ public class DeleteDetectorRequest extends ActionRequest {
 
     public WriteRequest.RefreshPolicy getRefreshPolicy() {
         return refreshPolicy;
+    }
+
+    public boolean isInternalCaller() {
+        return internalCaller;
     }
 }

--- a/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/TransportDeleteDetectorAction.java
@@ -77,12 +77,6 @@ public class TransportDeleteDetectorAction
 
     private static final Logger log = LogManager.getLogger(TransportDeleteDetectorAction.class);
 
-    /**
-     * Thread context header used by internal Wazuh plugin callers (e.g. Content Manager) to bypass
-     * standard-detector deletion restrictions.
-     */
-    public static final String WAZUH_INTERNAL_CALLER_HEADER = "_wazuh_internal_caller";
-
     private static final List<ThrowableCheckingPredicates>
             ACCEPTABLE_ENTITY_MISSING_THROWABLE_MATCHERS =
                     List.of(
@@ -148,10 +142,7 @@ public class TransportDeleteDetectorAction
     @Override
     protected void doExecute(
             Task task, DeleteDetectorRequest request, ActionListener<DeleteDetectorResponse> listener) {
-        // Capture before thread context is stashed in start()
-        boolean isInternalCaller =
-                "content-manager"
-                        .equals(this.threadPool.getThreadContext().getHeader(WAZUH_INTERNAL_CALLER_HEADER));
+        boolean isInternalCaller = request.isInternalCaller();
         AsyncDeleteDetectorAction asyncAction =
                 new AsyncDeleteDetectorAction(task, request, listener, detectorIndices, isInternalCaller);
         asyncAction.start();
@@ -260,62 +251,73 @@ public class TransportDeleteDetectorAction
             StepListener<AcknowledgedResponse> onDeleteWorkflowStep = new StepListener<>();
             // 1. Delete the workflow if the workflow is supported
             deleteWorkflow(detector, onDeleteWorkflowStep);
-            onDeleteWorkflowStep.whenComplete(acknowledgedResponse -> {
-                List<String> monitorIds = detector.getMonitorIds();
-                
-                // A detector with 0 rules will have 0 monitors to delete. Skipping monitor deletion steps.
-                if (monitorIds == null || monitorIds.isEmpty()) {
-                    deleteDetectorFromConfig(detector.getId(), request.getRefreshPolicy());
-                    return;
-                }
-                
-                ActionListener<DeleteMonitorResponse> deletesListener = new GroupedActionListener<>(new ActionListener<>() {
-                    @Override
-                    public void onResponse(Collection<DeleteMonitorResponse> responses) {
-                        SetOnce<RestStatus> errorStatusSupplier = new SetOnce<>();
-                        if (responses.stream().filter(response -> {
-                            if (response.getStatus() != RestStatus.OK) {
-                                log.error(
-                                    "Detector not being deleted because monitor [{}] could not be deleted. Status [{}]",
-                                    response.getId(),
-                                    response.getStatus()
-                                );
-                                errorStatusSupplier.trySet(response.getStatus());
-                                return true;
-                            }
-                            return false;
-                        }).count() > 0) {
-                            onFailures(
-                                new OpenSearchStatusException(
-                                    "Monitor associated with detected could not be deleted",
-                                    errorStatusSupplier.get()
-                                )
-                            );
-                        }
-                        deleteDetectorFromConfig(detector.getId(), request.getRefreshPolicy());
-                    }
+            onDeleteWorkflowStep.whenComplete(
+                    acknowledgedResponse -> {
+                        List<String> monitorIds = detector.getMonitorIds();
 
-                    @Override
-                    public void onFailure(Exception e) {
-                        if (exceptionChecker.doesGroupedActionListenerExceptionMatch(e, ACCEPTABLE_ENTITY_MISSING_THROWABLE_MATCHERS)) {
-                            logAcceptableEntityMissingException(e, detector.getId());
+                        // A detector with 0 rules will have 0 monitors to delete. Skipping monitor deletion
+                        // steps.
+                        if (monitorIds == null || monitorIds.isEmpty()) {
                             deleteDetectorFromConfig(detector.getId(), request.getRefreshPolicy());
-                        } else {
-                            log.error(String.format(Locale.ROOT, "Failed to delete detector %s", detector.getId()), e.getMessage());
-                            if (counter.compareAndSet(false, true)) {
-                                finishHim(null, e);
-                            }
+                            return;
                         }
-                    }
-                }, monitorIds.size());
-                for (String monitorId : monitorIds) {
-                    deleteAlertingMonitor(monitorId, request.getRefreshPolicy(), deletesListener);
-                }
-            }, e -> {
-                if (counter.compareAndSet(false, true)) {
-                    finishHim(null, e);
-                }
-            });
+
+                        ActionListener<DeleteMonitorResponse> deletesListener =
+                                new GroupedActionListener<>(
+                                        new ActionListener<>() {
+                                            @Override
+                                            public void onResponse(Collection<DeleteMonitorResponse> responses) {
+                                                SetOnce<RestStatus> errorStatusSupplier = new SetOnce<>();
+                                                if (responses.stream()
+                                                                .filter(
+                                                                        response -> {
+                                                                            if (response.getStatus() != RestStatus.OK) {
+                                                                                log.error(
+                                                                                        "Detector not being deleted because monitor [{}] could not be deleted. Status [{}]",
+                                                                                        response.getId(),
+                                                                                        response.getStatus());
+                                                                                errorStatusSupplier.trySet(response.getStatus());
+                                                                                return true;
+                                                                            }
+                                                                            return false;
+                                                                        })
+                                                                .count()
+                                                        > 0) {
+                                                    onFailures(
+                                                            new OpenSearchStatusException(
+                                                                    "Monitor associated with detected could not be deleted",
+                                                                    errorStatusSupplier.get()));
+                                                }
+                                                deleteDetectorFromConfig(detector.getId(), request.getRefreshPolicy());
+                                            }
+
+                                            @Override
+                                            public void onFailure(Exception e) {
+                                                if (exceptionChecker.doesGroupedActionListenerExceptionMatch(
+                                                        e, ACCEPTABLE_ENTITY_MISSING_THROWABLE_MATCHERS)) {
+                                                    logAcceptableEntityMissingException(e, detector.getId());
+                                                    deleteDetectorFromConfig(detector.getId(), request.getRefreshPolicy());
+                                                } else {
+                                                    log.error(
+                                                            String.format(
+                                                                    Locale.ROOT, "Failed to delete detector %s", detector.getId()),
+                                                            e.getMessage());
+                                                    if (counter.compareAndSet(false, true)) {
+                                                        finishHim(null, e);
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        monitorIds.size());
+                        for (String monitorId : monitorIds) {
+                            deleteAlertingMonitor(monitorId, request.getRefreshPolicy(), deletesListener);
+                        }
+                    },
+                    e -> {
+                        if (counter.compareAndSet(false, true)) {
+                            finishHim(null, e);
+                        }
+                    });
         }
 
         private void deleteWorkflow(

--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportDeleteDetectorAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportDeleteDetectorAction.java
@@ -33,8 +33,6 @@ import com.wazuh.securityanalytics.action.WDeleteDetectorAction;
 import com.wazuh.securityanalytics.action.WDeleteDetectorRequest;
 import com.wazuh.securityanalytics.action.WDeleteDetectorResponse;
 
-import static org.opensearch.securityanalytics.transport.TransportDeleteDetectorAction.WAZUH_INTERNAL_CALLER_HEADER;
-
 public class WTransportDeleteDetectorAction
         extends HandledTransportAction<WDeleteDetectorRequest, WDeleteDetectorResponse>
         implements SecureTransportAction {
@@ -52,17 +50,7 @@ public class WTransportDeleteDetectorAction
     protected void doExecute(
             Task task, WDeleteDetectorRequest request, ActionListener<WDeleteDetectorResponse> listener) {
         DeleteDetectorRequest internalRequest =
-                new DeleteDetectorRequest(request.getDetectorId(), request.getRefreshPolicy());
-
-        // Mark this request as coming from the Content Manager so that
-        // TransportDeleteDetectorAction allows deletion of standard detectors.
-        if (this.client.threadPool().getThreadContext().getHeader(WAZUH_INTERNAL_CALLER_HEADER)
-                == null) {
-            this.client
-                    .threadPool()
-                    .getThreadContext()
-                    .putHeader(WAZUH_INTERNAL_CALLER_HEADER, "content-manager");
-        }
+                new DeleteDetectorRequest(request.getDetectorId(), request.getRefreshPolicy(), true);
 
         this.client.execute(
                 DeleteDetectorAction.INSTANCE,

--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportDeleteSpaceResourcesAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportDeleteSpaceResourcesAction.java
@@ -214,7 +214,7 @@ public class WTransportDeleteSpaceResourcesAction
         String id = iterator.next();
         this.client.execute(
                 DeleteDetectorAction.INSTANCE,
-                new DeleteDetectorRequest(id, refreshPolicy),
+                new DeleteDetectorRequest(id, refreshPolicy, true),
                 ActionListener.wrap(
                         response -> {
                             deleted.incrementAndGet();


### PR DESCRIPTION
### Description
This PR fixes an error with the internal caller mechanism, this mechanism was changed during https://github.com/wazuh/wazuh-indexer/issues/1589 and remained with a bug that when a changed consumer was executed the detectors could not be deleted, this has been fixed adapting the mechanism

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-plugins/issues/1253


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
