### PR TITLE
Fix SAP integration _id collision across spaces during promotion

### DIFF
--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexIntegrationAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexIntegrationAction.java
@@ -107,8 +107,12 @@ public class WTransportIndexIntegrationAction
             try {
                 String integrationId = integration.getDocumentId();
                 String space = integration.getSpace();
-                String sapId =
-                        integrationId == null ? UUID.randomUUID().toString() : integrationId + "-" + space;
+                String sapId;
+                if (integrationId != null && "draft".equals(space)) {
+                    sapId = integrationId;
+                } else {
+                    sapId = UUID.randomUUID().toString();
+                }
 
                 IndexCustomLogTypeRequest internalRequest =
                         new IndexCustomLogTypeRequest(

--- a/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexIntegrationAction.java
+++ b/src/main/java/org/opensearch/securityanalytics/transport/WTransportIndexIntegrationAction.java
@@ -106,7 +106,9 @@ public class WTransportIndexIntegrationAction
         if (!Objects.equals(integration.getSpace(), "standard")) {
             try {
                 String integrationId = integration.getDocumentId();
-                String sapId = integrationId == null ? UUID.randomUUID().toString() : integrationId;
+                String space = integration.getSpace();
+                String sapId =
+                        integrationId == null ? UUID.randomUUID().toString() : integrationId + "-" + space;
 
                 IndexCustomLogTypeRequest internalRequest =
                         new IndexCustomLogTypeRequest(


### PR DESCRIPTION
### Description

Promoting an integration from draft to test overwrote the SAP document because both spaces used `document.id` as the `_id`. The delete then failed because the draft-space entry no longer existed

Now draft keeps `document.id` as `_id`, while test and custom spaces use a random UUID to avoid the collision

### Related Issues

Resolves https://github.com/wazuh/wazuh-indexer-plugins/issues/1282

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security-analytics/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
